### PR TITLE
Resolve the relative path to lib files last

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -33,7 +33,7 @@ var FILES = exports.FILES = [
     "../lib/sourcemap.js",
     "../lib/mozilla-ast.js"
 ].map(function(file){
-    return path.join(path.dirname(fs.realpathSync(__filename)), file);
+    return fs.realpathSync(path.join(path.dirname(__filename), file));
 });
 
 FILES.forEach(load_global);


### PR DESCRIPTION
This allows usage of UglifyJS on build systems which have a flat (or non-matching relative) directory structure for source files.

Fixes #539