### PR TITLE
Add a propery 'cloned_from' to the cloned ast

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -89,7 +89,10 @@ var AST_Token = DEFNODE("Token", "type value line col pos endpos nlb comments_be
 
 var AST_Node = DEFNODE("Node", "start end", {
     clone: function() {
-        return new this.CTOR(this);
+        var cloned = new this.CTOR(this);
+        cloned.cloned_from = this;
+        
+        return cloned;
     },
     $documentation: "Base class of all AST nodes",
     $propdoc: {


### PR DESCRIPTION
add a property 'cloned_from' which referred to the origin ast instance to the cloned ast; otherwise we will lose connection between transformer.before and transformer.after;
