### PR TITLE
OutputStream: Added support for quote_char option

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -60,7 +60,8 @@ function OutputStream(options) {
         bracketize    : false,
         semicolons    : true,
         comments      : false,
-        preserve_line : false
+        preserve_line : false,
+        quote_char    : null
     }, true);
 
     var indentation = 0;
@@ -95,7 +96,8 @@ function OutputStream(options) {
             return s;
         });
         if (options.ascii_only) str = to_ascii(str);
-        if (dq > sq) return "'" + str.replace(/\x27/g, "\\'") + "'";
+        var quote_char = options.quote_char || (dq > sq ? "'" : '"');
+        if (quote_char === "'") return "'" + str.replace(/\x27/g, "\\'") + "'";
         else return '"' + str.replace(/\x22/g, '\\"') + '"';
     };
 


### PR DESCRIPTION
Can be either `'`, `"`, or `null` (`null` means choose the one with fewest occurrences in the string, like the previous behavior).

Use case: Serializing `data-bind` attributes (Knockout.js) into doublequote delimited HTML attributes while avoiding an excessive number of &amp;quot; entities.

Corresponding pull req for UglifyJS1: https://github.com/mishoo/UglifyJS/pull/454 -- I've maintained a fork (`uglify-js-papandreou`) for some time because I need it for https://github.com/One-com/assetgraph