### PR TITLE
Fix crash, remove unused code and state variable.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -672,7 +672,6 @@ function parse($TEXT, options) {
         prev          : null,
         peeked        : null,
         in_function   : 0,
-        in_parameters : false,
         in_directives : true,
         in_loop       : 0,
         labels        : []
@@ -1044,7 +1043,6 @@ function parse($TEXT, options) {
         expect("(");
         var first = true;
         var a = [];
-        S.in_parameters = true;
         while (!is("punc", ")")) {
             if (first) first = false; else expect(",");
             if (is("expand", "...")) {
@@ -1058,7 +1056,6 @@ function parse($TEXT, options) {
                 a.push(expression(false));
             }
         }
-        S.in_parameters = false;
         var end = S.token
         next();
         return new AST_ArrowParametersOrSeq({
@@ -1375,97 +1372,60 @@ function parse($TEXT, options) {
     });
 
     var object_or_object_destructuring_ = embed_tokens(function() {
-        var start = S.token;
+        var start = S.token, first = true, a = [];
         expect("{");
-        function try_an_object() {
-            var first = true, a = [];
-            while (!is("punc", "}")) {
-                if (first) first = false; else expect(",");
-                if (!options.strict && is("punc", "}"))
-                    // allow trailing comma
-                    break;
-                var start = S.token;
-                var type = start.type;
-                var name = as_property_name();
-                if (type == "name" && !is("punc", ":")) {
-                    if (name == "get") {
-                        a.push(new AST_ObjectGetter({
-                            start : start,
-                            key   : as_atom_node(),
-                            value : function_(AST_Accessor),
-                            end   : prev()
-                        }));
-                        continue;
-                    }
-                    if (name == "set") {
-                        a.push(new AST_ObjectSetter({
-                            start : start,
-                            key   : as_atom_node(),
-                            value : function_(AST_Accessor),
-                            end   : prev()
-                        }));
-                        continue;
-                    }
-                }
-                
-                if (!is("punc", ":")) {
-                    // It's one of those object destructurings, the value is its own name
-                    a.push(new AST_ObjectSymbol({
-                        start: start,
-                        end: start,
-                        symbol: new AST_SymbolRef({
-                            start: start,
-                            end: start,
-                            name: name
-                        })
-                    }));
-                } else {
-                    if (S.in_parameters) {
-                        croak("Cannot destructure", S.token.line, S.token.col);
-                    }
-                    expect(":");
-                    a.push(new AST_ObjectKeyVal({
+        while (!is("punc", "}")) {
+            if (first) first = false; else expect(",");
+            if (!options.strict && is("punc", "}"))
+                // allow trailing comma
+                break;
+            var start = S.token;
+            var type = start.type;
+            var name = as_property_name();
+            if (type == "name" && !is("punc", ":")) {
+                if (name == "get") {
+                    a.push(new AST_ObjectGetter({
                         start : start,
-                        key   : name,
-                        value : expression(false),
+                        key   : as_atom_node(),
+                        value : function_(AST_Accessor),
                         end   : prev()
                     }));
+                    continue;
+                }
+                if (name == "set") {
+                    a.push(new AST_ObjectSetter({
+                        start : start,
+                        key   : as_atom_node(),
+                        value : function_(AST_Accessor),
+                        end   : prev()
+                    }));
+                    continue;
                 }
             }
-            next();
-            return new AST_Object({ properties: a })
+            
+            if (!is("punc", ":")) {
+                // It's one of those object destructurings, the value is its own name
+                a.push(new AST_ObjectSymbol({
+                    start: start,
+                    end: start,
+                    symbol: new AST_SymbolRef({
+                        start: start,
+                        end: start,
+                        name: name
+                    })
+                }));
+            } else {
+                expect(":");
+                a.push(new AST_ObjectKeyVal({
+                    start : start,
+                    key   : name,
+                    value : expression(false),
+                    end   : prev()
+                }));
+            }
         }
-
-        var obj = try_an_object();
-        if (obj instanceof AST_Object) { return obj; }
-
-        if (!S.in_parameters) {
-            croak("Cannot destructure", S.token.line, S.token.col);
-        }
-
-        var firstName = obj;
-
-        var namesInDestructuring = [];
-
-        namesInDestructuring.push( new AST_SymbolRef({
-            start : prev(),
-            end   : prev(),
-            name  : firstName
-        }));
-
-        while (!is("punc", "}")) {
-            expect(",");
-            namesInDestructuring.push(as_symbol(AST_SymbolRef))
-        }
-
-        expect('}');
-
-        return new AST_Destructuring({
-            start    : start,
-            end      : S.token,
-            names    : namesInDestructuring,
-            is_array : false
-        })
+        next();
+        return new AST_Object({ properties: a })
     });
 
     function as_property_name() {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -122,3 +122,14 @@ number_literals: {
         9;
     }
 }
+
+// Fabio: My patches accidentally caused a crash whenever
+// there's an extraneous set of parens around an object.
+regression_cannot_destructure: {
+    input: {
+        var x = ({ x : 3 });
+        x(({ x: 3 }));
+    }
+    expect_exact: "var x={x:3};x({x:3});";
+}
+


### PR DESCRIPTION
I left a mistake in my implementation of arrow functions, causing extraneous parens around an object to crash uglify.

I fixed that, and noticed there was quite some unused code, so I deleted it.