### PR TITLE
Fix error classes

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -178,16 +178,15 @@ function parse_js_number(num) {
 };
 
 function JS_Parse_Error(message, line, col, pos) {
-    this.message = message;
+    this.message = message + " (line: " + line + ", col: " + col + ", pos: " + pos + ")";
     this.line = line;
     this.col = col;
     this.pos = pos;
-    this.stack = new Error().stack;
+    // The second parameter omits the JS_Parse_Error constructor from the captured stack trace:
+    Error.captureStackTrace(this, JS_Parse_Error);
 };
 
-JS_Parse_Error.prototype.toString = function() {
-    return this.message + " (line: " + this.line + ", col: " + this.col + ", pos: " + this.pos + ")" + "\n\n" + this.stack;
-};
+JS_Parse_Error.prototype = Error.prototype;
 
 function js_error(message, filename, line, col, pos) {
     throw new JS_Parse_Error(message, line, col, pos);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,10 +81,14 @@ function repeat_string(str, i) {
     return d;
 };
 
-function DefaultsError(msg, defs) {
-    this.msg = msg;
+function DefaultsError(message, defs) {
+    this.message = message + "(defs: " + JSON.stringify(defs) + ")";
     this.defs = defs;
+    // The second parameter omits the DefaultError constructor from the captured stack trace:
+    Error.captureStackTrace(this, DefaultsError);
 };
+
+DefaultsError.prototype = Error.prototype;
 
 function defaults(args, defs, croak) {
     if (args === true)


### PR DESCRIPTION
Previously you would get output like this when a `DefaultError` was thrown:

```
/path/to/UglifyJS2/lib/utils.js:95
        throw new DefaultsError("`" + i + "` is not a supported option", defs)
              ^
[object Object]
```

With this patch you get:

```
/path/to/UglifyJS2/lib/utils.js:98
        throw new DefaultsError("`" + i + "` is not a supported option", defs)
              ^
Error: `toplevel` is not a supported option (defs: {"sequences":true,"properties":true,"dead_code":true,"drop_debugger":true,"unsafe":false,"unsafe_comps":false,"conditionals":true,"comparisons":true,"evaluate":true,"booleans":true,"loops":true,"unused":true,"hoist_funs":true,"hoist_vars":false,"if_return":true,"join_vars":true,"cascade":true,"side_effects":true,"warnings":true,"global_defs":{}})
    at defaults (/path/to/UglifyJS2/lib/utils.js:98:15)
    at Object.Compressor (/path/to/UglifyJS2/lib/compress.js:50:20)
    at Object.Compressor (/path/to/UglifyJS2/lib/compress.js:48:16)
    at theFunctionThatStartedTheCompressor (/path/to/yourProject/file.js:15:35)
```

The way I did it the `message` property of the error instances includes all the extra info (`defs` for `DefaultsError`, and `line`, `col` etc. for `JS_Parse_Error`) instead of being added to the output by a custom `toString` method. If that's a problem I can try another approach.

I wasn't sure whether you'd want the `defs` object to be included in the `DefaultsError` message itself, so I just put it in there.