### PR TITLE
Convert x.toString() to ""+x instead of x+""

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1413,9 +1413,9 @@ merge(Compressor.prototype, {
             }
             else if (exp instanceof AST_Dot && exp.property == "toString" && self.args.length == 0) {
                 return make_node(AST_Binary, self, {
-                    left: exp.expression,
+                    left: make_node(AST_String, self, { value: "" }),
                     operator: "+",
-                    right: make_node(AST_String, self, { value: "" })
+                    right: exp.expression
                 }).transform(compressor);
             }
         }


### PR DESCRIPTION
In some places this can save one byte in whitespace, e.g. after return.
Example:

``` javascript
function f(arg) {
        // return""+arg - no space between return and ""
        return arg.toString();
}
```
