### PR TITLE
Declare a source file when passing in a string.

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -74,12 +74,15 @@ exports.minify = function(files, options) {
         if (typeof files == "string")
             files = [ files ];
         files.forEach(function(file, i){
+            var filename = options.fromString
+                ? (typeof file === 'object' ? file.filename : i)
+                : file;
             var code = options.fromString
-                ? file
-                : fs.readFileSync(file, "utf8");
-            sourcesContent[file] = code;
+                ? (typeof file === 'object' ? file.content : file)
+                : fs.readFileSync(filename, "utf8");
+            sourcesContent[filename] = code;
             toplevel = UglifyJS.parse(code, {
-                filename: options.fromString ? i : file,
+                filename: filename,
                 toplevel: toplevel
             });
         });


### PR DESCRIPTION
another fix for multiple files support.

usage 
```
var opts =  {fromString:true};
var minified = uglify.minify([{content: source, filename: 'file1.js'}], opts);
```