### PR TITLE
Add --mangle-regex option

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The available options are:
   --reserve-domprops            Make (most?) DOM properties reserved for
                                 --mangle-props
   --mangle-props                Mangle property names
+  --mangle-regex                Only mangle property names matching the regex
   --name-cache                  File to hold mangled names mappings
 ```
 
@@ -250,6 +251,10 @@ arguments) — in this case it will exclude names from all those files.
 A default exclusion file is provided in `tools/domprops.json` which should
 cover most standard JS and DOM properties defined in various browsers.  Pass
 `--reserve-domprops` to read that in.
+
+You can also use a regular expression to define which property names should be
+mangled.  For example, `--mangle-regex="^_"` will only mangle property names
+that start with an underscore.
 
 When you compress multiple files using this option, in order for them to
 work together in the end we need to ensure somehow that one property gets

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ cover most standard JS and DOM properties defined in various browsers.  Pass
 `--reserve-domprops` to read that in.
 
 You can also use a regular expression to define which property names should be
-mangled.  For example, `--mangle-regex="^_"` will only mangle property names
+mangled.  For example, `--mangle-regex="/^_/"` will only mangle property names
 that start with an underscore.
 
 When you compress multiple files using this option, in order for them to

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -70,6 +70,7 @@ You need to pass an argument to this option to specify the name that your module
     .describe("reserved-file", "File containing reserved names")
     .describe("reserve-domprops", "Make (most?) DOM properties reserved for --mangle-props")
     .describe("mangle-props", "Mangle property names")
+    .describe("mangle-regex", "Only mangle property names matching the regex")
     .describe("name-cache", "File to hold mangled names mappings")
 
     .alias("p", "prefix")
@@ -375,10 +376,12 @@ async.eachLimit(files, 1, function (file, cb) {
     if (ARGS.mangle_props || ARGS.name_cache) (function(){
         var reserved = RESERVED ? RESERVED.props : null;
         var cache = readNameCache("props");
+        var regex = ARGS.mangle_regex ? new RegExp(ARGS.mangle_regex) : null;
         TOPLEVEL = UglifyJS.mangle_properties(TOPLEVEL, {
             reserved   : reserved,
             cache      : cache,
-            only_cache : !ARGS.mangle_props
+            only_cache : !ARGS.mangle_props,
+            regex      : regex
         });
         writeNameCache("props", cache);
     })();

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -192,6 +192,15 @@ function writeNameCache(key, cache) {
     return UglifyJS.writeNameCache(ARGS.name_cache, key, cache);
 }
 
+function extractRegex(str) {
+  if (/^\/.*\/[a-zA-Z]*$/.test(str)) {
+    var regex_pos = str.lastIndexOf("/");
+    return new RegExp(str.substr(1, regex_pos - 1), str.substr(regex_pos + 1));
+  } else {
+    throw new Error("Invalid regular expression: " + str);
+  }
+}
+
 if (ARGS.quotes === true) {
     ARGS.quotes = 3;
 }
@@ -218,9 +227,8 @@ if (BEAUTIFY)
 
 if (ARGS.comments != null) {
     if (/^\/.*\/[a-zA-Z]*$/.test(ARGS.comments)) {
-        var regex_pos = ARGS.comments.lastIndexOf("/");
         try {
-            OUTPUT_OPTIONS.comments = new RegExp(ARGS.comments.substr(1, regex_pos - 1), ARGS.comments.substr(regex_pos + 1));
+            OUTPUT_OPTIONS.comments = extractRegex(ARGS.comments);
         } catch (e) {
             print_error("ERROR: Invalid --comments: " + e.message);
         }
@@ -379,7 +387,7 @@ async.eachLimit(files, 1, function (file, cb) {
         var regex;
 
         try {
-          regex = ARGS.mangle_regex ? new RegExp(ARGS.mangle_regex) : null;
+          regex = ARGS.mangle_regex ? extractRegex(ARGS.mangle_regex) : null;
         } catch (e) {
             print_error("ERROR: Invalid --mangle-regex: " + e.message);
             process.exit(1);

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -376,7 +376,15 @@ async.eachLimit(files, 1, function (file, cb) {
     if (ARGS.mangle_props || ARGS.name_cache) (function(){
         var reserved = RESERVED ? RESERVED.props : null;
         var cache = readNameCache("props");
-        var regex = ARGS.mangle_regex ? new RegExp(ARGS.mangle_regex) : null;
+        var regex;
+
+        try {
+          regex = ARGS.mangle_regex ? new RegExp(ARGS.mangle_regex) : null;
+        } catch (e) {
+            print_error("ERROR: Invalid --mangle-regex: " + e.message);
+            process.exit(1);
+        }
+
         TOPLEVEL = UglifyJS.mangle_properties(TOPLEVEL, {
             reserved   : reserved,
             cache      : cache,

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -64,7 +64,8 @@ function mangle_properties(ast, options) {
     options = defaults(options, {
         reserved : null,
         cache : null,
-        only_cache : false
+        only_cache : false,
+        regex : null
     });
 
     var reserved = options.reserved;
@@ -78,6 +79,8 @@ function mangle_properties(ast, options) {
             props: new Dictionary()
         };
     }
+
+    var regex = options.regex;
 
     var names_to_mangle = [];
 
@@ -149,6 +152,7 @@ function mangle_properties(ast, options) {
     }
 
     function should_mangle(name) {
+        if (regex && !regex.test(name)) return false;
         if (reserved.indexOf(name) >= 0) return false;
         return cache.props.has(name)
             || names_to_mangle.indexOf(name) >= 0;


### PR DESCRIPTION
We've got a fairly large library where we'd like to mangle private property names. The library is large enough that using the `--reserved-file` option just isn't feasible.

Since all our private properties are prefixed with an underscore, we're proposing an additional option `--mangle-regex` where only properties matching the regular expression will be mangled. For us, it's now as simple as passing `--mangle-regex="^_"` as an option, and only properties starting with an underscore are mangled.