### PR TITLE
Control keeping function arguments with a single option

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -61,7 +61,7 @@ function Compressor(options, false_by_default) {
         loops         : !false_by_default,
         unused        : !false_by_default,
         hoist_funs    : !false_by_default,
-        keep_fargs    : false,
+        keep_fargs    : true,
         keep_fnames   : false,
         hoist_vars    : false,
         if_return     : !false_by_default,
@@ -1086,7 +1086,7 @@ merge(Compressor.prototype, {
             var tt = new TreeTransformer(
                 function before(node, descend, in_list) {
                     if (node instanceof AST_Lambda && !(node instanceof AST_Accessor)) {
-                        if (compressor.option("unsafe") && !compressor.option("keep_fargs")) {
+                        if (!compressor.option("keep_fargs")) {
                             for (var a = node.argnames, i = a.length; --i >= 0;) {
                                 var sym = a[i];
                                 if (sym.unreferenced()) {

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -1,5 +1,5 @@
 unused_funarg_1: {
-    options = { unused: true, unsafe: true };
+    options = { unused: true, keep_fargs: false };
     input: {
         function f(a, b, c, d, e) {
             return a + b;
@@ -13,7 +13,7 @@ unused_funarg_1: {
 }
 
 unused_funarg_2: {
-    options = { unused: true, unsafe: true };
+    options = { unused: true, keep_fargs: false };
     input: {
         function f(a, b, c, d, e) {
             return a + c;
@@ -173,7 +173,7 @@ keep_fnames: {
     }
     expect: {
         function foo() {
-            return function bar() {};
+            return function bar(baz) {};
         }
     }
 }


### PR DESCRIPTION
Keeping unused arguments can lead to unexpected behaviour as noted in #121. However, the fix means that `keep_fargs` option can only be used with other unsafe optimisations. It might not be desirable to use unsafe flag even if one would like to remove unused function arguments (perhaps to enable the AngularJS minifier support workarounds?).

I propose that the default value of `keep_fargs` is changed to `true` and the unsafe option guard is removed.