### PR TITLE
Fix RHS concat (raised in #330)

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2067,7 +2067,8 @@ merge(Compressor.prototype, {
                     && self.left.right instanceof AST_Constant
                     && self.right instanceof AST_Binary
                     && self.right.operator == "+"
-                    && self.right.left instanceof AST_Constant) {
+                    && self.right.left instanceof AST_Constant
+                    && self.right.is_string(compressor)) {
                     self = make_node(AST_Binary, self, {
                         operator: "+",
                         left: make_node(AST_Binary, self.left, {


### PR DESCRIPTION
When attempting to concat the left-side of the rhs, make sure the rhs is
a string.
