### PR TITLE
Fix issues 740 and 741 (related to `from_mozilla_ast`)

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -163,6 +163,20 @@
                             end   : my_end_token(M),
                             name  : M.name
                         });
+        },
+        ArrayExpression: function (M) {
+            var start = my_start_token(M);
+            var end = my_end_token(M);
+            return new AST_Array({
+                start: start,
+                end: end,
+                elements: M.elements.map(function (E) {
+                    return E ? from_moz(E) : new AST_Hole({
+                        start: start,
+                        end: end
+                    });
+                })
+            });
         }
     };
 
@@ -199,7 +213,6 @@
     map("CatchClause", AST_Catch, "param>argname, body%body");
 
     map("ThisExpression", AST_This);
-    map("ArrayExpression", AST_Array, "elements@elements");
     map("FunctionExpression", AST_Function, "id>name, params@argnames, body%body");
     map("BinaryExpression", AST_Binary, "operator=operator, left>left, right>right");
     map("LogicalExpression", AST_Binary, "operator=operator, left>left, right>right");
@@ -207,6 +220,13 @@
     map("ConditionalExpression", AST_Conditional, "test>condition, consequent>consequent, alternate>alternative");
     map("NewExpression", AST_New, "callee>expression, arguments@args");
     map("CallExpression", AST_Call, "callee>expression, arguments@args");
+
+    def_to_moz(AST_Array, function To_Moz_ArrayExpression(M) {
+         return {
+             type: "ArrayExpression",
+             elements: M.elements.map(to_moz)
+         }
+    });
 
     def_to_moz(AST_Directive, function To_Moz_Directive(M) {
         return {

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -110,7 +110,7 @@
         MemberExpression: function(M) {
             return new (M.computed ? AST_Sub : AST_Dot)({
                 start      : my_start_token(M),
-                end        : my_end_token(M),
+                end        : M.computed ? my_end_token(M) : my_full_token(M.property),
                 property   : M.computed ? from_moz(M.property) : M.property.name,
                 expression : from_moz(M.object)
             });
@@ -411,6 +411,22 @@
             line    : end && end.line,
             col     : end && end.column,
             pos     : range ? range[1] : moznode.end,
+            endline : end && end.line,
+            endcol  : end && end.column,
+            endpos  : range ? range[1] : moznode.end
+        });
+    };
+
+    function my_full_token(moznode) {
+        var loc = moznode.loc,
+            start = loc && loc.start,
+            end = loc && loc.end;
+        var range = moznode.range;
+        return new AST_Token({
+            file    : loc && loc.source,
+            line    : start && start.line,
+            col     : start && start.column,
+            pos     : range ? range[0] : moznode.start,
             endline : end && end.line,
             endcol  : end && end.column,
             endpos  : range ? range[1] : moznode.end


### PR DESCRIPTION
Fix issue #741 by storing `AST_Hole` objects instead of nulls when incoming Mozilla AST has nulls in the `elements` field of `ArrayExpression` object.

Also fix issue #740 by widening the `AST_Dot.end` token field to cover the whole property token, not just it's last byte. Actually, I think a similar transformation can be applied to pretty much all `start` and `end` fields, but I decided to be conservative at the moment.