### PR TITLE
fix base54

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -471,7 +471,9 @@ var base54 = (function() {
     base54.freq = function(){ return frequency };
     function base54(num) {
         var ret = "", base = 54;
+        num++;
         do {
+            num--;
             ret += String.fromCharCode(chars[num % base]);
             num = Math.floor(num / base);
             base = 64;


### PR DESCRIPTION
Current version of base54:
base54(54)=='ab'
base54(54+54*64)=='abb'
base54(54+54*64-1)=='_ab'

My version:
base54(54)=='aa'
base54(54+54*64)=='aaa'
base54(54+54*64-1)=='_9'