### PR TITLE
Fixed reading from STDIN

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -335,9 +335,8 @@ function getOptions(x, constants) {
 
 function read_whole_file(filename) {
     if (filename == "-") {
-        // XXX: this sucks.  How does one read the whole STDIN
-        // synchronously?
-        filename = "/dev/stdin";
+        var size = fs.fstatSync(process.stdin.fd).size;
+        return size > 0 ? fs.readSync(process.stdin.fd, size)[0] : "";
     }
     try {
         return fs.readFileSync(filename, "utf8");


### PR DESCRIPTION
Reading the code from STDIN by giving a single dash as the file name didn't work for me at all. Here's a working version.

Also, I don't really like that UglifyJS v2 is not compatible with v1 which didn't require any extra parameters to read from STDIN. I haven't touched that feature in this pull request, though.
