### PR TITLE
Add an option to prevent function names from being mangled

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -57,9 +57,14 @@ function SymbolDef(scope, index, orig) {
 
 SymbolDef.prototype = {
     unmangleable: function(options) {
-        return (this.global && !(options && options.toplevel))
+        if (!options) options = {};
+
+        return (this.global && !options.toplevel)
             || this.undeclared
-            || (!(options && options.eval) && (this.scope.uses_eval || this.scope.uses_with));
+            || (!options.eval && (this.scope.uses_eval || this.scope.uses_with))
+            || (options.keep_fnames
+                && (this.orig[0] instanceof AST_SymbolLambda
+                    || this.orig[0] instanceof AST_SymbolDefun));
     },
     mangle: function(options) {
         if (!this.mangled_name && !this.unmangleable(options)) {
@@ -322,11 +327,12 @@ AST_Symbol.DEFMETHOD("global", function(){
 
 AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options){
     return defaults(options, {
-        except   : [],
-        eval     : false,
-        sort     : false,
-        toplevel : false,
-        screw_ie8 : false
+        except      : [],
+        eval        : false,
+        sort        : false,
+        toplevel    : false,
+        screw_ie8   : false,
+        keep_fnames : false
     });
 });
 


### PR DESCRIPTION
See #552. This is mostly useful for having the actual function names in traces.