### PR TITLE
Throw descriptive error for Invalid RegExp

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1153,7 +1153,12 @@ function OutputStream(options) {
     };
 
     DEFPRINT(AST_RegExp, function(self, output){
-        var str = self.getValue().toString();
+        var str = self.getValue()
+        try {
+            str = str.toString();
+        } catch (e) {
+            throw new Error('Cannot evaluate RegExp [' + self.start.file + ':' + self.start.line + ',' + self.start.col + ']');
+        }
         if (output.option("ascii_only")) {
             str = output.to_ascii(str);
         } else if (output.option("unescape_regexps")) {


### PR DESCRIPTION
Came across some code on an internal project that was not only invalid, but crashing uglify. :crying_cat_face: 

Uglify's output wasn't too helpful.
```sh
/usr/local/lib/node_modules/uglify-js/lib/compress.js:688
                if (ex !== def) throw ex;
                                      ^
TypeError: Cannot call method 'toString' of undefined
    at i (/usr/local/lib/node_modules/uglify-js/lib/output.js:1156:35)
    at doit (/usr/local/lib/node_modules/uglify-js/lib/output.js:362:13)
    at AST_Node.print (/usr/local/lib/node_modules/uglify-js/lib/output.js:368:13)
    at AST_Node.print_to_string (/usr/local/lib/node_modules/uglify-js/lib/output.js:375:14)
    at best_of (/usr/local/lib/node_modules/uglify-js/lib/compress.js:668:21)
    at AST_Node.e [as evaluate] (/usr/local/lib/node_modules/uglify-js/lib/compress.js:686:26)
    at /usr/local/lib/node_modules/uglify-js/lib/compress.js:2182:21
    at AST_Node.optimize (/usr/local/lib/node_modules/uglify-js/lib/compress.js:113:23)
    at Object.merge.before (/usr/local/lib/node_modules/uglify-js/lib/compress.js:97:21)
    at AST_Node.transform (/usr/local/lib/node_modules/uglify-js/lib/transform.js:61:35)
```

Turns out the code in question, was invalid use of regular expressions, as in:
```js
"test".match(/test/i || /test2/i);
```

With this patch, Uglify points us in a direction.
```sh
/usr/local/lib/node_modules/uglify-js/lib/compress.js:688
                if (ex !== def) throw ex;
                                      ^
Error: Cannot evaluate RegExp [temp.js:1,13]
    at i (/usr/local/lib/node_modules/uglify-js/lib/output.js:1160:17)
    at doit (/usr/local/lib/node_modules/uglify-js/lib/output.js:362:13)
    at AST_Node.print (/usr/local/lib/node_modules/uglify-js/lib/output.js:368:13)
    at AST_Node.print_to_string (/usr/local/lib/node_modules/uglify-js/lib/output.js:375:14)
    at best_of (/usr/local/lib/node_modules/uglify-js/lib/compress.js:668:21)
    at AST_Node.e [as evaluate] (/usr/local/lib/node_modules/uglify-js/lib/compress.js:686:26)
    at /usr/local/lib/node_modules/uglify-js/lib/compress.js:2182:21
    at AST_Node.optimize (/usr/local/lib/node_modules/uglify-js/lib/compress.js:113:23)
    at Object.merge.before (/usr/local/lib/node_modules/uglify-js/lib/compress.js:97:21)
    at AST_Node.transform (/usr/local/lib/node_modules/uglify-js/lib/transform.js:61:35)
```

First time contributor, sorry for the lack of a formal test-case.  Also, I wasn't quite sure the best way to throw errors.