### PR TITLE
Feature/harmony destructuring expression

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1179,6 +1179,17 @@ function OutputStream(options) {
         var def = self.definition();
         output.print_name(def ? def.mangled_name || def.name : self.name);
     });
+    DEFPRINT(AST_ObjectSymbol, function(self, output){
+        var def = self.symbol.definition();
+        if (def && def.mangled_name) {
+            output.print(self.symbol.name);
+            output.print(':');
+            output.space();
+            output.print(def.mangled_name);
+        } else {
+            output.print(self.symbol.name);
+        }
+    });
     DEFPRINT(AST_Undefined, function(self, output){
         output.print("void 0");
     });

--- a/lib/output.js
+++ b/lib/output.js
@@ -1180,14 +1180,15 @@ function OutputStream(options) {
         output.print_name(def ? def.mangled_name || def.name : self.name);
     });
     DEFPRINT(AST_ObjectSymbol, function(self, output){
+        var name = self.mangled_key || self.symbol.name;
         var def = self.symbol.definition();
         if (def && def.mangled_name) {
-            output.print(self.symbol.name);
+            output.print(name);
             output.print(':');
             output.space();
             output.print(def.mangled_name);
         } else {
-            output.print(self.symbol.name);
+            output.print(name);
         }
     });
     DEFPRINT(AST_Undefined, function(self, output){

--- a/lib/output.js
+++ b/lib/output.js
@@ -1187,6 +1187,11 @@ function OutputStream(options) {
             output.print(':');
             output.space();
             output.print(def.mangled_name);
+        } else if (!(def && def.mangled_name) && self.mangled_key) {
+            output.print(name);
+            output.print(':');
+            output.space();
+            output.print(def.name);
         } else {
             output.print(name);
         }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1410,9 +1410,6 @@ function parse($TEXT, options) {
                 
                 if (!is("punc", ":")) {
                     // It's one of those object destructurings, the value is its own name
-                    if (!S.in_parameters) {
-                        croak("Invalid syntax", S.token.line, S.token.col);
-                    }
                     a.push(new AST_ObjectSymbol({
                         start: start,
                         end: start,

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -90,6 +90,9 @@ function mangle_properties(ast, options) {
         if (node instanceof AST_ObjectKeyVal) {
             add(node.key);
         }
+        else if (node instanceof AST_ObjectSymbol) {
+            add(node.symbol.name);
+        }
         else if (node instanceof AST_ObjectProperty) {
             // setter or getter, since KeyVal is handled above
             add(node.key.name);
@@ -110,6 +113,11 @@ function mangle_properties(ast, options) {
     return ast.transform(new TreeTransformer(function(node){
         if (node instanceof AST_ObjectKeyVal) {
             node.key = mangle(node.key);
+        }
+        else if (node instanceof AST_ObjectSymbol) {
+            if (should_mangle(node.symbol.name)) {
+                node.mangled_key = mangle(node.symbol.name)
+            }
         }
         else if (node instanceof AST_ObjectProperty) {
             // setter or getter

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -219,6 +219,10 @@ TreeTransformer.prototype = new TreeWalker;
         self.properties = do_list(self.properties, tw);
     });
 
+    _(AST_ObjectSymbol, function(self, tw){
+        self.symbol = self.symbol.transform(tw);
+    });
+
     _(AST_ObjectProperty, function(self, tw){
         self.value = self.value.transform(tw);
     });

--- a/test/compress/destructuring.js
+++ b/test/compress/destructuring.js
@@ -32,3 +32,12 @@ destructuring_vardef_in_loops: {
     }
     expect_exact: "for(var[x,y]in pairs);for(var[a]=0;;);for(var{c}of cees);"
 }
+destructuring_expressions: {
+    input: {
+        ({a, b});
+        [{a}];
+        f({x});
+    }
+    expect_exact: "({a,b});[{a}];f({x});"
+}
+

--- a/test/parser.js
+++ b/test/parser.js
@@ -118,13 +118,6 @@ module.exports = function () {
     ok.equal(expanding_def.name.names[0].TYPE, 'SymbolVar');
     ok.equal(expanding_def.name.names[1].TYPE, 'Expansion');
     ok.equal(expanding_def.name.names[1].symbol.TYPE, 'SymbolVar');
-
-    ok.throws(function () {
-        // Note: this *is* a valid destructuring, but before we implement
-        // destructuring (right now it's only destructuring *arguments*),
-        // this won't do.
-        UglifyJS.parse('[{a}]');
-    });
 }
 
 // Run standalone


### PR DESCRIPTION
This allows you to compress destructuring expressions (IE `return { height, width }` instead of `return { height: height, width: width }`).

We can now use ObjectSymbol (a property that is linked to a symbol) inside objects, and print it.

If either propmangle, mangle, or both are turned on, ObjectSymbol prints as a KeyValue. According to the above example, this would be `height:x`, `a:height` or `a:x` ("a" being a mangled property and "x" being a mangled name).

It's hard to test this last thing, so I had to test it manually and hope for the best. Is there any way to turn on mangling and propmangling in `test/compress/*` files?