### PR TITLE
slightly better error (tho theres room for improvement) and unit testing for it

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -188,20 +188,29 @@ function parse_js_number(num) {
     }
 };
 
-function JS_Parse_Error(message, line, col, pos) {
-    this.message = message;
+// the right way to create a custom error: http://stackoverflow.com/questions/8802845/inheriting-from-the-error-object-where-is-the-message-property
+function JS_Parse_Error(message, filename, line, col, pos) {
+    var tmp = Error.call(this, message);
+    tmp.name = this.name = 'JS_Parse_Error'
+
+    this.stack = tmp.stack
+    this.message = tmp.message
     this.line = line;
     this.col = col;
     this.pos = pos;
-    this.stack = new Error().stack;
-};
+    //this.file = filename // why isn't filename being used
 
-JS_Parse_Error.prototype.toString = function() {
-    return this.message + " (line: " + this.line + ", col: " + this.col + ", pos: " + this.pos + ")" + "\n\n" + this.stack;
-};
+    return this
+}
+    var IntermediateInheritor = function() {}
+        IntermediateInheritor.prototype = Error.prototype;
+    JS_Parse_Error.prototype = new IntermediateInheritor()
+    JS_Parse_Error.prototype.toString = function() {
+        return this.message + " ("+/*"file: " + this.file + ", "+*/"line: " + this.line + ", col: " + this.col + ", pos: " + this.pos + ")" + "\n\n" + this.stack;
+    };
 
 function js_error(message, filename, line, col, pos) {
-    throw new JS_Parse_Error(message, line, col, pos);
+    throw new JS_Parse_Error(message, filename, line, col, pos);
 };
 
 function is_token(token, type, val) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "JavaScript parser, mangler/compressor and beautifier toolkit",
     "homepage": "http://lisperator.net/uglifyjs",
     "main": "tools/node.js",
-    "version": "2.4.3",
+    "version": "2.4.4",
     "engines": { "node" : ">=0.4.0" },
     "maintainers": [{
         "name": "Mihai Bazon",
@@ -19,6 +19,9 @@
         "source-map" : "~0.1.7",
         "optimist"   : "~0.3.5",
         "uglify-to-browserify": "~1.0.0"
+    },
+    "devDependencies": {
+        "deadunit"   : "1.0.7"
     },
     "browserify": {
         "transform": [ "uglify-to-browserify" ]

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -5,6 +5,7 @@ var path = require("path");
 var fs = require("fs");
 var assert = require("assert");
 var sys = require("util");
+var Unit = require("deadunit")
 
 var tests_dir = path.dirname(module.filename);
 var failures = 0;
@@ -16,6 +17,38 @@ if (failures) {
     sys.error("!!! " + Object.keys(failed_files).join(", "));
     process.exit(1);
 }
+
+Unit.test("pretty tests", function() {
+    this.test("proper errors", function() {
+        this.count(10)
+
+        try {
+            var js = "var =  { invalid_js ]"
+            U.minify(js, {
+                fromString: true
+            })
+        } catch(e) {
+
+            this.ok(e instanceof U.JS_Parse_Error)
+            this.ok(e.line === 1, e.line)
+            this.ok(e.col === 4, e.col)
+            this.ok(e.pos === 4, e.pos)
+            this.ok(e.message === "Name expected", e.message)
+            this.ok(e.stack.indexOf("Name expected") !== -1, e.stack)
+            this.ok(e.toString().indexOf("Name expected (line: 1, col: 4, pos: 4)") !== -1, e.toString())
+            this.ok(e.stack.indexOf("JS_Parse_Error") !== -1, e.stack)
+
+            // the following test fails because the original calling line of code isn't included in the stack trace
+            // to be clear, its not ok that this fails - this needs to be fixed
+            this.ok(e.stack.indexOf("run-tests.js") !== -1, e.stack)
+
+            // I think the following fails because of the use of runInContext in tools/node.js
+            // again, this is *not* ok
+            this.ok(e instanceof Error)
+
+        }
+    })
+}).writeConsole()
 
 /* -----[ utils ]----- */
 


### PR DESCRIPTION
The JS_Parse_Error object's stack trace gets the appropriate message, and has the correct name. Unfortunately, the stack trace still doesn't include the top-level calling part of the stack, and still isn't an instance of `Error` - almost definitely because of the user of `runInContext` in tools/node.js