### PR TITLE
Fixes #263 - support specifying the filename when minifying using fromString option

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -72,7 +72,7 @@ exports.minify = function(files, options) {
             ? file
             : fs.readFileSync(file, "utf8");
         toplevel = UglifyJS.parse(code, {
-            filename: options.fromString ? "?" : file,
+            filename: options.fromString ? options.fromStringFile || "?" : file,
             toplevel: toplevel
         });
     });


### PR DESCRIPTION
Simple solution for #263 to allows working source-maps to be produced when minifying using the fromString option.