### PR TITLE
Support wrap and exportAll options for node.js tools.

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -84,6 +84,9 @@ exports.minify = function(files, options) {
             });
         });
     }
+    if (options.wrap) {
+      toplevel = toplevel.wrap_commonjs(options.wrap, options.exportAll);
+    }
 
     // 2. compress
     if (options.compress) {


### PR DESCRIPTION
Please support `wrap` and `exportAll` options for node.js tools.

Like: 
```
uglify.minify('target.js', {
  wrap: 'UglifyJS',
  exportAll: true
})
```