### PR TITLE
declare a source file even when passing in a string

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -63,10 +63,7 @@ exports.minify = function(files, options) {
     });
     if (typeof files == "string") {
         files = [ files ];
-
-        if (options.fromFile !== null) {
-          option.fromFile = [options.fromFile];
-        }
+        options.fromFile = options.fromFile ? [options.fromFile] : ["?"]
     }
 
     UglifyJS.base54.reset();
@@ -78,7 +75,7 @@ exports.minify = function(files, options) {
             ? file
             : fs.readFileSync(file, "utf8");
         toplevel = UglifyJS.parse(code, {
-            filename: options.fromString ? options.fromFile[index] || "?" : file,
+            filename: options.fromString ? options.fromFile[index] : file,
             toplevel: toplevel
         });
     });


### PR DESCRIPTION
when generating source maps by using the <code>fromString=true</code> in the <code>Uglify.minify</code> options, the source map contains a problematic array for the sources field

``` javascript
...
sources: ["?"],
...
```

thus, the source map can't be used because i can't point it at the original source. however, if i do not use a string directly but the filename itself, the source map feature works.

this pull request adds a <code>fromFile</code> option that can either be an array of filenames or just a single string filename to properly match up if just a single string of source code is passed in, or an array of source code.

so the following approaches now produce good source maps

``` javascript
Uglifyjs.minify(
  "function() { alert('yes');", 
  {fromString:true, fromFile:"yes.js"});
```

and

``` javascript
Uglifyjs.minify(
  ["function() { alert('yes');", "function() { alert('no');"], 
  {fromString:true, fromFile:["yes.js", "no.js"]});
```
