### PR TITLE
Preamble new line symbol (line break)

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -317,7 +317,7 @@ function OutputStream(options) {
     };
 
     if (options.preamble) {
-        print(options.preamble.replace(/\r\n?|[\n\u2028\u2029]|\s*$/g, "\n"));
+        print(options.preamble.replace(/\\n|\r\n?|[\n\u2028\u2029]|\s*$/g, "\n"));
     }
 
     var stack = [];


### PR DESCRIPTION
I need a line break in the preamble (CLI). When I use:
```bash
uglifyjs script.js -c -m --preamble "/**\n * line 1\n * line 2\n */" -o script.min.js
```
Output:
```
/**\n * line 1\n * line 2\n */

```
Need output:
```js
/**
 * line 1
 * line 2
 */

```

This small fix allows line break.