### PR TITLE
Updated "can't read file" message to use the correct variable.

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -223,7 +223,7 @@ try {
 async.eachLimit(files, 1, function (file, cb) {
     read_whole_file(file, function (err, code) {
         if (err) {
-            sys.error("ERROR: can't read file: " + filename);
+            sys.error("ERROR: can't read file: " + file);
             process.exit(1);
         }
         if (ARGS.p != null) {


### PR DESCRIPTION
When given a non-existing file, a rather unhelpful error message was printed instead of the intended message.
This commit fixes that message so it shows up as intended.