### PR TITLE
Stringify the argument before trying to parse it.

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -476,7 +476,7 @@ function getOptions(x, constants) {
     if (x !== "") {
         var ast;
         try {
-            ast = UglifyJS.parse(x, { expression: true });
+            ast = UglifyJS.parse(x + "", { expression: true });
         } catch(ex) {
             if (ex instanceof UglifyJS.JS_Parse_Error) {
                 sys.error("Error parsing arguments in: " + x);


### PR DESCRIPTION
If the argument is not a string (e.g. an object created by multiple --define flags), the parser attempts to call .input() on it, which fails.