### PR TITLE
Handle TryStatements trees from acorn >=0.2.0

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -51,7 +51,7 @@
                 start    : my_start_token(M),
                 end      : my_end_token(M),
                 body     : from_moz(M.block).body,
-                bcatch   : from_moz(M.handlers[0]),
+                bcatch   : from_moz(M.handlers ? M.handlers[0] : M.handler),
                 bfinally : M.finalizer ? new AST_Finally(from_moz(M.finalizer)) : null
             });
         },


### PR DESCRIPTION
This has been broken since https://github.com/marijnh/acorn/commit/62bc3641afc125276605fb7f5ea0f1f07457d9c5
