### PR TITLE
Document passing source maps directly to minify() using inSourceMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,16 @@ var result = UglifyJS.minify("compiled.js", {
 // same as before, it returns `code` and `map`
 ```
 
+If your input source map is not in a file, you can pass it in as an object
+using the `inSourceMap` argument:
+
+```javascript
+var result = UglifyJS.minify("compiled.js", {
+	inSourceMap: JSON.parse(my_source_map_string),
+	outSourceMap: "minified.js.map"
+});
+```
+
 The `inSourceMap` is only used if you also request `outSourceMap` (it makes
 no sense otherwise).
 


### PR DESCRIPTION
This is instead of  pull request #486. It was not clear at all that I could pass in an object to `inSourceMap`, even after reading the uglify code.