### PR TITLE
Fixed bug causing [ReferenceError: Process is not defined] messages while debugging in WebStorm.

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -6,6 +6,8 @@ var sys = require("util");
 var UglifyJS = vm.createContext({
     sys           : sys,
     console       : console,
+    process       : process,
+    Buffer        : Buffer,
     MOZ_SourceMap : require("source-map")
 });
 


### PR DESCRIPTION
It took me a long time to find the bug, but I finally did. Whenever I use [Jade](https://github.com/visionmedia/jade) in my node applications I get a whole bunch of [ReferenceError: process is not defined] in the console while debugging in [WebStorm](http://www.jetbrains.com/webstorm/).

http://stackoverflow.com/questions/17812371/nodejs-jade-referenceerror-process-is-not-defined

I'm not exactly sure why this happens only while debugging but including `process` and `Buffer` in the vm context seems to fix the issue.
