### PR TITLE
Only allow identifier start characters at the beginning of identifiers.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -170,7 +170,7 @@ function is_identifier_char(ch) {
 function is_identifier_string(str){
     var i = str.length;
     if (i == 0) return false;
-    if (is_digit(str.charCodeAt(0))) return false;
+    if (!is_identifier_start(str.charCodeAt(0))) return false;
     while (--i >= 0) {
         if (!is_identifier_char(str.charAt(i)))
             return false;


### PR DESCRIPTION
Without this fix, the following source:

   x = {"\u200c": 42};

would incorrectly be converted into a quoteless key. But while \u200c is allowed
to be in identifiers, it cannot be at the beginning, as per ES5.

(For example, the SockJS client library doesn't work under uglify starting with
d9ad3c7c.)
