### PR TITLE
Fixed TryStatement AST reformat when using acorn

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -51,7 +51,7 @@
                 start    : my_start_token(M),
                 end      : my_end_token(M),
                 body     : from_moz(M.block).body,
-                bcatch   : from_moz(M.handlers[0]),
+                bcatch   : from_moz(M.handler),
                 bfinally : M.finalizer ? new AST_Finally(from_moz(M.finalizer)) : null
             });
         },


### PR DESCRIPTION
As shown in http://mzl.la/1hkKgkE there is no property  named
`handlers` in the TryStatement node, but one named `handler`.
Previously, a TypeError (cannot reach `[0]` of `M.handlers`) exception
was thrown when using `uglifyjs` with the `—acorn` switch.
