### PR TITLE
Don't unescape \x00 in regexes (it breaks IE8)

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1140,6 +1140,7 @@ function OutputStream(options) {
             0x21   , // !
             0x0a   , // \n
             0x0d   , // \r
+            0x00   , // \0
             0xfeff , // Unicode BOM
             0x2028 , // unicode "line separator"
             0x2029 , // unicode "paragraph separator"


### PR DESCRIPTION
(I wish we had automated tests to address these kinds of problems, like the current tests in test/compress but for testing output.js instead of relying on it)
