### PR TITLE
Add support for CSP context without "unsafe-eval".

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -50,15 +50,27 @@ function DEFNODE(type, props, methods, base) {
     var self_props = props;
     if (base && base.PROPS)
         props = props.concat(base.PROPS);
-    var code = "return function AST_" + type + "(props){ if (props) { ";
-    for (var i = props.length; --i >= 0;) {
-        code += "this." + props[i] + " = props." + props[i] + ";";
-    }
     var proto = base && new base;
-    if (proto && proto.initialize || (methods && methods.initialize))
-        code += "this.initialize();";
-    code += "}}";
-    var ctor = new Function(code)();
+    var ctor;
+    if (typeof UglifyJS_NoUnsafeEval === "undefined") {
+        var code = "return function AST_" + type + "(props){ if (props) { ";
+        for (var i = props.length; --i >= 0;) {
+            code += "this." + props[i] + " = props." + props[i] + ";";
+        }
+        if (proto && proto.initialize || (methods && methods.initialize))
+            code += "this.initialize();";
+        code += "}}";
+        ctor = new Function(code)();
+    } else {
+      ctor = function (values) {
+          if (values) {
+              for (var i = props.length; --i >= 0; )
+                  this[props[i]] = values[props[i]];
+              if (proto && proto.initialize || (methods && methods.initialize))
+                  this.initialize();
+          }
+      };
+    }
     if (proto) {
         ctor.prototype = proto;
         ctor.BASE = base;

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -394,6 +394,76 @@
     };
 
     function map(moztype, mytype, propmap) {
+        if (typeof UglifyJS_NoUnsafeEval !== "undefined") {
+            var prop_list = [];
+            if (propmap) propmap.split(/\s*,\s*/).forEach(function(prop) {
+                var m = /([a-z0-9$_]+)(=|@|>|%)([a-z0-9$_]+)/i.exec(prop);
+                if (!m) throw new Error("Can't understand property map: " + prop);
+                if ('=@>%'.indexOf(m[2]) < 0) {
+                    throw new Error("Can't understand operator in propmap: " + prop);
+                }
+                prop_list.push(m);
+            });
+            var moz_to_me = function (M) {
+                var props = {
+                    start: my_start_token(M),
+                    end: my_end_token(M)
+                };
+                for (var i = 0; i < prop_list.length; i++) {
+                    var m = prop_list[i];
+                    var moz = m[1], how = m[2], my = m[3];
+                    var mozProp = M[moz];
+                    var myProp;
+                    switch (how) {
+                        case "@":
+                            myProp = mozProp.map(from_moz);
+                            break;
+                        case ">":
+                            myProp = from_moz(mozProp);
+                            break;
+                        case "=":
+                            myProp = mozProp;
+                            break;
+                        case "%":
+                            myProp = from_moz(mozProp).body;
+                            break;
+                    }
+                    props[my] = myProp;
+                }
+                return new mytype(props);
+            };
+            var me_to_moz = function (M) {
+                var props = {
+                    type: moztype
+                };
+                for (var i = 0; i < prop_list.length; i++) {
+                    var m = prop_list[i];
+                    var moz = m[1], how = m[2], my = m[3];
+                    var myProp = M[my];
+                    var mozProp;
+                    switch (how) {
+                        case "@":
+                            mozProp = myProp.map(to_moz);
+                            break;
+                        case ">":
+                            mozProp = to_moz(myProp);
+                            break;
+                        case "=":
+                            mozProp = myProp;
+                            break;
+                        case "%":
+                            mozProp = to_moz_block(M);
+                            break;
+                    }
+                    props[moz] = mozProp;
+                }
+                return props;
+            };
+            MOZ_TO_ME[moztype] = moz_to_me;
+            def_to_moz(mytype, me_to_moz);
+            return;
+        }
+
         var moz_to_me = "function From_Moz_" + moztype + "(M){\n";
         moz_to_me += "return new " + mytype.name + "({\n" +
             "start: my_start_token(M),\n" +

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -219,6 +219,11 @@ function set_intersection(a, b) {
 // [1] https://github.com/marijnh/acorn
 function makePredicate(words) {
     if (!(words instanceof Array)) words = words.split(" ");
+    if (typeof UglifyJS_NoUnsafeEval !== "undefined") {
+        return function (str) {
+            return words.indexOf(str) >= 0;
+        };
+    }
     var f = "", cats = [];
     out: for (var i = 0; i < words.length; ++i) {
         for (var j = 0; j < cats.length; ++j)


### PR DESCRIPTION
This pull request allows UglifyJS to run without using `new Function` which is forbidden in CSP-enabled context such as Chrome extensions and packaged apps. (For me, I'm trying to use UglifyJS in Chrome extensions.)

This pull request checks whether a global variable `UglifyJS_NoUnsafeEval` is available. If so, it attempts to use other solutions than `new Function`. Although the alternative implementation isn't quite optimized, it would only affect UglifyJS in CSP context and has no performance impact on normal usage. In fact I didn't modify anything related to the original implementation expect wrapping some code in if-statements in `lib/ast.js`.

All tests will pass for the new code if you add `UglifyJS_NoUnsafeEval: true` to the vm creation in `tools/node.js`, which can prove the correctness of the alternative implementation. But I don't know how to modify the test runner so that it can run both versions (with and without unsafe eval).

Please check if this pull request is appropriate for the project. In my opinion this PR won't hurt because it does not change the logic or performance with "normal" code. It does not even touch anything related to parsing, compressing and mangling. It only modifies the initialization part to make it run in CSP context and does nothing else.