### PR TITLE
Windows Support - Workaround for hiding warning without writing to /dev/null

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -1,7 +1,6 @@
 var fs = require("fs");
 
 // discard annoying NodeJS warning ("path.existsSync is now called `fs.existsSync`.")
-var original_stderr_write = process.stderr.write;
 process.stderr.write = function() { return true; };
 
 var vm = require("vm");
@@ -16,7 +15,7 @@ var UglifyJS = vm.createContext({
 });
 
 // return stderr to normal
-process.stderr.write = original_stderr_write;
+process.stderr.write = process.stderr.constructor.prototype.write;
 
 function load_global(file) {
     file = path.resolve(path.dirname(module.filename), file);


### PR DESCRIPTION
In reference to [Issue #9](https://github.com/mishoo/UglifyJS2/issues/9)

The hack was to hide the warning by caching (and then restoring) process.stderr, temporarily replacing it with a FS stream to /dev/null, which errors out on Windows.

This commit changes that to cache (and then restore) process.stderr.write, temporarily replacing it with a do-nothing function, avoiding the issue.

This does not fix the issue with reading from /dev/stdin when called without an input file.
