### PR TITLE
Use yargs instead of optimist.

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -5,12 +5,12 @@
 
 var UglifyJS = require("../tools/node");
 var sys = require("util");
-var optimist = require("optimist");
+var yargs = require("yargs");
 var fs = require("fs");
 var path = require("path");
 var async = require("async");
 var acorn;
-var ARGS = optimist
+var ARGS = yargs
     .usage("$0 input1.js [input2.js ...] [options]\n\
 Use a single dash to read input from the standard input.\
 \n\n\
@@ -129,7 +129,7 @@ if (ARGS.ast_help) {
 }
 
 if (ARGS.h || ARGS.help) {
-    sys.puts(optimist.help());
+    sys.puts(yargs.help());
     process.exit(0);
 }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "async"      : "~0.2.6",
         "source-map" : "0.1.34",
-        "optimist": "~0.3.5",
+        "yargs": "~1.3.3",
         "uglify-to-browserify": "~1.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
[`optimist`](https://github.com/substack/node-optimist) has been deprecated. [`yargs`](https://github.com/chevex/yargs), which started as a fork of `optimist`, is now the official successor.