### PR TITLE
Compress [...].join() also when it cannot be completely evaluated

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -750,10 +750,33 @@ merge(Compressor.prototype, {
                 if (this.expression instanceof AST_Dot
                     && this.expression.expression instanceof AST_Array
                     && this.expression.property == "join") {
-                    var x =  this.expression.expression.elements.map(function(el){
-                        return ev(el, compressor);
-                    });
-                    return x.join(ev(this.args[0], compressor));
+
+                    var join_arg = this.args[0] ? "" + ev(this.args[0], compressor) : ",";
+                    try {
+                        var x =  this.expression.expression.elements.map(function(el){
+                            return ev(el, compressor);
+                        });
+                        return x.join(join_arg);
+                    } catch (ex) {
+                        if (ex !== def) throw ex;
+                        join_arg = make_node_from_constant(compressor, join_arg, this.args[0]);
+                        var x = this.expression.expression.elements.reduce(function(el1, el2){
+                            return make_node(AST_Binary, null, {
+                                operator : "+",
+                                left     : make_node(AST_Binary, null, {
+                                    operator : "+",
+                                    left     : el1,
+                                    right    : join_arg,
+                                    start    : el1.start,
+                                    end      : join_arg.end
+                                }),
+                                right    : el2,
+                                start    : el1.start,
+                                end      : el2.end
+                            });
+                        });
+                        return x.transform(compressor);
+                    }
                 }
             }
             throw def;

--- a/test/compress/arrays.js
+++ b/test/compress/arrays.js
@@ -19,17 +19,21 @@ constant_join: {
         evaluate : true
     };
     input: {
-        var a = [ "foo", "bar", "baz" ].join("");
+        var a = [ "foo", "bar", "baz" ].join();
         var b = [ "foo", 1, 2, 3, "bar" ].join("");
         var c = [ boo(), "foo", 1, 2, 3, "bar", bar() ].join("");
         var d = [ "foo", 1 + 2 + "bar", "baz" ].join("-");
-        var e = [].join(foo + bar);
+        var e = [ boo ].join(foo + bar);
+        var f = [ boo ].join("");
+        var g = [ "foo", "boo" + bar, "baz"].join("-");
     }
     expect: {
-        var a = "foobarbaz";
+        var a = "foo,bar,baz";
         var b = "foo123bar";
-        var c = [ boo(), "foo", 1, 2, 3, "bar", bar() ].join(""); // we could still shorten this one, but oh well.
+        var c = boo() + "foo123bar" + bar();
         var d = "foo-3bar-baz";
-        var e = [].join(foo + bar);
+        var e = [ boo ].join(foo + bar);
+        var f = [ boo ].join();
+        var g = "foo-" + ("boo" + bar) + "-baz"; // we could still shorten this one, but oh well.
     }
 }


### PR DESCRIPTION
Follow-up to 78e98d2.

@mishoo, you forgot to pass the compressor to `ev()` in one case, so I fixed that, and also moved the exception there, to make forgetting it apparent, even without edge cases (in this case `[...].join(... + ...)`)
