### PR TITLE
Fix output for arrays containing undefined values.

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1007,6 +1007,11 @@ function OutputStream(options) {
             a.forEach(function(exp, i){
                 if (i) output.comma();
                 exp.print(output);
+                // If the final element is a hole, we need to make sure it
+                // doesn't look like a trailing comma, by inserting an actual
+                // trailing comma.
+                if (i === len - 1 && exp instanceof AST_Hole)
+                  output.comma();
             });
             if (len > 0) output.space();
         });

--- a/test/compress/arrays.js
+++ b/test/compress/arrays.js
@@ -1,10 +1,12 @@
 holes_and_undefined: {
     input: {
+        w = [1,,];
         x = [1, 2, undefined];
         y = [1, , 2, ];
         z = [1, undefined, 3];
     }
     expect: {
+        w=[1,,];
         x=[1,2,void 0];
         y=[1,,2];
         z=[1,void 0,3];


### PR DESCRIPTION
1b6bcca7 was a first attempt at this. That commit made Uglify stop replacing
holes with undefined, but instead it started replacing undefined with
holes. This is slightly problematic, because there is a difference between a
hole and an undefined value. More problematically, it changed [1,undefined] to
[1,] which generally doesn't even parse as a hole (just as a trailing comma), so
it didn't even preserve the length of the array!

Instead, parse holes as their own special AST node which prints invisibly.
