### PR TITLE
Convert undefined files to empty string

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -70,6 +70,8 @@ exports.minify = function(files, options) {
     if (options.spidermonkey) {
         toplevel = UglifyJS.AST_Node.from_mozilla_ast(files);
     } else {
+        if (typeof files == "undefined")
+            {files = ""};
         if (typeof files == "string")
             files = [ files ];
         files.forEach(function(file){


### PR DESCRIPTION
This is a fix for https://github.com/mishoo/UglifyJS2/issues/456

This is a subtle and hard-to-replicate bug, but the fix is unlikely to have any negative consequences, since the function obviously fails if `files` is undefined.
