### PR TITLE
Test on latest `node` and `io.js`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,23 @@
 language: node_js
 before_install: "npm install -g npm"
 node_js:
-    - "0.10"
+    - "iojs-v1.6"
+    - "iojs-v1.5"
+    - "iojs-v1.4"
+    - "iojs-v1.3"
+    - "iojs-v1.2"
+    - "iojs-v1.1"
+    - "iojs-v1.0"
+    - "0.12"
     - "0.11"
+    - "0.10"
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: "iojs-v1.4"
+    - node_js: "iojs-v1.3"
+    - node_js: "iojs-v1.2"
+    - node_js: "iojs-v1.1"
+    - node_js: "iojs-v1.0"
+    - node_js: "0.11"
+sudo: false


### PR DESCRIPTION
Per https://github.com/mishoo/UglifyJS2/commit/0262b4244c13b3ef148bf096874847aea84b93e5 - if you're going to stop testing on 0.8, you should be testing on 0.12.

Also allow failures on unstable nodes and "older than two latest" `io.js` versions, and enable "sudo: false" which makes tests run faster.