### PR TITLE
Bump deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     "LICENSE"
   ],
   "dependencies": {
-    "async": "~0.2.6",
+    "async": "^1.4.2",
     "source-map": "~0.5.1",
-    "uglify-to-browserify": "~1.0.0",
-    "yargs": "~3.5.4"
+    "uglify-to-browserify": "^1.0.2",
+    "yargs": "^3.27.0"
   },
   "devDependencies": {
-    "acorn": "~0.6.0",
-    "escodegen": "~1.3.3",
+    "acorn": "^2.4.0",
+    "escodegen": "^1.7.0",
     "esfuzz": "~0.3.1",
-    "estraverse": "~1.5.1"
+    "estraverse": "^4.1.0"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
Fixes downstream SPDX license warnings (fixed by newer version of
yargs).