### PR TITLE
Fix #569

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1722,6 +1722,11 @@ merge(Compressor.prototype, {
                     }).transform(compressor);
                     break;
                   case "Function":
+                    // new Function() => function(){}
+                    if (self.args.length == 0) return make_node(AST_Function, self, {
+                        argnames: [],
+                        body: []
+                    });
                     if (all(self.args, function(x){ return x instanceof AST_String })) {
                         // quite a corner-case, but we can handle it:
                         //   https://github.com/mishoo/UglifyJS2/issues/203


### PR DESCRIPTION
When no arguments are given to `new Function()`, it should be treated as
a regular anonymous function (http://es5.github.io/#x15.3.2.1)