### PR TITLE
Fix handling of "use asm" when no flags are passed

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -401,7 +401,7 @@ async.eachLimit(files, 1, function (file, cb) {
         writeNameCache("props", cache);
     })();
 
-    var SCOPE_IS_NEEDED = COMPRESS || MANGLE || BEAUTIFY || ARGS.lint;
+    var SCOPE_IS_NEEDED = true;
     var TL_CACHE = readNameCache("vars");
 
     if (SCOPE_IS_NEEDED) {

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -401,17 +401,14 @@ async.eachLimit(files, 1, function (file, cb) {
         writeNameCache("props", cache);
     })();
 
-    var SCOPE_IS_NEEDED = true;
     var TL_CACHE = readNameCache("vars");
 
-    if (SCOPE_IS_NEEDED) {
-        time_it("scope", function(){
-            TOPLEVEL.figure_out_scope({ screw_ie8: ARGS.screw_ie8, cache: TL_CACHE });
-            if (ARGS.lint) {
-                TOPLEVEL.scope_warnings();
-            }
-        });
-    }
+    time_it("scope", function(){
+        TOPLEVEL.figure_out_scope({ screw_ie8: ARGS.screw_ie8, cache: TL_CACHE });
+        if (ARGS.lint) {
+            TOPLEVEL.scope_warnings();
+        }
+    });
 
     if (COMPRESS) {
         time_it("squeeze", function(){
@@ -419,14 +416,12 @@ async.eachLimit(files, 1, function (file, cb) {
         });
     }
 
-    if (SCOPE_IS_NEEDED) {
-        time_it("scope", function(){
-            TOPLEVEL.figure_out_scope({ screw_ie8: ARGS.screw_ie8, cache: TL_CACHE });
-            if (MANGLE && !TL_CACHE) {
-                TOPLEVEL.compute_char_frequency(MANGLE);
-            }
-        });
-    }
+    time_it("scope", function(){
+        TOPLEVEL.figure_out_scope({ screw_ie8: ARGS.screw_ie8, cache: TL_CACHE });
+        if (MANGLE && !TL_CACHE) {
+            TOPLEVEL.compute_char_frequency(MANGLE);
+        }
+    });
 
     if (MANGLE) time_it("mangle", function(){
         MANGLE.cache = TL_CACHE;

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -864,10 +864,11 @@ var AST_String = DEFNODE("String", "value quote", {
     }
 }, AST_Constant);
 
-var AST_Number = DEFNODE("Number", "value", {
+var AST_Number = DEFNODE("Number", "value literal", {
     $documentation: "A number literal",
     $propdoc: {
-        value: "[number] the numeric value"
+        value: "[number] the numeric value",
+        literal: "[string] numeric value as string (optional)"
     }
 }, AST_Constant);
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -1158,8 +1158,10 @@ function OutputStream(options) {
         output.print_string(self.getValue(), self.quote);
     });
     DEFPRINT(AST_Number, function(self, output){
-        if (self.value_string !== undefined && self.scope && self.scope.has_directive('use asm')) {
-            output.print(self.value_string);
+        if (self.literal !== undefined
+            && +self.literal === self.value  /* paranoid check */
+            && self.scope && self.scope.has_directive('use asm')) {
+            output.print(self.literal);
         } else {
             output.print(make_num(self.getValue()));
         }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -335,7 +335,11 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
         if (prefix) num = prefix + num;
         var valid = parse_js_number(num);
         if (!isNaN(valid)) {
-            return token("num", valid);
+            var tok = token("num", valid);
+            if (num.indexOf('.') >= 0) {
+                tok.literal = num;
+            }
+            return tok;
         } else {
             parse_error("Invalid syntax: " + num);
         }
@@ -1148,10 +1152,7 @@ function parse($TEXT, options) {
             ret = _make_symbol(AST_SymbolRef);
             break;
           case "num":
-            ret = new AST_Number({ start: tok, end: tok, value: tok.value });
-            var value_string = $TEXT.substring(tok.pos, tok.endpos);
-            if (value_string.indexOf('.') >= 0)
-                ret.value_string = value_string;
+            ret = new AST_Number({ start: tok, end: tok, value: tok.value, literal: tok.literal });
             break;
           case "string":
             ret = new AST_String({

--- a/tools/node.js
+++ b/tools/node.js
@@ -45,6 +45,7 @@ exports.minify = function(files, options) {
     UglifyJS.base54.reset();
 
     // 1. parse
+    var haveScope = false;
     var toplevel = null,
         sourcesContent = {};
 
@@ -73,6 +74,7 @@ exports.minify = function(files, options) {
         var compress = { warnings: options.warnings };
         UglifyJS.merge(compress, options.compress);
         toplevel.figure_out_scope();
+        haveScope = true;
         var sq = UglifyJS.Compressor(compress);
         toplevel = toplevel.transform(sq);
     }
@@ -80,11 +82,17 @@ exports.minify = function(files, options) {
     // 3. mangle
     if (options.mangle) {
         toplevel.figure_out_scope(options.mangle);
+        haveScope = true;
         toplevel.compute_char_frequency(options.mangle);
         toplevel.mangle_names(options.mangle);
     }
 
-    // 4. output
+    // 4. scope (if needed)
+    if (!haveScope) {
+        toplevel.figure_out_scope();
+    }
+
+    // 5. output
     var inMap = options.inSourceMap;
     var output = {};
     if (typeof options.inSourceMap == "string") {


### PR DESCRIPTION
Fix handling of `"use asm";` code generation when no flags are passed to `uglifyjs`. SCOPE_IS_NEEDED is unconditionally true now to output the original floating point literals in asm.js blocks. Also refactored floating point literal parsing to be more in keeping with the AST class design.