### PR TITLE
allow for anonymous map generation using string type check

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -131,7 +131,7 @@ exports.minify = function(files, options) {
     var stream = UglifyJS.OutputStream(output);
     toplevel.print(stream);
 
-    if(options.outSourceMap){
+    if (options.outSourceMap && "string" === typeof options.outSourceMap) {
         stream += "\n//# sourceMappingURL=" + options.outSourceMap;
     }
 


### PR DESCRIPTION
There are use cases where it is undesirable to add the source map name to the output stream, e.g. in https://github.com/bestander/uglify-loader.
With this patch UglifyJS2 could be told to generate a sourcemap, but not issue any URL into the output stream, like
```
outSourceMap = true, // generate a source map, but do not issue a file name
```