### PR TITLE
Fix broken return-statements for preserve_line and extend with no_empty_line

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -61,6 +61,7 @@ function OutputStream(options) {
         semicolons       : true,
         comments         : false,
         preserve_line    : false,
+        no_empty_line    : false,
         screw_ie8        : false,
         preamble         : null,
     }, true);
@@ -69,6 +70,7 @@ function OutputStream(options) {
     var current_col = 0;
     var current_line = 1;
     var current_pos = 0;
+    var current_line_offset = 0;
     var OUTPUT = "";
 
     function to_ascii(str, identifier) {
@@ -150,7 +152,9 @@ function OutputStream(options) {
                     OUTPUT += ";";
                     current_col++;
                     current_pos++;
-                } else {
+                } else if (!options.preserve_line ||
+                            OUTPUT.substr(-6) !== "return")
+                {
                     OUTPUT += "\n";
                     current_pos++;
                     current_line++;
@@ -165,12 +169,20 @@ function OutputStream(options) {
 
         if (!options.beautify && options.preserve_line && stack[stack.length - 1]) {
             var target_line = stack[stack.length - 1].start.line;
-            while (current_line < target_line) {
+            while (current_line + current_line_offset < target_line) {
+                if (OUTPUT.substr(-6) === "return")
+                    break;
+
                 OUTPUT += "\n";
                 current_pos++;
                 current_line++;
                 current_col = 0;
                 might_need_space = false;
+
+                if (options.no_empty_line) {
+                    current_line_offset = target_line - current_line;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
I found `preserve_line` extremely useful for production builds, allowing me to always trace back errors to the exact source line. However, I found that it was broken as-is as it would separate return-statements from the value they should return (which in JS means return nothing). I also added `no_empty_line` to avoid it creating tons and tons of empty lines in an attempt to (unsuccessfully) match line numbers with optimizations enabled.

It currently tests with `OUTPUT.substr(-6) !== "return"`, it is not very neat but it's very isolated (and safe). I feared that tracking it "correctly" would be too invasive for an edge-use kind of thing. I don't mind making it "proper" though.

Feel free to critique, reject, etc :)

However, I personally found this super useful and it seemed like Ben Alpert at Khan Academy was quite interested in it too (but he's using CLI so exposing it would be nice then), I've also talked to 1-2 more who also seemed really interested.