### PR TITLE
Fix #280

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -86,13 +86,14 @@ merge(Compressor.prototype, {
     before: function(node, descend, in_list) {
         if (node._squeezed) return node;
         if (node instanceof AST_Scope) {
-            node.drop_unused(this);
+            //node.drop_unused(this);
             node = node.hoist_declarations(this);
         }
         descend(node, this);
         node = node.optimize(this);
         if (node instanceof AST_Scope) {
             node.drop_unused(this);
+            descend(node, this);
         }
         node._squeezed = true;
         return node;
@@ -1082,18 +1083,23 @@ merge(Compressor.prototype, {
                         }
                         return node;
                     }
-                    if (node instanceof AST_For && node.init instanceof AST_BlockStatement) {
+                    if (node instanceof AST_For) {
                         descend(node, this);
-                        // certain combination of unused name + side effect leads to:
-                        //    https://github.com/mishoo/UglifyJS2/issues/44
-                        // that's an invalid AST.
-                        // We fix it at this stage by moving the `var` outside the `for`.
-                        var body = node.init.body.slice(0, -1);
-                        node.init = node.init.body.slice(-1)[0].body;
-                        body.push(node);
-                        return in_list ? MAP.splice(body) : make_node(AST_BlockStatement, node, {
-                            body: body
-                        });
+
+                        if (node.init instanceof AST_BlockStatement) {
+                            // certain combination of unused name + side effect leads to:
+                            //    https://github.com/mishoo/UglifyJS2/issues/44
+                            // that's an invalid AST.
+                            // We fix it at this stage by moving the `var` outside the `for`.
+
+                            var body = node.init.body.slice(0, -1);
+                            node.init = node.init.body.slice(-1)[0].body;
+                            body.push(node);
+
+                            return in_list ? MAP.splice(body) : make_node(AST_BlockStatement, node, {
+                                body: body
+                            });
+                        }
                     }
                     if (node instanceof AST_Scope && node !== self)
                         return node;


### PR DESCRIPTION
The `init` of the `ForStatement` is not a `BlockStatement` before it was
descended. The descend has to happen first, and _then_ the actual
checks.

This is the best option imho. The "hack" way is just as slow and more prone to problems.
