### PR TITLE
Add support for somewhat preserving line numbers.

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -59,7 +59,8 @@ function OutputStream(options) {
         source_map    : null,
         bracketize    : false,
         semicolons    : true,
-        comments      : false
+        comments      : false,
+        preserve_line : false
     }, true);
 
     var indentation = 0;
@@ -154,6 +155,19 @@ function OutputStream(options) {
             might_need_semicolon = false;
             maybe_newline();
         }
+
+        if (!options.beautify && options.preserve_line && stack[stack.length - 1]) {
+            var target_line = stack[stack.length - 1].start.line;
+            while (current_line < target_line) {
+                OUTPUT += "\n";
+                current_pos++;
+                current_line++;
+                current_col = 0;
+
+                might_need_space = false;
+            }
+        }
+
         if (might_need_space) {
             var prev = last_char();
             if ((is_identifier_char(prev)


### PR DESCRIPTION
As with other companies/projects, I do not have time to implement usage of source-maps due to a clumsy deployment system. Being able to preserve newlines is a big win for client-side error logging.

Tested on jQuery 1.8.2 and files used in production environments.

Usage (for now): uglifyjs2 -b "beautify=0,preserve_line=1" /path/to/js

ref #46
