### PR TITLE
Added support for multiple input source maps to SourceMap object.

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -303,7 +303,7 @@ function OutputStream(options) {
     var add_mapping = options.source_map ? function(token, name) {
         try {
             if (token) options.source_map.add(
-                token.file || "?",
+                token.file,
                 current_line, current_col,
                 token.line, token.col,
                 (!name && token.type == "name") ? token.value : name

--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -69,7 +69,14 @@ function SourceMap(options) {
         orig_maps[consumer.file] = consumer;
     }
     function add(source, gen_line, gen_col, orig_line, orig_col, name) {
-        var originalMap = orig_maps[source] || orig_map;
+        var originalMap;
+        if (source) {
+            originalMap = orig_maps[source] || orig_map;
+        }
+        else {
+            source = "?";
+            originalMap = orig_map;
+        }
 
         if (originalMap) {
             var info = originalMap.originalPositionFor({

--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -53,19 +53,26 @@ function SourceMap(options) {
         orig_line_diff : 0,
         dest_line_diff : 0,
     });
+    var orig_maps = Object.create(null);
     var orig_map = options.orig && new MOZ_SourceMap.SourceMapConsumer(options.orig);
     var generator;
     if (orig_map) {
-      generator = MOZ_SourceMap.SourceMapGenerator.fromSourceMap(orig_map);
+        generator = MOZ_SourceMap.SourceMapGenerator.fromSourceMap(orig_map);
     } else {
         generator = new MOZ_SourceMap.SourceMapGenerator({
             file       : options.file,
             sourceRoot : options.root
         });
     }
+    function addInput(rawSourceMap) {
+        var consumer = new MOZ_SourceMap.SourceMapConsumer(rawSourceMap);
+        orig_maps[consumer.file] = consumer;
+    }
     function add(source, gen_line, gen_col, orig_line, orig_col, name) {
-        if (orig_map) {
-            var info = orig_map.originalPositionFor({
+        var originalMap = orig_maps[source] || orig_map;
+
+        if (originalMap) {
+            var info = originalMap.originalPositionFor({
                 line: orig_line,
                 column: orig_col
             });
@@ -77,6 +84,7 @@ function SourceMap(options) {
             orig_col = info.column;
             name = info.name || name;
         }
+
         generator.addMapping({
             generated : { line: gen_line + options.dest_line_diff, column: gen_col },
             original  : { line: orig_line + options.orig_line_diff, column: orig_col },
@@ -85,6 +93,7 @@ function SourceMap(options) {
         });
     }
     return {
+        addInput   : addInput,
         add        : add,
         get        : function() { return generator },
         toString   : function() { return JSON.stringify(generator.toJSON()); }


### PR DESCRIPTION
Something I'd written for my own library by monkey-patching UJS and thought I should contribute upstream.

This adds an `addInput(rawSourceMap)` to the object returned by UJS.SourceMap(). It now maintains a map from filename -> SourceMapConsumer and addInput populates this. It then uses this map inside `add(source, ...)` to look up the correct SourceMapConsumer for the given `source`.

It is still possible to provide the `{ orig: originalSourceMap }` to UJS.SourceMap() - this particular consumer continues to act as a default fallback when no sourcemap has been registered for a particular file.

For example, I use it to combine multiple .js files with their own individual source maps that were originally compiled from TypeScript files. So usage looks like this:

```javascript
var toplevel;
var toplevelSourceMap = UglifyJS.SourceMap();

for each .ts file {
    toplevel = UglifyJS.parse("corresponding .js file", { toplevel: toplevel });

    var sourceMap = fs.readFileSync("corresponding .js.map file");
    toplevelSourceMap.addInput(sourceMap);
}

var stream = UglifyJS.OutputStream({ source_map: toplevelSourceMap });
toplevel.print(stream);

stream.toString(); // combined .js
toplevelSourceMap.get().toString(); // combined .js.map
```

I have not exposed this via the CLI in this PR, but I guess it could be something like `--in-source-maps=<delimited paths>`