### PR TITLE
Make `DefaultsError` a real `Error` object

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,9 +82,12 @@ function repeat_string(str, i) {
 };
 
 function DefaultsError(msg, defs) {
+    Error.call(this, msg)
     this.msg = msg;
     this.defs = defs;
 };
+DefaultsError.prototype = Object.create(Error.prototype)
+DefaultsError.prototype.constructor = DefaultsError
 
 function defaults(args, defs, croak) {
     if (args === true)


### PR DESCRIPTION
This is really important in order for it to show up properly in lots of debugging logs and so that it gets a stack trace (otherwise it's very difficult to find out where it was originally thrown).
