### PR TITLE
Fix Empty String conversion to dot notation

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -172,7 +172,7 @@ function is_identifier_string(str){
         if (!is_identifier_char(str.charAt(i)))
             return false;
     }
-    return true;
+    return str.length > 0;
 };
 
 function parse_js_number(num) {

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -19,12 +19,14 @@ dot_properties: {
         a["if"] = "if";
         a["*"] = "asterisk";
         a["\u0EB3"] = "unicode";
+        a[""] = "whitespace";
     }
     expect: {
         a.foo = "bar";
         a["if"] = "if";
         a["*"] = "asterisk";
         a.\u0EB3 = "unicode";
+        a[""] = "whitespace";
     }
 }
 
@@ -38,11 +40,13 @@ dot_properties_es5: {
         a["if"] = "if";
         a["*"] = "asterisk";
         a["\u0EB3"] = "unicode";
+        a[""] = "whitespace";
     }
     expect: {
         a.foo = "bar";
         a.if = "if";
         a["*"] = "asterisk";
         a.\u0EB3 = "unicode";
+        a[""] = "whitespace";
     }
 }


### PR DESCRIPTION
The change from 2.3.0 to 2.3.1 included changing the property compressor checker from a RegExp to a loop (`is_identifier` to `is_identifier_string`). The latter did not account for cases when the string length is zero (i.e. the empty string).

This commit fixes that edge case in `is_identifier_string` and adds a test to the properties test exercising an empty string property name.

Fixes #199
