### PR TITLE
Harmony destructuring args

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -358,12 +358,72 @@ var AST_Toplevel = DEFNODE("Toplevel", "globals", {
     }
 }, AST_Scope);
 
+var AST_ArrowParametersOrSeq = DEFNODE("ArrowParametersOrSeq", "expressions", {
+    $documentation: "A set of arrow function parameters or a sequence expression. This is used because when the parser sees a \"(\" it could be the start of a seq, or the start of a parameter list of an arrow function.",
+    $propdoc: {
+        expressions: "[AST_Expression|AST_Destructuring*] array of expressions or argument names or destructurings."
+    },
+    as_params: function (croak) {
+        // We don't want anything which doesn't belong in a destructuring
+        var root = this;
+        return this.expressions.map(function to_fun_args(ex) {
+            if (ex instanceof AST_Object) {
+                if (ex.properties.length == 0)
+                    croak("Invalid destructuring function parameter", ex.start.line, ex.start.col);
+                return new AST_Destructuring({
+                    start: ex.start,
+                    end: ex.end,
+                    is_array: false,
+                    names: ex.properties.map(to_fun_args)
+                });
+            } else if (ex instanceof AST_ObjectSymbol) {
+                return new AST_SymbolFunarg({
+                    name: ex.symbol.name,
+                    start: ex.start,
+                    end: ex.end
+                });
+            } else if (ex instanceof AST_SymbolRef) {
+                return new AST_SymbolFunarg({
+                    name: ex.name,
+                    start: ex.start,
+                    end: ex.end
+                });
+            } else if (ex instanceof AST_Array) {
+                if (ex.elements.length === 0)
+                    croak("Invalid destructuring function parameter", ex.start.line, ex.start.col);
+                return new AST_Destructuring({
+                    start: ex.start,
+                    end: ex.end,
+                    is_array: true,
+                    names: ex.elements.map(to_fun_args)
+                });
+            } else {
+                console.log(ex.__proto__.TYPE)
+                croak("Invalid function parameter", ex.start.line, ex.start.col);
+            }
+        });
+    },
+    as_expr: function (croak) {
+        return AST_Seq.from_array(this.expressions);
+    }
+});
+
 var AST_Lambda = DEFNODE("Lambda", "name argnames uses_arguments", {
     $documentation: "Base class for functions",
     $propdoc: {
         name: "[AST_SymbolDeclaration?] the name of this function",
-        argnames: "[AST_SymbolFunarg*] array of function arguments",
+        argnames: "[AST_SymbolFunarg|AST_Destructuring*] array of function arguments or destructurings",
         uses_arguments: "[boolean/S] tells whether this function accesses the arguments array"
+    },
+    args_as_names: function () {
+        var out = [];
+        this.walk(new TreeWalker(function (parm) {
+            var that = this;
+            if (parm instanceof AST_SymbolFunarg) {
+                out.push(parm);
+            }
+        }));
+        return out;
     },
     _walk: function(visitor) {
         return visitor._visit(this, function(){
@@ -384,9 +444,25 @@ var AST_Function = DEFNODE("Function", null, {
     $documentation: "A function expression"
 }, AST_Lambda);
 
+var AST_Arrow = DEFNODE("Arrow", null, {
+    $documentation: "An ES6 Arrow function ((a) => b)"
+}, AST_Lambda);
+
 var AST_Defun = DEFNODE("Defun", null, {
     $documentation: "A function definition"
 }, AST_Lambda);
+
+/* -----[ DESTRUCTURING ]----- */
+var AST_Destructuring = DEFNODE("Destructuring", "names is_array", {
+    $documentation: "A destructuring of several names. Used in destructuring assignment and with destructuring function argument names",
+    _walk: function(visitor) {
+        return visitor._visit(this, function(){
+            this.names.forEach(function(name){
+                name._walk(visitor);
+            });
+        });
+    }
+});
 
 /* -----[ JUMPS ]----- */
 
@@ -768,6 +844,18 @@ var AST_ObjectProperty = DEFNODE("ObjectProperty", "key value", {
 
 var AST_ObjectKeyVal = DEFNODE("ObjectKeyVal", null, {
     $documentation: "A key: value object property",
+}, AST_ObjectProperty);
+
+var AST_ObjectSymbol = DEFNODE("ObjectSymbol", "symbol", {
+    $propdoc: {
+        symbol: "[AST_SymbolRef] what symbol it is"
+    },
+    $documentation: "A symbol in an object",
+    _walk: function (visitor) {
+        return visitor._visit(this, function(){
+            this.symbol._walk(visitor);
+        });
+    }
 }, AST_ObjectProperty);
 
 var AST_ObjectSetter = DEFNODE("ObjectSetter", null, {

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -398,7 +398,6 @@ var AST_ArrowParametersOrSeq = DEFNODE("ArrowParametersOrSeq", "expressions", {
                     names: ex.elements.map(to_fun_args)
                 });
             } else {
-                console.log(ex.__proto__.TYPE)
                 croak("Invalid function parameter", ex.start.line, ex.start.col);
             }
         });

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1279,7 +1279,6 @@ merge(Compressor.prototype, {
                 // collect only vars which don't show up in self's arguments list
                 var defs = [];
                 vars.each(function(def, name){
-                    // TODO test this too
                     if (self instanceof AST_Lambda
                         && find_if(function(x){ return x.name == def.name.name },
                                    self.args_as_names())) {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -231,6 +231,7 @@ merge(Compressor.prototype, {
             }
             function make_arguments_names_list(func) {
                 return func.argnames.map(function(sym){
+                    // TODO not sure what to do here with destructuring
                     return make_node(AST_String, sym, { value: sym.name });
                 });
             }
@@ -1088,17 +1089,26 @@ merge(Compressor.prototype, {
                     if (node instanceof AST_Lambda && !(node instanceof AST_Accessor)) {
                         if (!compressor.option("keep_fargs")) {
                             for (var a = node.argnames, i = a.length; --i >= 0;) {
-                                var sym = a[i];
-                                if (sym.unreferenced()) {
-                                    a.pop();
-                                    compressor.warn("Dropping unused function argument {name} [{file}:{line},{col}]", {
-                                        name : sym.name,
-                                        file : sym.start.file,
-                                        line : sym.start.line,
-                                        col  : sym.start.col
-                                    });
+                                if (a[i] instanceof AST_Destructuring) {
+                                    // Do not drop destructuring arguments.
+                                    // They constitute a type assertion, so dropping
+                                    // them would stop that TypeError which would happen
+                                    // if someone called it with an incorrectly formatted
+                                    // parameter.
+                                    break;
+                                } else {
+                                    var sym = a[i];
+                                    if (sym.unreferenced()) {
+                                        a.pop();
+                                        compressor.warn("Dropping unused function argument {name} [{file}:{line},{col}]", {
+                                            name : sym.name,
+                                            file : sym.start.file,
+                                            line : sym.start.line,
+                                            col  : sym.start.col
+                                        });
+                                    }
+                                    else break;
                                 }
-                                else break;
                             }
                         }
                     }
@@ -1262,9 +1272,10 @@ merge(Compressor.prototype, {
                 // collect only vars which don't show up in self's arguments list
                 var defs = [];
                 vars.each(function(def, name){
+                    // TODO test this too
                     if (self instanceof AST_Lambda
                         && find_if(function(x){ return x.name == def.name.name },
-                                   self.argnames)) {
+                                   self.args_as_names())) {
                         vars.del(name);
                     } else {
                         def = def.clone();
@@ -1784,6 +1795,7 @@ merge(Compressor.prototype, {
                                 if (ex !== ast) throw ex;
                             };
                             if (!fun) return self;
+                            // TODO does this work with destructuring? Test it.
                             var args = fun.argnames.map(function(arg, i){
                                 return make_node(AST_String, self.args[i], {
                                     value: arg.print_to_string()

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -230,9 +230,16 @@ merge(Compressor.prototype, {
                 return /@ngInject/.test(comment.value);
             }
             function make_arguments_names_list(func) {
+                var foundDestructuring = false;
                 return func.argnames.map(function(sym){
-                    // TODO not sure what to do here with destructuring
+                    if (sym instanceof AST_Destructuring) {
+                        compressor.warn("Function with destructuring arguments marked with @ngInject [{file}:{line},{col}]", token);
+                        foundDestructuring = true;
+                    }
+                    if (foundDestructuring) { return null; }
                     return make_node(AST_String, sym, { value: sym.name });
+                }).filter(function (name) {
+                    return name !== null;
                 });
             }
             function make_array(orig, elements) {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1801,7 +1801,6 @@ merge(Compressor.prototype, {
                                 if (ex !== ast) throw ex;
                             };
                             if (!fun) return self;
-                            // TODO does this work with destructuring? Test it.
                             var args = fun.argnames.map(function(arg, i){
                                 return make_node(AST_String, self.args[i], {
                                     value: arg.print_to_string()

--- a/lib/output.js
+++ b/lib/output.js
@@ -575,6 +575,17 @@ function OutputStream(options) {
         output.print_string(self.value);
         output.semicolon();
     });
+
+    DEFPRINT(AST_Destructuring, function (self, output) {
+        output.print(self.is_array ? "[" : "{");
+        var first = true;
+        self.names.forEach(function (name) {
+            if (first) first = false; else { output.comma(); output.space(); }
+            name.print(output);
+        })
+        output.print(self.is_array ? "]" : "}");
+    })
+
     DEFPRINT(AST_Debugger, function(self, output){
         output.print("debugger");
         output.semicolon();

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -629,6 +629,7 @@ function parse($TEXT, options) {
         prev          : null,
         peeked        : null,
         in_function   : 0,
+        in_parameters : false,
         in_directives : true,
         in_loop       : 0,
         labels        : []
@@ -936,34 +937,57 @@ function parse($TEXT, options) {
     };
 
     var function_ = function(ctor) {
+        var start = S.token
+
         var in_statement = ctor === AST_Defun;
         var name = is("name") ? as_symbol(in_statement ? AST_SymbolDefun : AST_SymbolLambda) : null;
         if (in_statement && !name)
             unexpected();
-        expect("(");
+
+        var args = params_or_seq_().as_params(croak);
+        var body = _function_body();
         return new ctor({
-            name: name,
-            argnames: (function(first, a){
-                while (!is("punc", ")")) {
-                    if (first) first = false; else expect(",");
-                    a.push(as_symbol(AST_SymbolFunarg));
-                }
-                next();
-                return a;
-            })(true, []),
-            body: (function(loop, labels){
-                ++S.in_function;
-                S.in_directives = true;
-                S.in_loop = 0;
-                S.labels = [];
-                var a = block_();
-                --S.in_function;
-                S.in_loop = loop;
-                S.labels = labels;
-                return a;
-            })(S.in_loop, S.labels)
+            start : args.start,
+            end   : body.end,
+            name  : name,
+            argnames: args,
+            body  : body
         });
     };
+
+    function params_or_seq_() {
+        var start = S.token
+        expect("(");
+        var first = true;
+        var a = [];
+        S.in_parameters = true;
+        while (!is("punc", ")")) {
+            if (first) first = false; else expect(",");
+            a.push(expression(false));
+        }
+        S.in_parameters = false;
+        var end = S.token
+        next();
+        return new AST_ArrowParametersOrSeq({
+            start: start,
+            end: end,
+            expressions: a
+        });
+    }
+
+    function _function_body() {
+        var loop = S.in_loop;
+        var labels = S.labels;
+        ++S.in_function;
+        S.in_directives = true;
+        S.in_loop = 0;
+        S.labels = [];
+        var a = block_();
+        --S.in_function;
+        S.in_loop = loop;
+        S.labels = labels;
+        return a;
+    }
 
     function if_() {
         var cond = parenthesised(), body = statement(), belse = null;
@@ -1198,6 +1222,7 @@ function parse($TEXT, options) {
     });
 
     var object_ = embed_tokens(function() {
+        var start = S.token;
         expect("{");
         var first = true, a = [];
         while (!is("punc", "}")) {
@@ -1228,13 +1253,32 @@ function parse($TEXT, options) {
                     continue;
                 }
             }
-            expect(":");
-            a.push(new AST_ObjectKeyVal({
-                start : start,
-                key   : name,
-                value : expression(false),
-                end   : prev()
-            }));
+            if (!is("punc", ":")) {
+                // It's one of those object destructurings, the value is its own name
+                if (!S.in_parameters) {
+                    croak("Invalid syntax", S.token.line, S.token.col);
+                }
+                a.push(new AST_ObjectSymbol({
+                    start: start,
+                    end: start,
+                    symbol: new AST_SymbolRef({
+                        start: start,
+                        end: start,
+                        name: name
+                    })
+                }));
+            } else {
+                if (S.in_parameters) {
+                    croak("Cannot destructure", S.token.line, S.token.col);
+                }
+                expect(":");
+                a.push(new AST_ObjectKeyVal({
+                    start : start,
+                    key   : name,
+                    value : expression(false),
+                    end   : prev()
+                }));
+            }
         }
         next();
         return new AST_Object({ properties: a });

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -50,6 +50,7 @@ function SymbolDef(scope, index, orig) {
     this.references = [];
     this.global = false;
     this.mangled_name = null;
+    this.object_destructuring_arg = false;
     this.undeclared = false;
     this.constant = false;
     this.index = index;
@@ -60,6 +61,7 @@ SymbolDef.prototype = {
         if (!options) options = {};
 
         return (this.global && !options.toplevel)
+            || this.object_destructuring_arg
             || this.undeclared
             || (!options.eval && (this.scope.uses_eval || this.scope.uses_with))
             || (options.keep_fnames
@@ -86,6 +88,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
     var scope = self.parent_scope = null;
     var defun = null;
     var nesting = 0;
+    var object_destructuring_arg = false;
     var tw = new TreeWalker(function(node, descend){
         if (options.screw_ie8 && node instanceof AST_Catch) {
             var save_scope = scope;
@@ -94,6 +97,12 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
             scope.parent_scope = save_scope;
             descend();
             scope = save_scope;
+            return true;
+        }
+        if (node instanceof AST_Destructuring && node.is_array === false) {
+            object_destructuring_arg = true;  // These don't nest
+            descend();
+            object_destructuring_arg = false;
             return true;
         }
         if (node instanceof AST_Scope) {
@@ -118,6 +127,10 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
         }
         if (node instanceof AST_Symbol) {
             node.scope = scope;
+        }
+        if (node instanceof AST_SymbolFunarg) {
+            node.object_destructuring_arg = object_destructuring_arg;
+            defun.def_variable(node);
         }
         if (node instanceof AST_SymbolLambda) {
             defun.def_function(node);
@@ -238,6 +251,7 @@ AST_Scope.DEFMETHOD("def_variable", function(symbol){
     if (!this.variables.has(symbol.name)) {
         def = new SymbolDef(this, this.variables.size(), symbol);
         this.variables.set(symbol.name, def);
+        def.object_destructuring_arg = symbol.object_destructuring_arg;
         def.global = !this.parent_scope;
     } else {
         def = this.variables.get(symbol.name);

--- a/test/compress/hoist.js
+++ b/test/compress/hoist.js
@@ -1,0 +1,67 @@
+
+hoist_vars: {
+    options = {
+        hoist_vars: true
+    }
+    input: {
+        function a() {
+            bar();
+            var var1;
+            var var2;
+        }
+        function b(anArg) {
+            bar();
+            var var1;
+            var anArg;
+        }
+    }
+    expect: {
+        function a() {
+            var var1, var2;  // Vars go up and are joined
+            bar();
+        }
+        function b(anArg) {
+            var var1;
+            bar();
+            // But vars named like arguments go away!
+        }
+    }
+}
+
+hoist_funs: {
+    options = {
+        hoist_funs: true
+    }
+    input: {
+        function a() {
+            bar();
+            function foo() {}
+        }
+    }
+    expect: {
+        function a() {
+            function foo() {}  // Funs go up
+            bar();
+        }
+    }
+}
+
+hoist_no_destructurings: {
+    options = {
+        hoist_vars: true,
+        hoist_funs: true
+    }
+    input: {
+        function a([anArg]) {
+            bar();
+            var var1;
+            var anArg;  // Because anArg is already declared, this goes away!
+        }
+    }
+    expect: {
+        function a([anArg]) {
+            var var1;
+            bar();
+        }
+    }
+}

--- a/test/compress/issue-203.js
+++ b/test/compress/issue-203.js
@@ -1,0 +1,30 @@
+
+compress_new_function: {
+    options = {
+        unsafe: true
+    }
+    input: {
+        new Function("aa, bb", 'return aa;');
+    }
+    expect: {
+        Function("a", "b", "return a");
+    }
+}
+
+compress_new_function_with_destruct: {
+    options = {
+        unsafe: true
+    }
+    input: {
+        new Function("aa, [bb]", 'return aa;');
+        new Function("aa, {bb}", 'return aa;');
+        new Function("[[aa]], [{bb}]", 'return aa;');
+    }
+    expect: {
+        Function("a", "[b]", "return a");
+        Function("a", "{bb}", "return a");
+        Function("[[a]]", "[{bb}]", 'return a');
+    }
+}
+
+

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,0 +1,103 @@
+
+var UglifyJS = require("..");
+var ok = require('assert');
+
+module.exports = function () {
+    console.log("--- Parser tests");
+
+    // Destructuring arguments
+
+    // Function argument nodes are correct
+    function get_args(args) {
+        return args.map(function (arg) {
+            return [arg.TYPE, arg.name];
+        });
+    }
+
+    // Destructurings as arguments
+    var destr_fun1 = UglifyJS.parse('(function ({a, b}) {})').body[0].body;
+    var destr_fun2 = UglifyJS.parse('(function ([a, [b]]) {})').body[0].body;
+    
+    ok.equal(destr_fun1.argnames.length, 1);
+    ok.equal(destr_fun2.argnames.length, 1);
+
+    var destruct1 = destr_fun1.argnames[0];
+    var destruct2 = destr_fun2.argnames[0];
+
+    ok(destruct1 instanceof UglifyJS.AST_Destructuring);
+    ok(destruct2 instanceof UglifyJS.AST_Destructuring);
+    ok(destruct2.names[1] instanceof UglifyJS.AST_Destructuring);
+
+    ok.equal(destruct1.start.value, '{');
+    ok.equal(destruct1.end.value, '}');
+    ok.equal(destruct2.start.value, '[');
+    ok.equal(destruct2.end.value, ']');
+
+    ok.equal(destruct1.is_array, false);
+    ok.equal(destruct2.is_array, true);
+
+    var aAndB = [
+        ['SymbolFunarg', 'a'],
+        ['SymbolFunarg', 'b']
+    ];
+
+    ok.deepEqual(
+        [
+            destruct1.names[0].TYPE,
+            destruct1.names[0].name],
+        aAndB[0]);
+
+    ok.deepEqual(
+        [
+            destruct2.names[1].names[0].TYPE,
+            destruct2.names[1].names[0].name
+        ],
+        aAndB[1]);
+
+    ok.deepEqual(
+        get_args(destr_fun1.args_as_names()),
+        aAndB)
+    ok.deepEqual(
+        get_args(destr_fun2.args_as_names()),
+        aAndB)
+
+    // Making sure we don't accidentally accept things which
+    // Aren't argument destructurings
+
+    ok.throws(function () {
+        UglifyJS.parse('(function ([]) {})');
+    }, /Invalid destructuring function parameter/);
+
+    ok.throws(function () {
+        UglifyJS.parse('(function ( { a, [ b ] } ) { })')
+    });
+
+    ok.throws(function () {
+        UglifyJS.parse('(function (1) { })');
+    }, /Invalid function parameter/);
+
+    ok.throws(function () {
+        UglifyJS.parse('(function (this) { })');
+    });
+
+    ok.throws(function () {
+        UglifyJS.parse('(function ([1]) { })');
+    }, /Invalid function parameter/);
+
+    ok.throws(function () {
+        UglifyJS.parse('(function [a] { })');
+    });
+
+    ok.throws(function () {
+        // Note: this *is* a valid destructuring, but before we implement
+        // destructuring (right now it's only destructuring *arguments*),
+        // this won't do.
+        UglifyJS.parse('[{a}]');
+    });
+}
+
+// Run standalone
+if (module.parent === null) {
+    module.exports();
+}
+

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -23,6 +23,10 @@ run_ast_conversion_tests({
     iterations: 1000
 });
 
+var run_parser_tests = require('./parser.js');
+
+run_parser_tests();
+
 /* -----[ utils ]----- */
 
 function tmpl() {


### PR DESCRIPTION
This branch adds support to ES6 destructuring arguments.

This is accomplished by parsing arguments in functions as though they were expressions (which parses parameters as SymbolRefs and destructuring arrays as plain arrays with SymbolRefs inside), and only then verifying that they are valid destructuring arguments, and by adding support to shorthand object key-value pairs (the syntatic sugar where `{a}` is interpreted as `{"a": a}`) to cover object destructuring.

I am aware that this could be done by adding a few AST nodes for representing array destructuring (`function ([err, returnCode]) {}`) and object destructuring (`function ({ option1, option2 }) {}`) and adding them to the arguments list. This approach already paves the way a bit for arrow functions, in that when the parser sees an open paren (`(`) it could be the start of an arrow function or a plain old parenthesized expression and that is represented in ES6 as the expression "CoverParenthesizedExpressionAndArrowParameterList". I absolutely love the huge name. That expression is AST_ArrowParametersOrSeq in my set of patches.

The AST_ArrowParametersOrSeq construct is meant to never leave parser.js. It's like shrodinger's cat. It could be a dead parenthesized expression or a living set of arrow function parameters. That's why it has the as_params and as_expr methods. `as_params` is already being used to massage arrays and shorthand object key-value pairs into function parameters, like it will arrow function parameters.

To support the shorthand object key-value pair construct and the object destructuring argument at the same time, a new AST_ObjectProperty subclass was added. It doesn't have a key/value pair, just a symbol whose name doubles as the object key.

There was also some work in modifying the AST_Lambda construct, which gets the `args_as_names` method (I'm unsure whether this name makes any sense to other human beings) which is used to find argument names (AST_SymbolFunarg instances, as massaged by AST_ArrowParametersOrSeq) and return them. It is used in some places instead of the `argnames` array, because `argnames` doesn't just have names anymore, it could have AST_Destructuring's.

AST_Destructuring function arguments cannot be dropped when unused because they constitute a type assertion, so unused argument removal code was modified.

This is a lot to take in, but I think it's the smallest set of changes I could do to make this feature happen (with the exception of AST_ArrowParametersOrSeq, but I'd rather add that too early than build code to parse object and array destructurings, just to later take it down).