### PR TITLE
Solves [ReferenceError: process is not defined] when using with Jade

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -6,6 +6,8 @@ var sys = require("util");
 var UglifyJS = vm.createContext({
     sys           : sys,
     console       : console,
+    process       : process,
+    Buffer        : Buffer,
     MOZ_SourceMap : require("source-map")
 });
 


### PR DESCRIPTION
When using Jade and compiling a template for the first time, there's a lot of this in the log:

```
[ReferenceError: process is not defined]
```

It seems the process variable is not being made available to the vm context by UglifyJS, which is a dependency of several of Jade's dependencies.  Making it available then leads to:

```
[ReferenceError: Buffer is not defined]
```

This pull request makes both process and Buffer available to the created context in order to quieten the errors in the logs.

I hope you'll consider merging it.