### PR TITLE
Update .travis.yml to pass the test on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-    - "0.4"
     - "0.8"
     - "0.10"
     - "0.11"


### PR DESCRIPTION
Travis CI doesn’t support Node v0.4.
http://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Provided-Node.js-Versions
