### PR TITLE
fromString option, use index from argument array for filename instead of "?"

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -73,13 +73,13 @@ exports.minify = function(files, options) {
     } else {
         if (typeof files == "string")
             files = [ files ];
-        files.forEach(function(file){
+        files.forEach(function(file, i){
             var code = options.fromString
                 ? file
                 : fs.readFileSync(file, "utf8");
             sourcesContent[file] = code;
             toplevel = UglifyJS.parse(code, {
-                filename: options.fromString ? "?" : file,
+                filename: options.fromString ? i : file,
                 toplevel: toplevel
             });
         });


### PR DESCRIPTION
The index allows the caller to map things like parse errors back to the code chunk where they appeared.

What I'm doing is put the call to minify() in a try/catch block; then I get a nice Error object when there is a parse error, with accurate line and column information, but no way of knowing which code chunk contains it.

I propose this as a conservative change: the API remains unchanged except that we would get a number instead of "?" which I guess few if any people rely on.

Coincidentally, when a single code chunk is given, the pseudo-filename 0 is a nice pun on stdin's file descriptor; to me calling minify with fromString feels similar to feeding a shell command from a pipe instead of giving it file names to read.