### PR TITLE
Output, to_ascii: Escape non-ascii chars with \xnn instead of \unnnn whenever possible

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -72,8 +72,13 @@ function OutputStream(options) {
     function to_ascii(str) {
         return str.replace(/[\u0080-\uffff]/g, function(ch) {
             var code = ch.charCodeAt(0).toString(16);
-            while (code.length < 4) code = "0" + code;
-            return "\\u" + code;
+            if (code.length <= 2) {
+                while (code.length < 2) code = "0" + code;
+                return "\\x" + code;
+            } else {
+                while (code.length < 4) code = "0" + code;
+                return "\\u" + code;
+            }
         });
     };
 


### PR DESCRIPTION
Previously ASCII-only mode was a bit wasteful:

```
$ uglifyjs --beautify ascii_only=true
alert("føø");
^D
alert("f\u00f8\u00f8");
```

With this patch the output is:

```
alert("f\xf8\xf8");
```
