### PR TITLE
Read the entire STDIN.

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -347,12 +347,15 @@ function getOptions(x, constants) {
 }
 
 function read_whole_file(filename) {
-    if (filename == "-") {
-        // XXX: this sucks.  How does one read the whole STDIN
-        // synchronously?
-        filename = "/dev/stdin";
-    }
     try {
+        if (filename == "-") {
+            var chunks = [];
+            do {
+                var chunk = fs.readFileSync("/dev/stdin", "utf8");
+                chunks.push(chunk);
+            } while (chunk.length);
+            return chunks.join("");
+        }
         return fs.readFileSync(filename, "utf8");
     } catch(ex) {
         sys.error("ERROR: can't read file: " + filename);


### PR DESCRIPTION
The problem with reading synchronously from /dev/stdin is that you can get a spurious EOF when the input buffer is empty, even if more content is coming. Now STDIN is read from a loop, and only stops polling when all input has been read. This fixes #70 #85 and other errors related to parsing large files on STDIN.
