### PR TITLE
Replace the correct node when replacing in `void` sequences

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1937,7 +1937,7 @@ merge(Compressor.prototype, {
         if (self.cdr instanceof AST_UnaryPrefix
             && self.cdr.operator == "void"
             && !self.cdr.expression.has_side_effects(compressor)) {
-            self.cdr.operator = self.car;
+            self.cdr.expression = self.car;
             return self.cdr;
         }
         if (self.cdr instanceof AST_Undefined) {

--- a/test/compress/issue-611.js
+++ b/test/compress/issue-611.js
@@ -1,0 +1,21 @@
+issue_611: {
+  options = {
+    sequences: true,
+    side_effects: true
+  };
+  input: {
+    define(function() {
+      function fn() {}
+      if (fn()) {
+        fn();
+        return void 0;
+      }
+    });
+  }
+  expect: {
+    define(function() {
+      function fn(){}
+      if (fn()) return void fn();
+    });
+  }
+}


### PR DESCRIPTION
Close #611.