### PR TITLE
using the original sourcemap as the base

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -53,10 +53,7 @@ function SourceMap(options) {
         orig_line_diff : 0,
         dest_line_diff : 0,
     });
-    var generator = new MOZ_SourceMap.SourceMapGenerator({
-        file       : options.file,
-        sourceRoot : options.root
-    });
+    var generator;
     var orig_map = options.orig && new MOZ_SourceMap.SourceMapConsumer(options.orig);
     function add(source, gen_line, gen_col, orig_line, orig_col, name) {
         if (orig_map) {
@@ -78,7 +75,15 @@ function SourceMap(options) {
             source    : source,
             name      : name
         });
-    };
+    }
+    if (orig_map) {
+      generator = MOZ_SourceMap.SourceMapGenerator.fromSourceMap(orig_map);
+    } else {
+      generator = new MOZ_SourceMap.SourceMapGenerator({
+          file       : options.file,
+          sourceRoot : options.root
+      });
+    }
     return {
         add        : add,
         get        : function() { return generator },


### PR DESCRIPTION
As today, if the original source map is provided, the generator was still ruling the transformations of the source, instead we should create the generator from the original map when needed. More information about this feature here:

*  https://github.com/mozilla/source-map#sourcemapgeneratorfromsourcemapsourcemapconsumer