### PR TITLE
Fix mangling issues with safari

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -145,6 +145,16 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(){
             func = node;
             descend();
             func = prev_func;
+
+            if (node instanceof AST_Function && node.name && node.argnames.length) {
+                var ref = new AST_SymbolRef({
+                    scope: node.argnames[0].scope,
+                    name: node.name.name,
+                    thedef: node.name.thedef
+                });
+                ref.reference(true);
+            }
+
             return true;
         }
         if (node instanceof AST_SymbolRef) {
@@ -199,9 +209,9 @@ AST_Lambda.DEFMETHOD("init_scope_vars", function(){
     this.uses_arguments = false;
 });
 
-AST_SymbolRef.DEFMETHOD("reference", function() {
+AST_SymbolRef.DEFMETHOD("reference", function(virtual) {
     var def = this.definition();
-    def.references.push(this);
+    if (!virtual) def.references.push(this);
     var s = this.scope;
     while (s) {
         push_uniq(s.enclosed, def);


### PR DESCRIPTION
Fixes #326 and #179

It isn't a really clean solution, but it works. The idea is to "virtually" reference the function name inside the scope. But to be able know it isn't _really_ referenced, we add a `virtual` flag to `AST_SymbolRef.reference`.
