### PR TITLE
Escape null characters as \x00

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -96,7 +96,7 @@ function OutputStream(options) {
               case "\u2029": return "\\u2029";
               case '"': ++dq; return '"';
               case "'": ++sq; return "'";
-              case "\0": return "\\0";
+              case "\0": return "\\x00";
             }
             return s;
         });


### PR DESCRIPTION
Since \0 might be mistakenly interpreted as octal if followed by a number and using literal null is in some cases interpreted as end of string, escape null as \x00.

For example, the following JS

``` javascript
"\x001"
```

is before this patch minified as 

``` javascript
"\01"
```

Depending on whether strict mode is enabled or not, this either results in syntax error or equivalent of `\x01`. PR fixes this edge case behaviour and should [fix minification of pdf.js](https://github.com/mozilla/pdf.js/issues/2479).
