### PR TITLE
Simplify nested conditionals if possible

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2296,6 +2296,19 @@ merge(Compressor.prototype, {
                 return consequent;
             }
         }
+        // x?y?z:a:a --> x&&y?z:a
+        if (consequent instanceof AST_Conditional
+            && consequent.alternative.equivalent_to(alternative)) {
+            return make_node(AST_Conditional, self, {
+                condition: make_node(AST_Binary, self, {
+                    left: self.condition,
+                    operator: "&&",
+                    right: consequent.condition
+                }),
+                consequent: consequent.consequent,
+                alternative: alternative
+            });
+        }
         return self;
     });
 

--- a/test/compress/conditionals.js
+++ b/test/compress/conditionals.js
@@ -205,3 +205,30 @@ cond_4: {
         some_condition(), do_something();
     }
 }
+
+cond_5: {
+    options = {
+        conditionals: true
+    };
+    input: {
+        if (some_condition()) {
+            if (some_other_condition()) {
+                do_something();
+            } else {
+                alternate();
+            }
+        } else {
+            alternate();
+        }
+
+        if (some_condition()) {
+            if (some_other_condition()) {
+                do_something();
+            }
+        }
+    }
+    expect: {
+        some_condition() && some_other_condition() ? do_something() : alternate();
+        some_condition() && some_other_condition() && do_something();
+    }
+}


### PR DESCRIPTION
This change adds some simple optimizations to nested conditionals. In our codebase, we have some generated code that this applies to.

``` js
x ? y ? z : a : a
// should be able to be safely converted to
x && y ? z : a
```

I don't have any benchmarks on how much of a benefit this provides in different circumstances, but I'd be happy to run some numbers if there's interest.

This is my first time contributing to Uglify; please let me know if there's anything I haven't done properly.
