### PR TITLE
Escape \t like other special characters

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -92,6 +92,7 @@ function OutputStream(options) {
               case "\f": return "\\f";
               case "\n": return "\\n";
               case "\r": return "\\r";
+              case "\t": return "\\t";
               case "\u2028": return "\\u2028";
               case "\u2029": return "\\u2029";
               case '"': ++dq; return '"';


### PR DESCRIPTION
Fixes #369.