### PR TITLE
Add sourceMappingUrl to output in node module

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -126,6 +126,11 @@ exports.minify = function(files, options) {
     }
     var stream = UglifyJS.OutputStream(output);
     toplevel.print(stream);
+
+    if(options.outSourceMap){
+        stream += "\n//# sourceMappingURL=" + options.outSourceMap;
+    }
+
     return {
         code : stream + "",
         map  : output.source_map + ""


### PR DESCRIPTION
If options.outSourceMap is specified the sourceMappingURL comment is appended to the output stream. 

Not sure if this was an intentional omission but the docs make it sound like this should happen, but at the moment it's only happening from the command line tool.
