### PR TITLE
Pass filename for string based contexts from options.filename

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -194,7 +194,7 @@ JS_Parse_Error.prototype.toString = function() {
 };
 
 function js_error(message, filename, line, col, pos) {
-    throw new JS_Parse_Error(message, line, col, pos);
+    throw new JS_Parse_Error(''+ message + ' at ' + filename, line, col, pos);
 };
 
 function is_token(token, type, val) {

--- a/tools/node.js
+++ b/tools/node.js
@@ -78,7 +78,7 @@ exports.minify = function(files, options) {
                 : fs.readFileSync(file, "utf8");
             sourcesContent[file] = code;
             toplevel = UglifyJS.parse(code, {
-                filename: options.fromString ? "?" : file,
+                filename: options.fromString ? (options.filename ? options.filename : "?") : file,
                 toplevel: toplevel
             });
         });


### PR DESCRIPTION
I had a problem with [Uglifyify](https://github.com/hughsk/uglifyify) that some errors didn't have correct file names visible -- but there still was line, column and position there and it was really hard to find where was the real problem. 

I've fixed the problem below by 

* Not ignoring `filename` argument at `js_error()`
* Passing on `options.filename` for string based contexts

I have also created a pull request for uglifyify: hughsk/uglifyify#21
