### PR TITLE
Fix backslashes in source-map paths on Windows

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -252,7 +252,7 @@ async.eachLimit(files, 1, function (file, cb) {
         }
         if (ARGS.p != null) {
             if (P_RELATIVE) {
-                file = path.relative(path.dirname(ARGS.source_map), file);
+                file = path.relative(path.dirname(ARGS.source_map), file).replace(/\\/g, '/');
             } else {
                 var p = parseInt(ARGS.p, 10);
                 if (!isNaN(p)) {


### PR DESCRIPTION
The path in the source-map always contains backslashes when `--prefix relative` is used. Even if the input files are specified with a forward slash.

Without `--prefix relative`:
```
>uglifyjs --output out.js path/to/a.js --source-map out.js.map
>cat out.js.map
{"version":3,"file":"out.js","sources":["path/to/a.js"],"names":["a"],"mappings":"AAAA,QAASA,KACR,MAAO"}
```

With `--prefix relative`:
```
>uglifyjs --output out.js path/to/a.js --source-map out.js.map --prefix relative
>cat out.js.map
{"version":3,"file":"out.js","sources":["path\\to\\a.js"],"names":["a"],"mappings":"AAAA,QAASA,KACR,MAAO"}
```

This causes an error when debugging in Firefox.