### PR TITLE
Bump source-map version to 0.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "async": "~0.2.6",
-    "source-map": "0.1.34",
+    "source-map": "~0.4.2",
     "uglify-to-browserify": "~1.0.0",
     "yargs": "~3.5.4"
   },


### PR DESCRIPTION
I'm trying to deal with some issues when trying to generate source-maps using webpack + UglifyJs. I noticed that UglifyJS is using a quite old version of `source-map` and I tried upgrading the package. 

Using this newer version of `source-map` seems to fix the issue I describe here: https://github.com/webpack/webpack/pull/1176

https://github.com/mozilla/source-map/blob/master/CHANGELOG.md