### PR TITLE
Add filename to the JS_Parse_Error exception.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -181,8 +181,9 @@ function parse_js_number(num) {
     }
 };
 
-function JS_Parse_Error(message, line, col, pos) {
+function JS_Parse_Error(message, filename, line, col, pos) {
     this.message = message;
+    this.filename = filename;
     this.line = line;
     this.col = col;
     this.pos = pos;
@@ -194,7 +195,7 @@ JS_Parse_Error.prototype.toString = function() {
 };
 
 function js_error(message, filename, line, col, pos) {
-    throw new JS_Parse_Error(message, line, col, pos);
+    throw new JS_Parse_Error(message, filename, line, col, pos);
 };
 
 function is_token(token, type, val) {


### PR DESCRIPTION
It would be nice to have access to the filename of the file that includes the code that causes a JavaScript error. This is especially handy if uglifying multiple files at once.

Only a small change is needed for this to happen as it's already available in the function that throws the error.