### PR TITLE
Sourcemap fixes

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -80,11 +80,12 @@ function OutputStream(options) {
                 while (code.length < 4) code = "0" + code;
                 return "\\u" + code;
             }
-        });
+        }).replace(/\x0B/g, "\\x0B");
     };
 
     function make_string(str) {
         var dq = 0, sq = 0;
+
         str = str.replace(/[\\\b\f\n\r\t\x22\x27\u2028\u2029\0]/g, function(s){
             switch (s) {
               case "\\": return "\\\\";


### PR DESCRIPTION
c85d4318b935968b7266136008cbcf55c0418772 fixes an issue minifying backbone.js. There is an off-by-one error when the keys of object literals are quoted strings.

```
{
   'some': 'thing'
// ^ Uglify says the 'some' token begins on this index, when it really is the next one
}
```

d051f29cacc4f47b71437b8f5afaa9ef7dc428f2 fixes an issue minifying lo-dash.

```
{
   '\n': 'newline'
//   ^ Sourcemap's "names" array contains a newline character and maps it here
//     when it should be mapping the escaped "\n" string
}
```
