### PR TITLE
Handle <!-- and --> within string literals and expressions

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -125,8 +125,9 @@ function OutputStream(options) {
 
     function encode_string(str, quote) {
         var ret = make_string(str, quote);
-        if (options.inline_script)
-            ret = ret.replace(/<\x2fscript([>\/\t\n\f\r ])/gi, "<\\/script$1");
+        ret = ret.replace(/<\x2fscript([>\/\t\n\f\r ])/gi, "<\\/script$1");
+        ret = ret.replace(/\x3c!--/g, "\\x3c!--");
+        ret = ret.replace(/--\x3e/g, "--\\x3e");
         return ret;
     };
 
@@ -1046,7 +1047,15 @@ function OutputStream(options) {
     });
     DEFPRINT(AST_Binary, function(self, output){
         self.left.print(output);
-        output.space();
+        if (self.operator == ">"
+            && self.left instanceof AST_UnaryPostfix
+            && self.left.operator == "--") {
+            // space is mandatory to avoid outputting -->
+            output.print(" ");
+        } else {
+            // the space is optional depending on "beautify"
+            output.space();
+        }
         output.print(self.operator);
         if (self.operator == "<"
             && self.right instanceof AST_UnaryPrefix
@@ -1054,7 +1063,6 @@ function OutputStream(options) {
             && self.right.expression instanceof AST_UnaryPrefix
             && self.right.expression.operator == "--") {
             // space is mandatory to avoid outputting <!--
-            // http://javascript.spec.whatwg.org/#comment-syntax
             output.print(" ");
         } else {
             // the space is optional depending on "beautify"

--- a/test/compress/html_comments.js
+++ b/test/compress/html_comments.js
@@ -1,0 +1,15 @@
+html_comment_in_expression: {
+    input: {
+        function f(a, b, x, y) { return a < !--b && x-- > y; }
+    }
+    expect_exact: "function f(a,b,x,y){return a< !--b&&x-- >y}";
+}
+
+html_comment_in_string_literal: {
+    input: {
+        function f() { return "<!--HTML-->comment in<!--string literal-->"; }
+    }
+    expect_exact: 'function f(){return"\\x3c!--HTML--\\x3ecomment in\\x3c!--string literal--\\x3e"}';
+}
+
+


### PR DESCRIPTION
Candidate fix for #799.

* Output `-- >` instead of `-->` in expressions.
* Escape `<!--` and `-->` within string literals.

@rvanvelzen Could you please review?