### PR TITLE
feature(package) add amdefine

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "async"      : "~0.2.6",
         "source-map" : "~0.1.7",
         "optimist"   : "~0.3.5",
-        "uglify-to-browserify": "~1.0.0"
+        "uglify-to-browserify": "~1.0.0",
+        "amdefine"   : "0.1.0"
     },
     "browserify": {
         "transform": [ "uglify-to-browserify" ]


### PR DESCRIPTION
Add [Amdefine](https://github.com/jrburke/amdefine). 
Without this module Uglify-js v2.4.8 do not starting.

```
Error: Cannot find module 'amdefine'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/komar/cloudcmd/node_modules/minify/node_modules/uglify-js/node_modules/source-map/lib/source-map/source-map-generator.js:8:18)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```
