### PR TITLE
Update async package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "url": "https://github.com/mishoo/UglifyJS2.git"
     },
     "dependencies": {
-        "async"      : "~0.2.6",
+        "async"      : "~0.9.0",
         "source-map" : "0.1.34",
         "yargs": "~1.3.3",
         "uglify-to-browserify": "~1.0.0"


### PR DESCRIPTION
The package is quite outdated, I think there is no non-BC change for upgrading the async package

https://github.com/mishoo/UglifyJS2/blob/master/bin/uglifyjs#L261, although the function doesn't change in the ``aysnc`` package, this can prevent the user application download multiple ``async`` package


also, wondering the reason to lock ``source-map``?