### PR TITLE
Evaluate "foo".length ==> 3

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -775,6 +775,14 @@ merge(Compressor.prototype, {
             if (d && d.constant && d.init) return ev(d.init, compressor);
             throw def;
         });
+        def(AST_Dot, function(compressor){
+            if (compressor.option('unsafe') && this.property == "length") {
+                var str = ev(this.expression, compressor);
+                if (typeof str == "string")
+                    return str.length;
+            }
+            throw def;
+        });
     })(function(node, func){
         node.DEFMETHOD("_eval", func);
     });
@@ -2349,7 +2357,7 @@ merge(Compressor.prototype, {
                 return make_node(AST_Dot, self, {
                     expression : self.expression,
                     property   : prop
-                });
+                }).optimize(compressor);
             }
             var v = parseFloat(prop);
             if (!isNaN(v) && v.toString() == prop) {
@@ -2359,6 +2367,10 @@ merge(Compressor.prototype, {
             }
         }
         return self;
+    });
+
+    OPT(AST_Dot, function(self, compressor){
+        return self.evaluate(compressor)[0];
     });
 
     function literals_in_boolean_context(self, compressor) {

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -52,3 +52,23 @@ dot_properties_es5: {
         a[""] = "whitespace";
     }
 }
+
+evaluate_length: {
+    options = {
+        properties: true,
+        unsafe: true,
+        evaluate: true
+    };
+    input: {
+        a = "foo".length;
+        a = ("foo" + "bar")["len" + "gth"];
+        a = b.length;
+        a = ("foo" + b).length;
+    }
+    expect: {
+        a = 3;
+        a = 6;
+        a = b.length;
+        a = ("foo" + b).length;
+    }
+}


### PR DESCRIPTION
This patch evaluates `"foo".length` into just `3`, i.e. `{string literal}.length` into a `{number}`.

The evaluation is done only when options `evaluate` and `unsafe` are on.
