### PR TITLE
Fix bad parsing of `new new x()()` constructs

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1114,7 +1114,7 @@ function parse($TEXT, options) {
         });
     };
 
-    var new_ = function() {
+    var new_ = function(allow_calls) {
         var start = S.token;
         expect_token("operator", "new");
         var newexp = expr_atom(false), args;
@@ -1129,7 +1129,7 @@ function parse($TEXT, options) {
             expression : newexp,
             args       : args,
             end        : prev()
-        }), true);
+        }), allow_calls);
     };
 
     function as_atom_node() {
@@ -1173,7 +1173,7 @@ function parse($TEXT, options) {
 
     var expr_atom = function(allow_calls) {
         if (is("operator", "new")) {
-            return new_();
+            return new_(allow_calls);
         }
         var start = S.token;
         if (is("punc")) {

--- a/test/compress/new.js
+++ b/test/compress/new.js
@@ -1,0 +1,12 @@
+new_statement: {
+    input: {
+        new x(1);
+        new x(1)(2);
+        new x(1)(2)(3);
+        new new x(1);
+        new new x(1)(2);
+        new (new x(1))(2);
+        (new new x(1))(2);
+    }
+    expect_exact: "new x(1);new x(1)(2);new x(1)(2)(3);new new x(1);new new x(1)(2);new new x(1)(2);(new new x(1))(2);"
+}


### PR DESCRIPTION
Fixes #739