### PR TITLE
mozilla-ast: unary is prefix, update is postfix

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -128,8 +128,8 @@
                 return new AST_RegExp(args);
             }
         },
-        UnaryExpression: From_Moz_Unary,
-        UpdateExpression: From_Moz_Unary,
+        UnaryExpression: From_Moz_Unary(true),
+        UpdateExpression: From_Moz_Unary(false),
         Identifier: function(M) {
             var p = FROM_MOZ_STACK[FROM_MOZ_STACK.length - 2];
             return new (M.name == "this" ? AST_This
@@ -147,13 +147,15 @@
         }
     };
 
-    function From_Moz_Unary(M) {
-        return new (M.prefix ? AST_UnaryPrefix : AST_UnaryPostfix)({
-            start      : my_start_token(M),
-            end        : my_end_token(M),
-            operator   : M.operator,
-            expression : from_moz(M.argument)
-        })
+    function From_Moz_Unary(prefix) {
+        return function(M) {
+          return new (prefix ? AST_UnaryPrefix : AST_UnaryPostfix)({
+              start      : my_start_token(M),
+              end        : my_end_token(M),
+              operator   : M.operator,
+              expression : from_moz(M.argument)
+          })
+        }
     };
 
     var ME_TO_MOZ = {};


### PR DESCRIPTION
Fixes problems with esprima, because sometimes it generates following AST:

``` js
{
  type: 'UnaryExpression',
  operator: '!',
  argument: { ... }
}
```

and it gets translated into: `...!`
