### PR TITLE
Fix max_line_len not working for JSON files

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -221,7 +221,7 @@ function OutputStream(options) {
 
     var newline = options.beautify ? function() {
         print("\n");
-    } : noop;
+    } : maybe_newline;
 
     var semicolon = options.beautify ? function() {
         print(";");


### PR DESCRIPTION
As `maybe_newline()` is only called when `might_need_semicolon` is `true`, the `max_line_len` option has no effect for files without (or with very few) semicolons (like JSON files). A simple for this problem is to use `maybe_newline()` instead of `noop` as the `newline()` function in non-beautify mode.