### PR TITLE
remove Symbol's argument when we're unsafe and Symbol is undeclared

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1831,6 +1831,11 @@ merge(Compressor.prototype, {
                         }
                     }
                     break;
+                  case "Symbol":
+                    // Symbol's argument is only used for debugging.
+                    self.args = [];
+                    return self;
+                    break;
                 }
             }
             else if (exp instanceof AST_Dot && exp.property == "toString" && self.args.length == 0) {


### PR DESCRIPTION
Declaring a Symbol name is used merely for debugging purposes.

The only way to see it programmatically is by using toString (`Symbol("somename").toString()` => `Symbol(somename)`), so this transformation is only available when `unsafe` is turned on. That, and because `Symbol` can be redefined.