### PR TITLE
space_function option to always include a space after function keyword

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -50,6 +50,7 @@ function OutputStream(options) {
         indent_level     : 4,
         quote_keys       : false,
         space_colon      : true,
+        space_function   : false,
         ascii_only       : false,
         unescape_regexps : false,
         inline_script    : false,
@@ -713,8 +714,10 @@ function OutputStream(options) {
         if (!nokeyword) {
             output.print("function");
         }
-        if (self.name) {
+        if (options.space_function || self.name) {
             output.space();
+        }
+        if (self.name) {
             self.name.print(output);
         }
         output.with_parens(function(){


### PR DESCRIPTION
For anonymous functions, the only output option seems to be:

```
function() { ...
```

However, it is sometimes desirable to always include a space after the `function` keyword for readability. The `space_function` option (`false` by default, to preserve existing functionality) can be set to `true` to always include a space after the `function` keyword:

```
function () { ...
```
## Fringe Argument

Let's consistently define the syntax of a function block as being:

`function [<function name>]([<arguments>]) { ...`

The space after the keyword is always there, regardless of the function of being named or anonymous:

`function foo() { ...`, `function () { ...`

The syntax of a function call is:

`<function name>()`

For example:

`foo()`

When a function declaration is written without a space after the `function` keyword, it is reminiscent of a function call, while it is not:

`function() {`
