### PR TITLE
Fix evaluating the typeof an arrow function.

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -738,6 +738,9 @@ merge(Compressor.prototype, {
             // places too. :-( Wish JS had multiple inheritance.
             throw def;
         });
+        def(AST_Arrow, function() {
+            throw def;
+        });
         function ev(node, compressor) {
             if (!compressor) throw new Error("Compressor must be passed");
 
@@ -756,7 +759,8 @@ merge(Compressor.prototype, {
               case "typeof":
                 // Function would be evaluated to an array and so typeof would
                 // incorrectly return 'object'. Hence making is a special case.
-                if (e instanceof AST_Function) return typeof function(){};
+                if (e instanceof AST_Function ||
+                    e instanceof AST_Arrow) return typeof function(){};
 
                 e = ev(e, compressor);
 

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -36,6 +36,16 @@ regression_arrow_functions_and_hoist: {
     expect_exact: "a=>b;"
 }
 
+typeof_arrow_functions: {
+    options = {
+        evaluate: true
+    }
+    input: {
+        typeof (x) => null;
+    }
+    expect_exact: "\"function\";"
+}
+
 destructuring_arguments: {
     input: {
         (function ( a ) { });


### PR DESCRIPTION
I was looking into the new `typeof` string, `"symbol"`, and how it could affect uglifyjs, and found that evaluating the typeof of an arrow function caused UglifyJS to crash. Not helpful at all, so I added the same exceptions AST_Function had.

I also wish JS had multiple inheritance :(