### PR TITLE
Handle the case when SourceMapConsumer.originalPositionFor returns null source.

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -64,6 +64,9 @@ function SourceMap(options) {
                 line: orig_line,
                 column: orig_col
             });
+            if (info.source === null) {
+                return;
+            }
             source = info.source;
             orig_line = info.line;
             orig_col = info.column;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "async"      : "~0.2.6",
-        "source-map" : "~0.1.31",
+        "source-map" : "~0.1.33",
         "optimist"   : "~0.3.5",
         "uglify-to-browserify": "~1.0.0"
     },


### PR DESCRIPTION
This happens when SourceMapConsumer does not have a valid position to map the input line and column. This is a change in mozilla/source-map starting from version 0.1.33

Fixes #436
