### PR TITLE
Allow property access for Infinity

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1109,7 +1109,7 @@ function OutputStream(options) {
     });
     DEFPRINT(AST_Hole, noop);
     DEFPRINT(AST_Infinity, function(self, output){
-        output.print("1/0");
+        output.print("(1/0)");
     });
     DEFPRINT(AST_NaN, function(self, output){
         output.print("0/0");

--- a/test/compress/issue-597.js
+++ b/test/compress/issue-597.js
@@ -1,0 +1,4 @@
+infinity_to_string: {
+    input: { Infinity.toString() }
+    expect: { (1/0).toString() }
+}


### PR DESCRIPTION
This makes it so `Infinity` is always written as `(0/1)`.  This could be done only when `Infinity` is in a member expression.

Fixes #597.
