### PR TITLE
Fix #597

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2203,12 +2203,28 @@ merge(Compressor.prototype, {
               case "undefined":
                 return make_node(AST_Undefined, self);
               case "NaN":
-                return make_node(AST_NaN, self);
+                return make_node(AST_NaN, self).transform(compressor);
               case "Infinity":
-                return make_node(AST_Infinity, self);
+                return make_node(AST_Infinity, self).transform(compressor);
             }
         }
         return self;
+    });
+
+    OPT(AST_Infinity, function (self, compressor) {
+        return make_node(AST_Binary, self, {
+            operator : '/',
+            left     : make_node(AST_Number, null, {value: 1}),
+            right    : make_node(AST_Number, null, {value: 0})
+        });
+    });
+
+    OPT(AST_NaN, function (self, compressor) {
+        return make_node(AST_Binary, self, {
+            operator : '/',
+            left     : make_node(AST_Number, null, {value: 0}),
+            right    : make_node(AST_Number, null, {value: 0})
+        });
     });
 
     OPT(AST_Undefined, function(self, compressor){

--- a/lib/output.js
+++ b/lib/output.js
@@ -549,12 +549,6 @@ function OutputStream(options) {
             return true;
     });
 
-    PARENS(AST_NaN, function(output){
-        var p = output.parent();
-        if (p instanceof AST_PropAccess && p.expression === this)
-            return true;
-    });
-
     PARENS([ AST_Assign, AST_Conditional ], function (output){
         var p = output.parent();
         // !(a = false) → true
@@ -1109,10 +1103,10 @@ function OutputStream(options) {
     });
     DEFPRINT(AST_Hole, noop);
     DEFPRINT(AST_Infinity, function(self, output){
-        output.print("1/0");
+        output.print("Infinity");
     });
     DEFPRINT(AST_NaN, function(self, output){
-        output.print("0/0");
+        output.print("NaN");
     });
     DEFPRINT(AST_This, function(self, output){
         output.print("this");

--- a/test/compress/issue-597.js
+++ b/test/compress/issue-597.js
@@ -1,0 +1,25 @@
+NaN_and_Infinity_must_have_parens: {
+    options = {};
+    input: {
+        Infinity.toString();
+        NaN.toString();
+    }
+    expect: {
+        (1/0).toString();
+        (0/0).toString();
+    }
+}
+
+NaN_and_Infinity_should_not_be_replaced_when_they_are_redefined: {
+    options = {};
+    input: {
+        var Infinity, NaN;
+        Infinity.toString();
+        NaN.toString();
+    }
+    expect: {
+        var Infinity, NaN;
+        Infinity.toString();
+        NaN.toString();
+    }
+}


### PR DESCRIPTION
NaN and Infinity were replaced in the output generation, instead of
during compression. This could lead to results where `1/0` was inserted
without parens leading to invalid output.

The nodes are replaced in the compression step now, and the output
generation returns their regular names. This should not be a problem,
since they're already only constructed from the original name.
