### PR TITLE
Maintain inline sourcesContent from inSourceMap

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -58,6 +58,15 @@ function SourceMap(options) {
         sourceRoot : options.root
     });
     var orig_map = options.orig && new MOZ_SourceMap.SourceMapConsumer(options.orig);
+
+    // Copy across inline sourcesContent, if any
+    if (options.orig.sourcesContent) {
+        var len = options.orig.sourcesContent.length;
+        for (var i = 0; i < len; i++) {
+            generator.setSourceContent(options.orig.sources[i], options.orig.sourcesContent[i]);
+        }
+    }
+
     function add(source, gen_line, gen_col, orig_line, orig_col, name) {
         if (orig_map) {
             var info = orig_map.originalPositionFor({

--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -60,7 +60,7 @@ function SourceMap(options) {
     var orig_map = options.orig && new MOZ_SourceMap.SourceMapConsumer(options.orig);
 
     // Copy across inline sourcesContent, if any
-    if (options.orig.sourcesContent) {
+    if (options.orig && options.orig.sourcesContent) {
         var len = options.orig.sourcesContent.length;
         for (var i = 0; i < len; i++) {
             generator.setSourceContent(options.orig.sources[i], options.orig.sourcesContent[i]);


### PR DESCRIPTION
If the input source map has inline source content (e.g. from Browserify in debug mode) then copy that across to the new source map so it continues to be inline after minification.