### PR TITLE
Fix issue #62.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -589,7 +589,7 @@ function parse($TEXT, options) {
     });
 
     var S = {
-        input         : typeof $TEXT == "string" ? tokenizer($TEXT, options.filename) : $TEXT,
+        input         : typeof $TEXT != "object" ? tokenizer($TEXT, options.filename) : $TEXT,
         token         : null,
         prev          : null,
         peeked        : null,


### PR DESCRIPTION
When the input is still a scalar but not a string, the parser does not correctly call the tokenizer.
