### PR TITLE
Allow passing arbitrary output options into minify

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -95,7 +95,11 @@ exports.minify = function(files, options) {
         orig: inMap,
         root: options.sourceRoot
     });
-    var stream = UglifyJS.OutputStream({ source_map: map });
+    var output_options = {
+        source_map: map
+    };
+    UglifyJS.merge(output_options, options.output_options);
+    var stream = UglifyJS.OutputStream(output_options);
     toplevel.print(stream);
     return {
         code : stream + "",


### PR DESCRIPTION
I find myself wanting to set various output options (beautify, indent_level, and comments, specifically), and it would be nice to not have to duplicate the entire minify() function in my code.
