### PR TITLE
Better escaping of null characters.

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -96,7 +96,7 @@ function OutputStream(options) {
               case '"': ++dq; return '"';
               case "'": ++sq; return "'";
               case "\0":
-                var next = s.charCodeAt(i + 1);
+                var next = str.charCodeAt(i + 1);
                 return 48 <= next && next <= 57 ? "\\x00" : "\\0";
             }
             return s;

--- a/lib/output.js
+++ b/lib/output.js
@@ -84,7 +84,7 @@ function OutputStream(options) {
 
     function make_string(str) {
         var dq = 0, sq = 0;
-        str = str.replace(/[\\\b\f\n\r\t\x22\x27\u2028\u2029\0]/g, function(s){
+        str = str.replace(/[\\\b\f\n\r\t\x22\x27\u2028\u2029\0]/g, function(s, i){
             switch (s) {
               case "\\": return "\\\\";
               case "\b": return "\\b";
@@ -95,7 +95,9 @@ function OutputStream(options) {
               case "\u2029": return "\\u2029";
               case '"': ++dq; return '"';
               case "'": ++sq; return "'";
-              case "\0": return "\\x00";
+              case "\0":
+                var next = s.charCodeAt(i + 1);
+                return 48 <= next && next <= 57 ? "\\x00" : "\\0";
             }
             return s;
         });


### PR DESCRIPTION
If a null character isn't followed by a digit, then it should be safe to
escape it using the shorter sequence "\0" instead of "\x00".

See #220.