### PR TITLE
Add proper support for "use asm"; blocks

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -401,7 +401,7 @@ async.eachLimit(files, 1, function (file, cb) {
         writeNameCache("props", cache);
     })();
 
-    var SCOPE_IS_NEEDED = COMPRESS || MANGLE || ARGS.lint;
+    var SCOPE_IS_NEEDED = COMPRESS || MANGLE || BEAUTIFY || ARGS.lint;
     var TL_CACHE = readNameCache("vars");
 
     if (SCOPE_IS_NEEDED) {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -111,6 +111,7 @@ merge(Compressor.prototype, {
         node.DEFMETHOD("optimize", function(compressor){
             var self = this;
             if (self._optimized) return self;
+            if (compressor.has_directive("use asm")) return self;
             var opt = optimizer(self, compressor);
             opt._optimized = true;
             if (opt === self) return opt;
@@ -1026,6 +1027,7 @@ merge(Compressor.prototype, {
 
     AST_Scope.DEFMETHOD("drop_unused", function(compressor){
         var self = this;
+        if (compressor.has_directive("use asm")) return self;
         if (compressor.option("unused")
             && !(self instanceof AST_Toplevel)
             && !self.uses_eval
@@ -1205,9 +1207,10 @@ merge(Compressor.prototype, {
     });
 
     AST_Scope.DEFMETHOD("hoist_declarations", function(compressor){
+        var self = this;
+        if (compressor.has_directive("use asm")) return self;
         var hoist_funs = compressor.option("hoist_funs");
         var hoist_vars = compressor.option("hoist_vars");
-        var self = this;
         if (hoist_funs || hoist_vars) {
             var dirs = [];
             var hoisted = [];
@@ -2028,15 +2031,14 @@ merge(Compressor.prototype, {
     var commutativeOperators = makePredicate("== === != !== * & | ^");
 
     OPT(AST_Binary, function(self, compressor){
-        var reverse = compressor.has_directive("use asm") ? noop
-            : function(op, force) {
-                if (force || !(self.left.has_side_effects(compressor) || self.right.has_side_effects(compressor))) {
-                    if (op) self.operator = op;
-                    var tmp = self.left;
-                    self.left = self.right;
-                    self.right = tmp;
-                }
-            };
+        function reverse(op, force) {
+            if (force || !(self.left.has_side_effects(compressor) || self.right.has_side_effects(compressor))) {
+                if (op) self.operator = op;
+                var tmp = self.left;
+                self.left = self.right;
+                self.right = tmp;
+            }
+        }
         if (commutativeOperators(self.operator)) {
             if (self.right instanceof AST_Constant
                 && !(self.left instanceof AST_Constant)) {
@@ -2104,10 +2106,10 @@ merge(Compressor.prototype, {
         if (compressor.option("conditionals")) {
             if (self.operator == "&&") {
                 var ll = self.left.evaluate(compressor);
-                var rr = self.right.evaluate(compressor);
                 if (ll.length > 1) {
                     if (ll[1]) {
                         compressor.warn("Condition left of && always true [{file}:{line},{col}]", self.start);
+                        var rr = self.right.evaluate(compressor);
                         return rr[0];
                     } else {
                         compressor.warn("Condition left of && always false [{file}:{line},{col}]", self.start);
@@ -2117,13 +2119,13 @@ merge(Compressor.prototype, {
             }
             else if (self.operator == "||") {
                 var ll = self.left.evaluate(compressor);
-                var rr = self.right.evaluate(compressor);
                 if (ll.length > 1) {
                     if (ll[1]) {
                         compressor.warn("Condition left of || always true [{file}:{line},{col}]", self.start);
                         return ll[0];
                     } else {
                         compressor.warn("Condition left of || always false [{file}:{line},{col}]", self.start);
+                        var rr = self.right.evaluate(compressor);
                         return rr[0];
                     }
                 }

--- a/lib/output.js
+++ b/lib/output.js
@@ -1151,7 +1151,11 @@ function OutputStream(options) {
         output.print_string(self.getValue(), self.quote);
     });
     DEFPRINT(AST_Number, function(self, output){
-        output.print(make_num(self.getValue()));
+        if (self.value_string !== undefined && self.scope && self.scope.has_directive('use asm')) {
+            output.print(self.value_string);
+        } else {
+            output.print(make_num(self.getValue()));
+        }
     });
 
     function regexp_safe_literal(code) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1141,6 +1141,9 @@ function parse($TEXT, options) {
             break;
           case "num":
             ret = new AST_Number({ start: tok, end: tok, value: tok.value });
+            var value_string = $TEXT.substring(tok.pos, tok.endpos);
+            if (value_string.indexOf('.') >= 0)
+                ret.value_string = value_string;
             break;
           case "string":
             ret = new AST_String({

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -119,6 +119,10 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
             push_uniq(scope.directives, node.value);
             return true;
         }
+        if (node instanceof AST_Number) {
+            node.scope = scope;
+            return true;
+        }
         if (node instanceof AST_With) {
             for (var s = scope; s; s = s.parent_scope)
                 s.uses_with = true;

--- a/test/compress/asm.js
+++ b/test/compress/asm.js
@@ -1,0 +1,106 @@
+asm_mixed: {
+    options = {
+        sequences     : true,
+        properties    : true,
+        dead_code     : true,
+        drop_debugger : true,
+        conditionals  : true,
+        comparisons   : true,
+        evaluate      : true,
+        booleans      : true,
+        loops         : true,
+        unused        : true,
+        hoist_funs    : true,
+        keep_fargs    : true,
+        keep_fnames   : false,
+        hoist_vars    : true,
+        if_return     : true,
+        join_vars     : true,
+        cascade       : true,
+        side_effects  : true,
+        negate_iife   : true
+    };
+    input: {
+        // adapted from http://asmjs.org/spec/latest/
+        function asm_GeometricMean(stdlib, foreign, buffer) {
+          "use asm";
+          var exp = stdlib.Math.exp;
+          var log = stdlib.Math.log;
+          var values = new stdlib.Float64Array(buffer);
+          function logSum(start, end) {
+            start = start|0;
+            end = end|0;
+            var sum = 0.0, p = 0, q = 0;
+            // asm.js forces byte addressing of the heap by requiring shifting by 3
+            for (p = start << 3, q = end << 3; (p|0) < (q|0); p = (p + 8)|0) {
+              sum = sum + +log(values[p>>3]);
+            }
+            return +sum;
+          }
+          function geometricMean(start, end) {
+            start = start|0;
+            end = end|0;
+            return +exp(+logSum(start, end) / +((end - start)|0));
+          }
+          return { geometricMean: geometricMean };
+        }
+        function no_asm_GeometricMean(stdlib, foreign, buffer) {
+          var exp = stdlib.Math.exp;
+          var log = stdlib.Math.log;
+          var values = new stdlib.Float64Array(buffer);
+          function logSum(start, end) {
+            start = start|0;
+            end = end|0;
+            var sum = 0.0, p = 0, q = 0;
+            // asm.js forces byte addressing of the heap by requiring shifting by 3
+            for (p = start << 3, q = end << 3; (p|0) < (q|0); p = (p + 8)|0) {
+              sum = sum + +log(values[p>>3]);
+            }
+            return +sum;
+          }
+          function geometricMean(start, end) {
+            start = start|0;
+            end = end|0;
+            return +exp(+logSum(start, end) / +((end - start)|0));
+          }
+          return { geometricMean: geometricMean };
+        }
+    }
+    expect: {
+        function asm_GeometricMean(stdlib, foreign, buffer) {
+            "use asm";
+            var exp = stdlib.Math.exp;
+            var log = stdlib.Math.log;
+            var values = new stdlib.Float64Array(buffer);
+            function logSum(start, end) {
+                start = start | 0;
+                end = end | 0;
+                var sum = 0.0, p = 0, q = 0;
+                for (p = start << 3, q = end << 3; (p | 0) < (q | 0); p = p + 8 | 0) {
+                    sum = sum + +log(values[p >> 3]);
+                }
+                return +sum;
+            }
+            function geometricMean(start, end) {
+                start = start | 0;
+                end = end | 0;
+                return +exp(+logSum(start, end) / +(end - start | 0));
+            }
+            return { geometricMean: geometricMean };
+        }
+        function no_asm_GeometricMean(stdlib, foreign, buffer) {
+            function logSum(start, end) {
+                start = 0 | start, end = 0 | end;
+                var sum = 0, p = 0, q = 0;
+                for (p = start << 3, q = end << 3; (0 | q) > (0 | p); p = p + 8 | 0) sum += +log(values[p >> 3]);
+                return +sum;
+            }
+            function geometricMean(start, end) {
+                return start = 0 | start, end = 0 | end, +exp(+logSum(start, end) / +(end - start | 0));
+            }
+            var exp = stdlib.Math.exp, log = stdlib.Math.log, values = new stdlib.Float64Array(buffer);
+            return { geometricMean: geometricMean };
+        }
+    }
+}
+


### PR DESCRIPTION
Add proper support for `"use asm";` blocks. Since many traditional javascript optimizations are non-conforming in the restricted asm.js javascript subset, within `"use asm";` sections compression optimization is disabled and floating point literals are preserved in their original form. The assumption is that asm.js code generated by programs like emscripten is already optimized. Non-asm.js sections are optimized as before. Asm.js sections can still be mangled and minified of whitespace. No special command line flags are required.