### PR TITLE
Feature/harmony let

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -654,6 +654,10 @@ var AST_Var = DEFNODE("Var", null, {
     $documentation: "A `var` statement"
 }, AST_Definitions);
 
+var AST_Let = DEFNODE("Let", null, {
+    $documentation: "A `let` statement"
+}, AST_Definitions);
+
 var AST_Const = DEFNODE("Const", null, {
     $documentation: "A `const` statement"
 }, AST_Definitions);

--- a/lib/output.js
+++ b/lib/output.js
@@ -976,6 +976,9 @@ function OutputStream(options) {
         if (!avoid_semicolon)
             output.semicolon();
     });
+    DEFPRINT(AST_Let, function(self, output){
+        self._do_print(output, "let");
+    });
     DEFPRINT(AST_Var, function(self, output){
         self._do_print(output, "var");
     });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -44,7 +44,7 @@
 
 "use strict";
 
-var KEYWORDS = 'break case catch const continue debugger default delete do else finally for function if in of instanceof new return switch throw try typeof var void while with';
+var KEYWORDS = 'break case catch const continue debugger default delete do else finally for function if in of instanceof new return switch throw try typeof var let void while with';
 var KEYWORDS_ATOM = 'false null true';
 var RESERVED_WORDS = 'abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized this throws transient volatile yield'
     + " " + KEYWORDS_ATOM + " " + KEYWORDS;
@@ -875,6 +875,9 @@ function parse($TEXT, options) {
               case "var":
                 return tmp = var_(), semicolon(), tmp;
 
+              case "let":
+                return tmp = let_(), semicolon(), tmp;
+
               case "const":
                 return tmp = const_(), semicolon(), tmp;
 
@@ -945,13 +948,15 @@ function parse($TEXT, options) {
         expect("(");
         var init = null;
         if (!is("punc", ";")) {
-            init = is("keyword", "var")
-                ? (next(), var_(true))
-                : expression(true, true);
+            init =
+                is("keyword", "var") ? (next(), var_(true)) :
+                is("keyword", "let") ? (next(), let_(true)) :
+                                       expression(true, true);
             var is_in = is("operator", "in");
             var is_of = is("keyword", "of");
             if (is_in || is_of) {
-                if (init instanceof AST_Var && init.definitions.length > 1)
+                if ((init instanceof AST_Var || init instanceof AST_Let) &&
+                        init.definitions.length > 1)
                     croak("Only one variable declaration allowed in for..in loop");
                 next();
                 if (is_in) {
@@ -1243,6 +1248,14 @@ function parse($TEXT, options) {
 
     var var_ = function(no_in) {
         return new AST_Var({
+            start       : prev(),
+            definitions : vardefs(no_in, false),
+            end         : prev()
+        });
+    };
+
+    var let_ = function(no_in) {
+        return new AST_Let({
             start       : prev(),
             definitions : vardefs(no_in, false),
             end         : prev()

--- a/test/compress/block-scope.js
+++ b/test/compress/block-scope.js
@@ -1,0 +1,8 @@
+
+let_statement: {
+    input: {
+        let x = 6;
+    }
+    expect_exact: "let x=6;"
+}
+

--- a/test/compress/block-scope.js
+++ b/test/compress/block-scope.js
@@ -6,3 +6,28 @@ let_statement: {
     expect_exact: "let x=6;"
 }
 
+do_not_hoist_let: {
+    options = {
+        hoist_vars: true,
+    };
+    input: {
+        function x() {
+            if (FOO) {
+                let let1;
+                let let2;
+                var var1;
+                var var2;
+            }
+        }
+    }
+    expect: {
+        function x() {
+            var var1, var2;
+            if (FOO) {
+                let let1;
+                let let2;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This adds support for `let`. Did I miss something?

It was simpler than I expected, because the compressor won't hoist non-var declarations, and `let` is not to be hoisted.

`var let = 6` fails to parse. Is this important? Firefox seems to take that as a syntax error too.