### PR TITLE
add tow properties to AST_node that i think useful...

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -58,6 +58,8 @@ TreeTransformer.prototype = new TreeWalker;
         node.DEFMETHOD("transform", function(tw, in_list){
             var x, y;
             tw.push(this);
+            this.walker = new TreeWalker;
+            this.walker.stack = tw.stack.concat();
             if (tw.before) x = tw.before(this, descend, in_list);
             if (x === undefined) {
                 if (!tw.after) {
@@ -75,8 +77,10 @@ TreeTransformer.prototype = new TreeWalker;
         });
     };
 
-    function do_list(list, tw) {
-        return MAP(list, function(node){
+    function do_list(list, tw)
+    {
+        return MAP(list, function(node , i){
+            node._position = i;
             return node.transform(tw, true);
         });
     };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -77,8 +77,7 @@ TreeTransformer.prototype = new TreeWalker;
         });
     };
 
-    function do_list(list, tw)
-    {
+    function do_list(list, tw){
         return MAP(list, function(node , i){
             node._position = i;
             return node.transform(tw, true);


### PR DESCRIPTION

I was making a obfuscating js tool width uglify , i think uglify is  awesome！I need some method in my work.

**case1-find the walker:**
* when we use transformer,treeWalker is very helpful in before/after method ,such as tw.find_parent() tw.stack... , but we can't get tw in before's arguments.
* sometimes i used tree-walk to collect node ,but when i want to do something with this node, i can't get this treeWalker...,such as :

<pre>
var cacheNode = [];
/*i need collect all node first*/
var tw = new new UglifyJS.TreeTransformer(function(node,descend){
   if (xxx) {
       cacheNode.push(node);
   }
});
/*to find cacheNode[i]'s parent*/
var node = cacheNode[0];
console.log("i want find cacheNode[i]'s parent and i don't want to do a new walk because it's unnecessary...i can't do it...");
</pre>
* what i want is:
<pre>
/*to find cacheNode[i]'s parent*/
var node = cacheNode[0];
var tw = node.walker;
console.log("i can get walker by node ^ ^");
</pre>

**case2-find node's position in body:**
* sometimes i want know replace one statement with many statement, i just want to know the position of this statement in its parent's body.
<pre>
/*souece code:
function test(){
	 var a = 1;
  	 var b = 2;
}
*/
var tw = new new UglifyJS.TreeTransformer(function(node,descend){
  if (nodeA) {
	console.log("do u know the position in parent'body?")
  }
});
</pre> 

* i want this:
<pre>
var tw = new new UglifyJS.TreeTransformer(function(node,descend){
  if (nodeA) {
	console.log("I know you are the"+ nodeA._position + "statement!");
  }
});
</pre>