### PR TITLE
Don't unescape byte order marks in regexps

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1126,7 +1126,7 @@ function OutputStream(options) {
             str = str.split("\\\\").map(function(str){
                 return str.replace(/\\u[0-9a-fA-F]{4}|\\x[0-9a-fA-F]{2}/g, function(s){
                     var code = parseInt(s.substr(2), 16);
-                    return code == 0x2f || code == 10 || code == 13 || code == 0x2028 || code == 0x2029 ? s : String.fromCharCode(code);
+                    return code == 0xfeff || code == 0x2f || code == 10 || code == 13 || code == 0x2028 || code == 0x2029 ? s : String.fromCharCode(code);
                 });
             }).join("\\\\");
         }


### PR DESCRIPTION
If BOMs are unescaped, minifying UglifyJS itself produces code that cannot be parsed with UglifyJS parser. This adds BOM the the list of always escaped characters in regexp literals.

The bug can be replicated by minifying UglifyJS itself.

```
$ uglifyjs --self | uglifyjs
Parse error at -:3,0
Unexpected token: punc (})
```

The cause for this error is the following line:

``` javascript
$TEXT.replace(/\r\n?|[\n\u2028\u2029]/g, "\n").replace(/^\uFEFF/, ''),
```

After #54, the unicode escape is unescaped.
