### PR TITLE
Use uglify source map token names if missing

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -70,7 +70,7 @@ function SourceMap(options) {
             source = info.source;
             orig_line = info.line;
             orig_col = info.column;
-            name = info.name;
+            name = info.name || name;
         }
         generator.addMapping({
             generated : { line: gen_line + options.dest_line_diff, column: gen_col },


### PR DESCRIPTION
This PR will use the names provided by Uglify when the input source map `names` entry doesn't provide info for the current position.

When `--in-source-map` is used and the previous source map doesn't include any name entries (e.g. the source file was only concatenated and not mangled in any way) the token names provided by Uglify are ignored.
