### PR TITLE
Basic support of asm.js uglification

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -89,13 +89,15 @@ merge(Compressor.prototype, {
     },
     before: function(node, descend, in_list) {
         if (node._squeezed) return node;
-        var was_scope = false;
+        // asm.js: drop unused only, leave everything else as is inside "use asm" scope
+        var asm = this.has_directive("use asm"),
+            was_scope = false;
         if (node instanceof AST_Scope) {
-            node = node.hoist_declarations(this);
+            if (!asm) node = node.hoist_declarations(this);
             was_scope = true;
         }
         descend(node, this);
-        node = node.optimize(this);
+        if (!asm) node = node.optimize(this);
         if (was_scope && node instanceof AST_Scope) {
             node.drop_unused(this);
             descend(node, this);
@@ -892,6 +894,15 @@ merge(Compressor.prototype, {
         def(AST_EmptyStatement, function(compressor){ return false });
         def(AST_Constant, function(compressor){ return false });
         def(AST_This, function(compressor){ return false });
+
+        // asm.js: `new stdlib.XYZ` inside "use asm" scope are always pure
+        def(AST_New, function(compressor){
+            if (compressor.has_directive("use asm")) return false;
+            // AST_Call fallback
+            var pure = compressor.option("pure_funcs");
+            if (!pure) return true;
+            return pure.indexOf(this.expression.print_to_string()) < 0;
+        });
 
         def(AST_Call, function(compressor){
             var pure = compressor.option("pure_funcs");

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -260,6 +260,14 @@ AST_Scope.DEFMETHOD("def_variable", function(symbol){
 
 AST_Scope.DEFMETHOD("next_mangled", function(options){
     var ext = this.enclosed;
+
+    // asm.js: don't mask module-scope names
+    var asm = this.has_directive("use asm"),
+        pasm = this.parent_scope ? this.parent_scope.has_directive("use asm") : false;
+    if (pasm) {
+        this.cname = this.parent_scope.cname;
+    }
+
     out: while (true) {
         var m = base54(++this.cname);
         if (!is_identifier(m)) continue; // skip over "do"
@@ -267,6 +275,21 @@ AST_Scope.DEFMETHOD("next_mangled", function(options){
         // https://github.com/mishoo/UglifyJS2/issues/242 -- do not
         // shadow a name excepted from mangling.
         if (options.except.indexOf(m) >= 0) continue;
+
+        // asm.js: don't reuse module name although it is out of the current scope
+        if (asm) {
+            var sym = this.name;
+            var penc = this.parent_scope.enclosed;
+            if (sym && penc.length) {
+                for (var i = 0; i < penc.length; i++) {
+                    var psym = penc[i];
+                    if (sym.name == psym.name) {
+                        var name = psym.mangled_name || (psym.unmangleable(options) && psym.name);
+                        if (m == name) continue out;
+                    }
+                }
+            }
+        }
 
         // we must ensure that the mangled name does not shadow a name
         // from some parent scope that is referenced in this or in


### PR DESCRIPTION
A had a problem when trying to uglify asm.js modules in my [asmcrypto.js](https://github.com/vibornoff/asmcrypto.js) project.

To fix that issue I added basic support:
* Asm.js is turned on by directive "use asm", so when it is met,
* Name mangler doesn't reuse names in the inner scopes of the modules, and
* Compression is turned off for that modules.