### PR TITLE
Drop all `console` statements properly

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1873,11 +1873,16 @@ merge(Compressor.prototype, {
             }
         }
         if (compressor.option("drop_console")) {
-            if (self.expression instanceof AST_PropAccess &&
-                self.expression.expression instanceof AST_SymbolRef &&
-                self.expression.expression.name == "console" &&
-                self.expression.expression.undeclared()) {
-                return make_node(AST_Undefined, self).transform(compressor);
+            if (self.expression instanceof AST_PropAccess) {
+                var name = self.expression.expression;
+                while (name.expression) {
+                    name = name.expression;
+                }
+                if (name instanceof AST_SymbolRef
+                    && name.name == "console"
+                    && name.undeclared()) {
+                    return make_node(AST_Undefined, self).transform(compressor);
+                }
             }
         }
         return self.evaluate(compressor)[0];

--- a/test/compress/drop-console.js
+++ b/test/compress/drop-console.js
@@ -1,0 +1,24 @@
+drop_console_1: {
+    options = {};
+    input: {
+        console.log('foo');
+        console.log.apply(console, arguments);
+    }
+    expect: {
+        console.log('foo');
+        console.log.apply(console, arguments);
+    }
+}
+
+drop_console_1: {
+    options = { drop_console: true };
+    input: {
+        console.log('foo');
+        console.log.apply(console, arguments);
+    }
+    expect: {
+        // with regular compression these will be stripped out as well
+        void 0;
+        void 0;
+    }
+}


### PR DESCRIPTION
Because the base reference can be an member expression as well, we have to dig a bit deeper to find the leftmost base reference.

Fixes #451