### PR TITLE
[node.js] Add inSourceMapFromString option so one can pass in the sourcemap contents in inSourceMap.

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -103,7 +103,7 @@ exports.minify = function(files, options) {
     // 4. output
     var inMap = options.inSourceMap;
     var output = {};
-    if (typeof options.inSourceMap == "string") {
+    if (typeof options.inSourceMap == "string" && !options.inSourceMapFromString) {
         inMap = fs.readFileSync(options.inSourceMap, "utf8");
     }
     if (options.outSourceMap) {


### PR DESCRIPTION
I have both a js file and sourcemap for it in strings in my app. In order to call minify() I either need to write the source map to a temp file (yuck), or switch to the complicated API (feels overwhelming).

This small patch lets me pass in the sourcemap by adding the new option `inSourceMapFromString`, which is analogous to the `fromString` option.