### PR TITLE
Feature/harmony super

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -940,6 +940,10 @@ var AST_This = DEFNODE("This", null, {
     $documentation: "The `this` symbol",
 }, AST_Symbol);
 
+var AST_Super = DEFNODE("Super", null, {
+    $documentation: "The `super` symbol",
+}, AST_Symbol);
+
 var AST_Constant = DEFNODE("Constant", null, {
     $documentation: "Base class for all constants",
     getValue: function() {

--- a/lib/output.js
+++ b/lib/output.js
@@ -1151,6 +1151,9 @@ function OutputStream(options) {
     DEFPRINT(AST_This, function(self, output){
         output.print("this");
     });
+    DEFPRINT(AST_Super, function(self, output){
+        output.print("super");
+    });
     DEFPRINT(AST_Constant, function(self, output){
         output.print(self.getValue());
     });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1361,7 +1361,9 @@ function parse($TEXT, options) {
 
     function _make_symbol(type) {
         var name = S.token.value;
-        return new (name == "this" ? AST_This : type)({
+        return new (name == "this" ? AST_This :
+                    name == "super" ? AST_Super :
+                    type)({
             name  : String(name),
             start : S.token,
             end   : S.token
@@ -1481,6 +1483,7 @@ function parse($TEXT, options) {
     function is_assignable(expr) {
         if (!options.strict) return true;
         if (expr instanceof AST_This) return false;
+        if (expr instanceof AST_Super) return false;
         return (expr instanceof AST_PropAccess || expr instanceof AST_Symbol);
     };
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -472,6 +472,8 @@ AST_Toplevel.DEFMETHOD("compute_char_frequency", function(options){
             base54.consider("new");
         else if (node instanceof AST_This)
             base54.consider("this");
+        else if (node instanceof AST_Super)
+            base54.consider("super");
         else if (node instanceof AST_Try)
             base54.consider("try");
         else if (node instanceof AST_Catch)

--- a/test/compress/super.js
+++ b/test/compress/super.js
@@ -1,0 +1,9 @@
+
+super_can_be_parsed: {
+    input: {
+        super(1,2);
+        super.meth();
+    }
+    expect_exact: "super(1,2);super.meth();"
+}
+


### PR DESCRIPTION
There's not much to this, and it's not absolutely necessary since uglify can already parse and minify "super" references by treating it as an implicit global.