### PR TITLE
Unit test to detect issue in 8d14efe for #126 that causes aggressive parenthesis removal, functional differences

### DIFF
--- a/test/compress/issue-126.js
+++ b/test/compress/issue-126.js
@@ -10,6 +10,7 @@ concatenate_rhs_strings: {
         foo(bar() + 123 + "Hello" + "World" + ("Foo" + "Bar"));
         foo("Foo" + "Bar" + bar() + 123 + "Hello" + "World" + ("Foo" + "Bar"));
         foo("Hello" + bar() + 123 + "World");
+        foo(bar() + 'Foo' + (10 + parseInt('10')));
     }
     expect: {
         foo(bar() + 123 + "HelloWorld");
@@ -18,5 +19,6 @@ concatenate_rhs_strings: {
         foo(bar() + 123 + "HelloWorldFooBar");
         foo("FooBar" + bar() + "123HelloWorldFooBar");
         foo("Hello" + bar() + "123World");
+        foo(bar() + 'Foo' + (10 + parseInt('10')));
     }
 }


### PR DESCRIPTION
Adds a unit test to test for aggressive parenthesis removal introduced in 8d14efe for #126 that causes functional changes.

In WordPress, we had this code (excerpted):

`'style="width: '+( 10 + parseInt(f) )+'px"'`

It used to minify like this:

`'style="width: '+(10+parseInt(f))+'px"'`

But in 2.4.1 it minifies as:

`'style="width: 10'+parseInt(f)+'px"'` (functionally different).

A fix for this is above my JS pay grade, but here's a unit test that catches the issue.
