### PR TITLE
Give a good error message if an invalid regular expression is found.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -484,7 +484,7 @@ function tokenizer($TEXT, filename, html5_comments) {
         try {
           r = new RegExp(regexp, mods);
         } catch(e) {
-          parse_error("Invalid regular expression");
+          parse_error(e.message);
         }
         return token("regexp", r);
     });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -480,7 +480,13 @@ function tokenizer($TEXT, filename, html5_comments) {
             regexp += ch;
         }
         var mods = read_name();
-        return token("regexp", new RegExp(regexp, mods));
+        var r;
+        try {
+          r = new RegExp(regexp, mods);
+        } catch(e) {
+          parse_error("Invalid regular expression");
+        }
+        return token("regexp", r);
     });
 
     function read_operator(prefix) {


### PR DESCRIPTION
This patch makes UglifyJS give a decent error message with the line number if a regular expression with invalid flags is found.

```
$ echo 'var r = /foo/abc;' | ./bin/uglifyjs 
Parse error at -:1,8
Invalid regular expression
Error
    at new JS_Parse_Error (/Users/chris/Coding/UglifyJS2/lib/parse.js:196:18)
    at js_error (/Users/chris/Coding/UglifyJS2/lib/parse.js:204:11)
    at parse_error (/Users/chris/Coding/UglifyJS2/lib/parse.js:314:9)
    at /Users/chris/Coding/UglifyJS2/lib/parse.js:487:11
    at /Users/chris/Coding/UglifyJS2/lib/parse.js:538:24
    at handle_slash (/Users/chris/Coding/UglifyJS2/lib/parse.js:516:34)
    at Object.next_token [as input] (/Users/chris/Coding/UglifyJS2/lib/parse.js:567:27)
    at next (/Users/chris/Coding/UglifyJS2/lib/parse.js:672:25)
    at vardefs (/Users/chris/Coding/UglifyJS2/lib/parse.js:1093:48)
    at var_ (/Users/chris/Coding/UglifyJS2/lib/parse.js:1106:27)
```

Before UglifyJS would just give a message like "SyntaxError: Invalid flags supplied to RegExp constructor 'abc'" and a stacktrace into itself which isn't very useful.