### PR TITLE
SourceMapping pragma has changed to //#

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -309,7 +309,7 @@ async.eachLimit(files, 1, function (file, cb) {
 
     if (SOURCE_MAP) {
         fs.writeFileSync(ARGS.source_map, SOURCE_MAP, "utf8");
-        output += "\n/*\n//# sourceMappingURL=" + (ARGS.source_map_url || ARGS.source_map) + "\n*/";
+        output += "\n//# sourceMappingURL=" + (ARGS.source_map_url || ARGS.source_map);
     }
 
     if (OUTPUT_FILE) {


### PR DESCRIPTION
See: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit

The spec was updated on May 16th since `//@` was causing some issues with IE.
