### PR TITLE
Fix #556

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -86,7 +86,7 @@ function OutputStream(options) {
 
     function make_string(str) {
         var dq = 0, sq = 0;
-        str = str.replace(/[\\\b\f\n\r\t\x22\x27\u2028\u2029\0]/g, function(s){
+        str = str.replace(/[\\\b\f\n\r\t\x22\x27\u2028\u2029\0\ufeff]/g, function(s){
             switch (s) {
               case "\\": return "\\\\";
               case "\b": return "\\b";
@@ -98,6 +98,7 @@ function OutputStream(options) {
               case '"': ++dq; return '"';
               case "'": ++sq; return "'";
               case "\0": return "\\x00";
+              case "\ufeff": return "\\ufeff";
             }
             return s;
         });


### PR DESCRIPTION
`\uFEFF` (ZERO WIDTH NO-BREAK SPACE) is removed when parsing, but was
un-escaped for the output when `ascii_only` was false.

When using
UglifyJS multiple times (creating packages from minified sources, for
example), this would lead to problems because the byte was removed when
parsing for the second time.