### PR TITLE
Preserve original sourceContents from inSourceMap

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -53,11 +53,13 @@ function SourceMap(options) {
         orig_line_diff : 0,
         dest_line_diff : 0,
     });
-    var generator = new MOZ_SourceMap.SourceMapGenerator({
+    var orig_map = options.orig && new MOZ_SourceMap.SourceMapConsumer(options.orig);
+    var generator = options.orig
+		? MOZ_SourceMap.SourceMapGenerator.fromSourceMap(orig_map)
+		: new MOZ_SourceMap.SourceMapGenerator({
         file       : options.file,
         sourceRoot : options.root
     });
-    var orig_map = options.orig && new MOZ_SourceMap.SourceMapConsumer(options.orig);
     function add(source, gen_line, gen_col, orig_line, orig_col, name) {
         if (orig_map) {
             var info = orig_map.originalPositionFor({


### PR DESCRIPTION
Fixes #563
Fixes #152
Somehow addresses #145 by preserving the original sources in the inSourceMap (if they are there)

This way you can do multiple transformations the source map e.g.
`typescript` / `coffeescript` -> `js` -> `browserify` -> `exorcist` -> `uglify` 