### PR TITLE
adding the expect_exact clause, which instead of parsing code will just ...

### DIFF
--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -168,6 +168,10 @@ function parse_test(file) {
                     else if (stat.body.length == 0) stat = new U.AST_EmptyStatement();
                 }
                 if (node.label.name === "expect_exact") {
+                    if (!(stat.TYPE === "SimpleStatement" && stat.body.TYPE === "String")) {
+                        throw new Error("The value of the expect_exact clause should be a string! " +
+                            "Like this: `expect_exact: \"some.exact.javascript;\"`");
+                    }
                     test[node.label.name] = stat.body.start.value
                 } else {
                     test[node.label.name] = stat;

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -84,7 +84,12 @@ function run_compress_tests() {
                 warnings: false
             });
             var cmp = new U.Compressor(options, true);
-            var expect = make_code(as_toplevel(test.expect), false);
+            var expect
+            if (test.expect) {
+                expect = make_code(as_toplevel(test.expect), false);
+            } else {
+                expect = test.expect_exact;
+            }
             var input = as_toplevel(test.input);
             var input_code = make_code(test.input);
             var output = input.transform(cmp);
@@ -150,7 +155,7 @@ function parse_test(file) {
             }
             if (node instanceof U.AST_LabeledStatement) {
                 assert.ok(
-                    node.label.name == "input" || node.label.name == "expect",
+                    node.label.name == "input" || node.label.name == "expect" || node.label.name == "expect_exact",
                     tmpl("Unsupported label {name} [{line},{col}]", {
                         name: node.label.name,
                         line: node.label.start.line,
@@ -162,7 +167,11 @@ function parse_test(file) {
                     if (stat.body.length == 1) stat = stat.body[0];
                     else if (stat.body.length == 0) stat = new U.AST_EmptyStatement();
                 }
-                test[node.label.name] = stat;
+                if (node.label.name === "expect_exact") {
+                    test[node.label.name] = stat.body.start.value
+                } else {
+                    test[node.label.name] = stat;
+                }
                 return true;
             }
         });


### PR DESCRIPTION
...read a string for expects, making it suitable for testing OutputStream

Attempts to provide a way to fix #337 by adding a way to test uglifyjs's output against literal strings instead of other trees.

The reasoning behind this is that the parser may have a bug that can hide the OutputStream's bug. It is also very useful to test whether parens are removed or not (and I really need this for my feature/harmony arrow functions!).