### PR TITLE
Allow ascii_only flag for compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,9 @@ to set `true`; it's effectively a shortcut for `foo=true`).
   compressor from mangling/discarding function names.  Useful for code relying on
   `Function.prototype.name`.
 
+- `ascii-only` (default `false`) -- escape Unicode characters in strings and
+  regexps
+
 
 ### The `unsafe` option
 

--- a/README.md
+++ b/README.md
@@ -354,8 +354,8 @@ to set `true`; it's effectively a shortcut for `foo=true`).
   compressor from mangling/discarding function names.  Useful for code relying on
   `Function.prototype.name`.
 
-- `ascii-only` (default `false`) -- escape Unicode characters in strings and
-  regexps
+- `ascii-only` -- default `false`. Escape Unicode characters in strings and
+  regexps.
 
 
 ### The `unsafe` option

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -225,6 +225,9 @@ if (ARGS.keep_fnames) {
 if (BEAUTIFY)
     UglifyJS.merge(OUTPUT_OPTIONS, BEAUTIFY);
 
+if (COMPRESS)
+    OUTPUT_OPTIONS.ascii_only = !!COMPRESS.ascii_only
+
 if (ARGS.comments != null) {
     if (/^\/.*\/[a-zA-Z]*$/.test(ARGS.comments)) {
         try {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -74,6 +74,7 @@ function Compressor(options, false_by_default) {
         screw_ie8     : false,
         drop_console  : false,
         angular       : false,
+        ascii_only    : false,
 
         warnings      : true,
         global_defs   : {}

--- a/test/compress/ascii_only.js
+++ b/test/compress/ascii_only.js
@@ -1,0 +1,19 @@
+prevents_unicode_escape_sequences_from_being_converted: {
+    options = {ascii_only: true};
+    input: {
+        var a = "\u2000";
+    }
+    expect: {
+        var a = "\u2000";
+    }
+}
+
+converts_unicode_characters_to_escape_sequences: {
+    options = {ascii_only: true};
+    input: {
+        var a = " ";
+    }
+    expect: {
+        var a = "\u2000";
+    }
+}


### PR DESCRIPTION
I'm trying to work around a browser bug involving unicode characters in JavaScript. I need UglifyJS to not rewrite my unicode escape sequences as actual unicode characters. This PR allows the `ascii_only` option for compression.