### PR TITLE
Add `sourceMapURL` option to node tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,15 @@ console.log(result.map);
 
 Note that the source map is not saved in a file, it's just returned in
 `result.map`.  The value passed for `outSourceMap` is only used to set the
-`file` attribute in the source map (see [the spec][sm-spec]).
+`file` attribute in the source map (see [the spec][sm-spec]). The value set
+in the `//# sourceMappingURL` comment defaults to `outSourceMap`, but this
+can be overridden by setting the `sourceMapURL` parameter:
+```javascript
+var result = UglifyJS.minify([ "file1.js", "file2.js", "file3.js" ], {
+	outSourceMap: "out.js.map",
+	sourceMapURL: "sourcemaps/out.js.map",
+});
+```
 
 You can also specify sourceRoot property to be included in source map:
 ```javascript

--- a/tools/node.js
+++ b/tools/node.js
@@ -57,6 +57,7 @@ exports.minify = function(files, options) {
         outSourceMap : null,
         sourceRoot   : null,
         inSourceMap  : null,
+        sourceMapURL : null,
         fromString   : false,
         warnings     : false,
         mangle       : {},
@@ -130,7 +131,7 @@ exports.minify = function(files, options) {
     toplevel.print(stream);
 
     if(options.outSourceMap){
-        stream += "\n//# sourceMappingURL=" + options.outSourceMap;
+        stream += "\n//# sourceMappingURL=" + (options.sourceMapURL || options.outSourceMap);
     }
 
     var source_map = output.source_map;


### PR DESCRIPTION
Currently, the cli allows a client to
override the assignment of the `sourceMappingURL`
comment from the value passed via `source-map` to the
value passed via `source-map-url`. This is necessary
because the `file` property of a sourcemap, which
according to the spec should specify the minified
source filename, should not be the same as the URL
at which to find the sourcemap for this file.

In practice, the `file` property is not often used,
so the two can often be assigned to the same thing,
but there is a need in some cases to assign these
different.

This change updates the node tool api to reflect
the cli in this respect, introducing an option
`sourceMapURL` that will override the assignment
of `outSourceMap` to the value in the `sourceMappingURL`
comment.