### PR TITLE
Make node.js 0.8 the minimum supported version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ before_install: "npm install -g npm"
 node_js:
     - "iojs"
     - "0.12"
-    - "0.11"
     - "0.10"
+    - "0.8"
 matrix:
   fast_finish: true
 sudo: false

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "BSD",
   "version": "2.4.21",
   "engines": {
-    "node": ">=0.4.0"
+    "node": ">=0.8.0"
   },
   "maintainers": [
     "Mihai Bazon <mihai.bazon@gmail.com> (http://lisperator.net/)"


### PR DESCRIPTION
Node.js 0.4 and 0.6 are ancient; things don't work there.
Update Travis CI configuration accordingly.

Note, that the npm update in Travis is needed for 0.8 only at the moment.

/CC @mishoo @rvanvelzen: if you are not going to test 0.8 then you should drop support for it since things can break without anyone noticing.