### PR TITLE
Locks source-map dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "async"      : "~0.2.6",
-        "source-map" : "~0.1.31",
+        "source-map" : "0.1.32",
         "optimist"   : "~0.3.5",
         "uglify-to-browserify": "~1.0.0"
     },


### PR DESCRIPTION
Fixes #436

`source-map` ~~does not follow semver~~ so the dependency should be locked down. This will 'solve' #436 until the functionality to support sourcemap 0.1.33 is added to this library.

I understand the ideal situation is to add support for 0.1.33, but we don't yet. This is a quick patch to fix all of the libraries that depend on UglifyJS2 for its source map features, which are currently broken.

Edit:

On looking into the issue more, the situation might not be exactly as described above. It seems to be a bit more complicated, as it was _technically_ a bug that was being fixed. [Ref](https://github.com/mozilla/source-map/issues/99).

I'm unsure if always locking down the dependency is necessary, but I'm thinking it should be done _at least_ until support for 0.1.33 is added.
