### PR TITLE
Assume missing map names means name hasn't changed

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -67,7 +67,9 @@ function SourceMap(options) {
             source = info.source;
             orig_line = info.line;
             orig_col = info.column;
-            name = info.name;
+            if (info.name) {
+                name = info.name;
+            }
         }
         generator.addMapping({
             generated : { line: gen_line + options.dest_line_diff, column: gen_col },


### PR DESCRIPTION
If the original source map doesn't specify a name for a location then assume that the name hasn't changed from the original source. In that case, use the current name detected by Uglify's AST.