### PR TITLE
Conditional assignment of equivalent constants compressed  ( x=y?1:1 --> x=1 )

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2322,11 +2322,15 @@ merge(Compressor.prototype, {
             });
         }
         // x=y?1:1 --> x=1
-        if (!self.condition.has_side_effects(compressor)
-            && consequent instanceof AST_Constant
+        if (consequent instanceof AST_Constant
             && alternative instanceof AST_Constant
             && consequent.equivalent_to(alternative)) {
-            return make_node_from_constant(compressor, consequent.value, self);
+            if (self.condition.has_side_effects(compressor)) {
+                return AST_Seq.from_array([self.condition, make_node_from_constant(compressor, consequent.value, self)]);
+            } else {
+                return make_node_from_constant(compressor, consequent.value, self);
+
+            }
         }
         return self;
     });

--- a/test/compress/conditionals.js
+++ b/test/compress/conditionals.js
@@ -258,30 +258,38 @@ cond_7: {
 
         x = y ? 'foo' : y ? 'foo' : 'fo'+'o';
 
+        // Compress conditions that have side effects
+        if (condition()) {
+            x = 10+10;
+        } else {
+            x = 20;
+        }
+
+        if (z) {
+            x = 'fuji';
+        } else if (condition()) {
+            x = 'fu'+'ji';
+        } else {
+            x = 'fuji';
+        }
+
+        x = condition() ? 'foobar' : 'foo'+'bar';
+
         // don't compress these
         x = y ? a : b;
 
         x = y ? 'foo' : 'fo';
-
-        // make sure not to mess with conditions that have side effects
-        // TODO: Make sure to mess with conditions that have side effects... proprely
-        if (some_condition()) {
-            x = 1+1;
-        } else {
-            x = 2;
-        }
-
-        x = some_condition() ? 'foo' : 'fo'+'o';
     }
     expect: {
         x = 2;
         x = 2;
         x = 'foo';
         x = 'foo';
+        x = (condition(), 20);
+        x = z ? 'fuji' : (condition(), 'fuji');
+        x = (condition(), 'foobar');
         x = y ? a : b;
         x = y ? 'foo' : 'fo';
-        x = some_condition() ? 2 : 2;
-        x = some_condition() ? 'foo' : 'foo';
     }
 }
 


### PR DESCRIPTION
When all possible outcomes of a conditional assignment are equivalent constants, and the condition has no side effects, compress them into a simple assignment.

For example:

``` javascript
        if (y) {
            x = 1+1;
        } else {
            x = 2;
        }
        // will become x=2;

        if (y) {
            x = 1+1;
        } else if (z) {
            x = 2;
        } else {
            x = 3-1;
        }
        // will become x=2;

        x = y ? 'foo' : 'fo'+'o';
        // will become x='foo';

        x = y ? 'foo' : y ? 'foo' : 'fo'+'o';
        // will become x='foo';
```

Compressed and evaluated:

``` javascript
//Before this change:
x=y?2:2; x=y?2:z?2:2; x=y?"foo":"foo"; x=y?"foo":y?"foo":"foo";
//After this change:
x=2; x=2; x="foo"; x="foo";
```
