### PR TITLE
Add option to alphabetize object literals during compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ to set `true`; it's effectively a shortcut for `foo=true`).
 - `drop_console` -- default `false`.  Pass `true` to discard calls to
   `console.*` functions.
 
+- `alphabetize` -- default `false`.  Pass `true` to alphabetize keys in object
+  literals.
+
 ### The `unsafe` option
 
 It enables some transformations that *might* break code logic in certain

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -72,6 +72,7 @@ function Compressor(options, false_by_default) {
         screw_ie8     : false,
         drop_console  : false,
         angular       : false,
+        alphabetize   : !false_by_default,
 
         warnings      : true,
         global_defs   : {}
@@ -2365,7 +2366,28 @@ merge(Compressor.prototype, {
         return self;
     };
     OPT(AST_Array, literals_in_boolean_context);
-    OPT(AST_Object, literals_in_boolean_context);
     OPT(AST_RegExp, literals_in_boolean_context);
+    OPT(AST_Object, function(self, compressor) {
+        if (compressor.option("alphabetize") && self.properties.length) {
+            var sortedProps = self.properties.sort(function(a, b) {
+                if (a.key < b.key) {
+                    return -1;
+                }
+                if (a.key > b.key) {
+                    return 1;
+                }
+                return 0;
+            });
+            for (var i = self.properties.length; i--;) {
+                if (self.properties[i] !== sortedProps[i]) {
+                    return make_node(AST_Object, self, {
+                        properties: sortedProps
+                    });
+                }
+            }
+        }
+
+        return literals_in_boolean_context(self, compressor);
+    });
 
 })();

--- a/test/compress/objects.js
+++ b/test/compress/objects.js
@@ -1,0 +1,35 @@
+alphabetize_disabled_by_default: {
+    options = {};
+    input: {
+        foo({
+            c: 1,
+            a: 2,
+            b: 3
+        });
+    }
+    expect: {
+        foo({
+            c: 1,
+            a: 2,
+            b: 3
+        });
+    }
+}
+
+alphabetize_orders_keys: {
+    options = { alphabetize: true };
+    input: {
+        foo({
+            c: 1,
+            a: 2,
+            b: 3
+        });
+    }
+    expect: {
+        foo({
+            a: 2,
+            b: 3,
+            c: 1
+        });
+    }
+}


### PR DESCRIPTION
This patch adds the option to have object literals alphabetized. This provides no direct size benefit, but can have very large benefits after gzipping. Consider the following example:

``` js
foo({
  a: function() {/* ... */ return x;},
  b: function() {/* ... */}
});
bar({
  b: function() {/* ... */},
  a: function() {/* ... */ return x;}
});
```

Gzip can't do much on the above example. If the object literals were alphabetized, though, the end of `a` and the key and function for `b` would be compressed away.

This has notable benefits in codebases that use a very Java-esque means of providing inheritance (i.e.: using some sort of `extend` function and declaring each method as a key in an object literal). A module may expose an "abstract class" which is meant to be implemented multiple times. The keys in the implementing "class"'s object literals may be in different orders, though, and if some of those members are the same or similar, that's a missed opportunity for compression:

```
var AbstractClass = Base.extend({
    size: function() {throw new Error('implement me');},
    capacity: function() {throw new Error('implement me');},
    add: function(item) {
        this.data.push(item);
    }
});
var ArrayClass = AbstractClass.extend({
    size: function() {return this.data.length;},
    capacity: function() {return this.max_len;}
});
var MockedArrayClass = AbstractClass.extend({
    add: function() {},  // no-op
    capacity: function() {return this.max_len;},
    size: function() {return this.fake_len;}
});
```

In the above example, reordering `capacity` and `size` will allow gzip to do a better job of compressing the `MockedArrayClass`.

The only potential downside here is that normally-adjacent keys in an object literal (which are grouped by similarity) may no longer be adjacent if there's another key that falls between them alphabetically, which can reduce the opportunity for compression. This is a somewhat contrived case, but it's the reason why I included the change under its own option and made it disabled by default.
