### PR TITLE
Fix bad sourcemap offsets on escapes in dict keys

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -80,7 +80,7 @@ function OutputStream(options) {
                 while (code.length < 4) code = "0" + code;
                 return "\\u" + code;
             }
-        });
+        }).replace(/\x0B/g, "\\x0B");
     };
 
     function make_string(str) {
@@ -278,12 +278,46 @@ function OutputStream(options) {
 
     var add_mapping = options.source_map ? function(token, name) {
         try {
-            if (token) options.source_map.add(
-                token.file || "?",
-                current_line, current_col,
-                token.line, token.col,
-                (!name && token.type == "name") ? token.value : name
-            );
+            if (token) {
+                var tokenName;
+                var tokenChars;
+                var escapable = [
+                  {find:'\n', replace:'\\n'},
+                  {find:'\r', replace:'\\r'},
+                  {find:'\t', replace:'\\t'},
+                  {find:'\b', replace:'\\b'},
+                  {find:'\f', replace:'\\f'},
+                  {find:'\v', replace:'\\v'},
+                  {find:'\\', replace:'\\\\'},
+                  {find:'\u2028', replace:'\\u2028'},
+                  {find:'\u2029', replace:'\\u2029'}
+                ];
+
+                tokenName = (!name && token.type == "name") ? token.value : name;
+
+                if(tokenName) {
+                  // Cast to a string, it might be a number
+                  tokenName = new String(tokenName);
+
+                  // Fixes offsets for escaped chars in keys of object literals
+                  tokenChars = tokenName.split('');
+                  for(var i=0, ii=tokenChars.length; i<ii; i++) {
+                    for(var y=0, yy=escapable.length; y<yy; y++) {
+                      if(tokenChars[i] === escapable[y].find && (i===0 || tokenChars[i-1] != '\\')) {
+                        tokenChars[i] = escapable[y].replace;
+                      }
+                    }
+                  }
+                  tokenName = tokenChars.join('');
+                }
+
+                options.source_map.add(
+                  token.file || "?",
+                  current_line, current_col,
+                  token.line, token.col,
+                  tokenName
+                );
+            }
         } catch(ex) {
             AST_Node.warn("Couldn't figure out mapping for {file}:{line},{col} → {cline},{ccol} [{name}]", {
                 file: token.file,


### PR DESCRIPTION
... like #303, except without offsetting past the initial quote
character. (That offset doesn't seem to be necessary)