### PR TITLE
fixes issue #621 SourceMap toString JSON format

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -87,6 +87,6 @@ function SourceMap(options) {
     return {
         add        : add,
         get        : function() { return generator },
-        toString   : function() { return generator.toString() }
+        toString   : function() { return JSON.stringify(generator.toJSON()); }
     };
 };


### PR DESCRIPTION
The correct format of a sourcemap is acquired
from a mozilla source map generator by calling
toJSON on this object. This patch alters the
toString function on mozilla generators to print
the format that is to spec instead of the generator's
internal representation of itself.