### PR TITLE
Add an option to the compressor to retain function expression names

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -62,6 +62,7 @@ function Compressor(options, false_by_default) {
         unused        : !false_by_default,
         hoist_funs    : !false_by_default,
         keep_fargs    : false,
+        keep_fnames   : false,
         hoist_vars    : false,
         if_return     : !false_by_default,
         join_vars     : !false_by_default,
@@ -1666,7 +1667,7 @@ merge(Compressor.prototype, {
 
     OPT(AST_Function, function(self, compressor){
         self = AST_Lambda.prototype.optimize.call(self, compressor);
-        if (compressor.option("unused")) {
+        if (compressor.option("unused") && !compressor.option("keep_fnames")) {
             if (self.name && self.name.unreferenced()) {
                 self.name = null;
             }

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -163,3 +163,17 @@ used_var_in_catch: {
         }
     }
 }
+
+keep_fnames: {
+    options = { unused: true, keep_fnames: true };
+    input: {
+        function foo() {
+            return function bar(baz) {};
+        }
+    }
+    expect: {
+        function foo() {
+            return function bar() {};
+        }
+    }
+}


### PR DESCRIPTION
See #552. This is useful for stack traces.