### PR TITLE
Add option to disable warnings when generating source map

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -62,6 +62,7 @@ function OutputStream(options) {
         comments      : false,
         preserve_line : false,
         negate_iife   : !(options && options.beautify),
+        warnings      : true,
     }, true);
 
     var indentation = 0;
@@ -285,7 +286,7 @@ function OutputStream(options) {
                 (!name && token.type == "name") ? token.value : name
             );
         } catch(ex) {
-            AST_Node.warn("Couldn't figure out mapping for {file}:{line},{col} → {cline},{ccol} [{name}]", {
+            if (options.warnings) AST_Node.warn("Couldn't figure out mapping for {file}:{line},{col} → {cline},{ccol} [{name}]", {
                 file: token.file,
                 line: token.line,
                 col: token.col,


### PR DESCRIPTION
Uglify generates a lot of warnings when generating the compressed code + source map for my project, spamming stdout with lines such as  ``WARN: Couldn't figure out mapping for file.js:1,0 → 1,1 []``

This patch adds an option to disable these warnings in `lib/output.js`