### PR TITLE
fixes #259: don't unnecessarily quote object properties when --screw-ie8

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -129,11 +129,6 @@ if (ARGS.d) {
     if (COMPRESS) COMPRESS.global_defs = getOptions("d");
 }
 
-if (ARGS.screw_ie8) {
-    if (COMPRESS) COMPRESS.screw_ie8 = true;
-    if (MANGLE) MANGLE.screw_ie8 = true;
-}
-
 if (ARGS.r) {
     if (MANGLE) MANGLE.except = ARGS.r.replace(/^\s+|\s+$/g).split(/\s*,+\s*/);
 }
@@ -141,6 +136,12 @@ if (ARGS.r) {
 var OUTPUT_OPTIONS = {
     beautify: BEAUTIFY ? true : false
 };
+
+if (ARGS.screw_ie8) {
+    if (COMPRESS) COMPRESS.screw_ie8 = true;
+    if (MANGLE) MANGLE.screw_ie8 = true;
+    OUTPUT_OPTIONS.screw_ie8 = true;
+}
 
 if (BEAUTIFY)
     UglifyJS.merge(OUTPUT_OPTIONS, BEAUTIFY);

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2005,8 +2005,7 @@ merge(Compressor.prototype, {
         var prop = self.property;
         if (prop instanceof AST_String && compressor.option("properties")) {
             prop = prop.getValue();
-            if ((compressor.option("screw_ie8") && RESERVED_WORDS(prop))
-                || (!(RESERVED_WORDS(prop)) && is_identifier_string(prop))) {
+            if (RESERVED_WORDS(prop) ? compressor.option("screw_ie8") : is_identifier_string(prop)) {
                 return make_node(AST_Dot, self, {
                     expression : self.expression,
                     property   : prop

--- a/lib/output.js
+++ b/lib/output.js
@@ -54,13 +54,13 @@ function OutputStream(options) {
         inline_script : false,
         width         : 80,
         max_line_len  : 32000,
-        ie_proof      : true,
         beautify      : false,
         source_map    : null,
         bracketize    : false,
         semicolons    : true,
         comments      : false,
         preserve_line : false,
+        screw_ie8     : false,
         negate_iife   : !(options && options.beautify),
     }, true);
 
@@ -761,7 +761,7 @@ function OutputStream(options) {
         if (!self.body)
             return output.force_semicolon();
         if (self.body instanceof AST_Do
-            && output.option("ie_proof")) {
+            && !output.option("screw_ie8")) {
             // https://github.com/mishoo/UglifyJS/issues/#issue/57 IE
             // croaks with "syntax error" on code like this: if (foo)
             // do ... while(cond); else ...  we need block brackets
@@ -1048,10 +1048,10 @@ function OutputStream(options) {
                     && +key + "" == key)
                    && parseFloat(key) >= 0) {
             output.print(make_num(key));
-        } else if (!is_identifier(key)) {
-            output.print_string(key);
-        } else {
+        } else if (RESERVED_WORDS(key) ? output.option("screw_ie8") : is_identifier_string(key)) {
             output.print_name(key);
+        } else {
+            output.print_string(key);
         }
         output.colon();
         self.value.print(output);


### PR DESCRIPTION
fixes #259

I couldn't figure out how to test it. The `compress` tests just test for structural equivalence. Here's the closest I could come (but they obviously don't work):

``` js
quote_reserved_words_by_default: {
    options = {};

    input: { ({do: 0}) }
    expect: { ({"do": 0}) }
}

screw_ie8_option_allows_for_unquoted_reserved_words: {
    options = {
        screw_ie8: true,
    };

    input: { ({do: 0}) }
    expect: { ({do: 0}) }
}
```
