### PR TITLE
Allow inSourceMap option to be a generated JSON source map

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -92,17 +92,18 @@ exports.minify = function(files, options) {
     }
 
     // 4. output
-    var map = null;
-    var inMap = null;
-    if (options.inSourceMap) {
+    var inMap = options.inSourceMap;
+    var output = {};
+    if (typeof options.inSourceMap == "string") {
         inMap = fs.readFileSync(options.inSourceMap, "utf8");
     }
-    if (options.outSourceMap) map = UglifyJS.SourceMap({
-        file: options.outSourceMap,
-        orig: inMap,
-        root: options.sourceRoot
-    });
-    var output = { source_map: map };
+    if (options.outSourceMap) {
+        output.source_map = UglifyJS.SourceMap({
+            file: options.outSourceMap,
+            orig: inMap,
+            root: options.sourceRoot
+        });
+    }
     if (options.output) {
         UglifyJS.merge(output, options.output);
     }
@@ -110,7 +111,7 @@ exports.minify = function(files, options) {
     toplevel.print(stream);
     return {
         code : stream + "",
-        map  : map + ""
+        map  : output.source_map + ""
     };
 };
 


### PR DESCRIPTION
It seems a little silly to have to write a generated source map to a file or even to a string just to use it right away in UglifyJS.  I was using the long hand API and manually using the `source_map` option to `ast.print_to_string` but it seemed a little unnecessary so I added the ability for `inSourceMap` to be a generated JSON source map as well as a string filename.  This should solve issue #123 as well.
