### PR TITLE
Break dependency loop with optional source-map

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     },
     "dependencies": {
         "async"      : "~0.2.6",
-        "source-map" : "~0.1.33",
         "optimist"   : "~0.3.5",
         "uglify-to-browserify": "~1.0.0"
+    },
+    "optionalDependencies": {
+        "source-map" : "~0.1.33"
     },
     "browserify": {
         "transform": [ "uglify-to-browserify" ]


### PR DESCRIPTION
uglifyjs -> source-map -> dryice -> uglifyjs
is a dependency loop - it is usually a very good idea to get rid of them.
It can be tedious to explain.
Maybe refer to [debian policy 7.2, paragraph 6](https://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps) to understand how it is bad for package management as a whole.
I propose that particular solution because dryice doesn't rely on source-map and uglifyjs runs all right without source-map (as long as we don't want to get source maps).

This might only be needed by distributions like debian, in which a separate patch can be maintained,
so i'd understand perfectly if that PR was rejected.

Regards,
Jérémy.
