### PR TITLE
Don't warn for an unreferenced exception symbol in a catch block.

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -532,6 +532,7 @@ AST_Toplevel.DEFMETHOD("scope_warnings", function(options){
         }
         if (options.unreferenced
             && (node instanceof AST_SymbolDeclaration || node instanceof AST_Label)
+            && !(node instanceof AST_SymbolCatch)
             && node.unreferenced()) {
             AST_Node.warn("{type} {name} is declared but not referenced [{file}:{line},{col}]", {
                 type: node instanceof AST_Label ? "Label" : "Symbol",


### PR DESCRIPTION
A catch block may not use the exception variable, in which case UJS will warn about it being unreferenced. Since there is no way to write a catch block in JS without specifying a variable to hold the exception, this warning is superfluous.

This change checks that a symbol is not an AST_SymbolCatch before warning about it being unreferenced.

Before this change:

``` sh
$ echo 'try { } catch (ex) { }' | ./uglifyjs --lint

WARN: Symbol ex is declared but not referenced [-:1,15]
try{}catch(ex){}
```

After this change:

``` sh
$ echo 'try { } catch (ex) { }' | ./uglifyjs --lint

try{}catch(ex){}
```
