### PR TITLE
Escape null characters as \0 unless followed by 0-7.

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -85,7 +85,8 @@ function OutputStream(options) {
 
     function make_string(str) {
         var dq = 0, sq = 0;
-        str = str.replace(/[\\\b\f\n\r\t\x22\x27\u2028\u2029\0]/g, function(s){
+        str = str.replace(/[\\\b\f\n\r\t\x22\x27\u2028\u2029\0]/g,
+          function(s, i, w) {
             switch (s) {
               case "\\": return "\\\\";
               case "\b": return "\\b";
@@ -96,7 +97,7 @@ function OutputStream(options) {
               case "\u2029": return "\\u2029";
               case '"': ++dq; return '"';
               case "'": ++sq; return "'";
-              case "\0": return "\\x00";
+              case "\0": return /^[0-7]/.test(w.substr(i+1)) ? "\\x00" : "\\0";
             }
             return s;
         });

--- a/test/compress/concat-strings.js
+++ b/test/compress/concat-strings.js
@@ -11,6 +11,9 @@ concat_1: {
         var d = 1 + x() + 2 + 3 + "boo";
 
         var e = 1 + x() + 2 + "X" + 3 + "boo";
+
+        // be careful with concatentation with "\0" with octal-looking strings.
+        var f = "\0" + 360 + "\0" + 8 + "\0";
     }
     expect: {
         var a = "foobar" + x() + "moofoo" + y() + "xyz" + q();
@@ -18,5 +21,6 @@ concat_1: {
         var c = 1 + x() + 2 + "boo";
         var d = 1 + x() + 2 + 3 + "boo";
         var e = 1 + x() + 2 + "X3boo";
+        var f = "\x00360\08\0";
     }
 }


### PR DESCRIPTION
Small change to get a couple bytes back from UglifyJS.

The verbose "\x00" is oddly longer than the normal "\0" seen in code and only necessary when followed by an octal digit.  This change looks at the string, and it uses the shorter escape code in the normal case when not followed by [0-7].
