### PR TITLE
Allow colons in the pairs passed to AST_Toplevel.wrap_enclose

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -295,10 +295,10 @@ var AST_Toplevel = DEFNODE("Toplevel", "globals", {
         var parameters = [];
 
         arg_parameter_pairs.forEach(function(pair) {
-            var split = pair.split(":");
+            var splitAt = pair.lastIndexOf(":");
 
-            args.push(split[0]);
-            parameters.push(split[1]);
+            args.push(pair.substr(0, splitAt));
+            parameters.push(pair.substr(splitAt + 1));
         });
 
         var wrapped_tl = "(function(" + parameters.join(",") + "){ '$ORIG'; })(" + args.join(",") + ")";


### PR DESCRIPTION
The old code essentially split on the first colon and took everything after it as the parameter name. Since the parameter name has to be given last and can only be one colon-less word, it's better to split on the last colon. This also allows using ternary expressions, strings containing colons, etc. for the arg.

For example:

```
root = root.wrap_enclose(['(typeof global !== "undefined") ? global : this:global']);
```

The old code would make the wrapper `(function ( this) { ... })((typeof global !== "undefined") ? global );` which would then fail to compile. With this change it'll be `(function (global) { ... })((typeof global !== "undefined") ? global : this);`
