### PR TITLE
Wrong end token in conditionals

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1376,12 +1376,13 @@ function parse($TEXT, options) {
             next();
             var yes = expression(false);
             expect(":");
+            var alternative = expression(false, no_in);
             return new AST_Conditional({
                 start       : start,
                 condition   : expr,
                 consequent  : yes,
-                alternative : expression(false, no_in),
-                end         : peek()
+                alternative : alternative,
+                end         : prev()
             });
         }
         return expr;


### PR DESCRIPTION
This pull request fixes the end token for `AST_Conditional` nodes.

The following piece of code displays the start and end tokens of both a conditional and a binary node.
The end token of a conditional node is wrong.

**Code**

``` js
var UglifyJS = require("uglify-js");
var ast = UglifyJS.parse("var c = a ? 1 : 2 ; var d = a != 2; var e = 4;");
var walker = new UglifyJS.TreeWalker(function (node){
  if (node instanceof UglifyJS.AST_Conditional) {
    console.log("Conditional from '" + node.start.value + "' to '" + node.end.value+ "'.");
  } else if (node instanceof UglifyJS.AST_Binary) {
    console.log("Binary from '" + node.start.value + "' to '"+ node.end.value + "'.");
  }
});
ast.walk(walker);
```

**Expected result**

```
Conditional from 'a' to '2'.
Binary from 'a' to '2'.
```

**Actual result**

```
Conditional from 'a' to 'var'.
Binary from 'a' to '2'.
```

**Version**

Tested with UglifyJS version 2.4.10.
