### PR TITLE
Quote objects with numeric keys

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1028,7 +1028,7 @@ function OutputStream(options) {
     DEFPRINT(AST_ObjectKeyVal, function(self, output){
         var key = self.key;
         if (output.option("quote_keys")) {
-            output.print_string(key);
+            output.print_string(key + "");
         } else if ((typeof key == "number"
                     || !output.option("beautify")
                     && +key + "" == key)


### PR DESCRIPTION
Beautification of code with numeric keys in objects like this
```javascript
a={1:"some value"}
```
fails if "quote_keys=true" options is passed:
```
/usr/local/share/npm/lib/node_modules/uglify-js2/lib/output.js:81
        str = str.replace(/[\\\b\f\n\r\t\x22\x27\u2028\u2029\0]/g, function(s)
                  ^
TypeError: Object 1 has no method 'replace'
```
I think numeric keys should be quoted as any other, since this does not break any code (object property is still accessible by both numeric and string key).