### PR TITLE
Fix other operator output producing <!-- or -->

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1048,8 +1048,9 @@ function OutputStream(options) {
         output.print(self.operator);
     });
     DEFPRINT(AST_Binary, function(self, output){
+        var op = self.operator;
         self.left.print(output);
-        if (self.operator == ">"
+        if (op[0] == ">" /* ">>" ">>>" ">" ">=" */
             && self.left instanceof AST_UnaryPostfix
             && self.left.operator == "--") {
             // space is mandatory to avoid outputting -->
@@ -1058,8 +1059,8 @@ function OutputStream(options) {
             // the space is optional depending on "beautify"
             output.space();
         }
-        output.print(self.operator);
-        if (self.operator == "<"
+        output.print(op);
+        if ((op == "<" || op == "<<")
             && self.right instanceof AST_UnaryPrefix
             && self.right.operator == "!"
             && self.right.expression instanceof AST_UnaryPrefix

--- a/test/compress/html_comments.js
+++ b/test/compress/html_comments.js
@@ -5,11 +5,67 @@ html_comment_in_expression: {
     expect_exact: "function f(a,b,x,y){return a< !--b&&x-- >y}";
 }
 
+html_comment_in_less_than: {
+    input: {
+        function f(a, b) { return a < !--b; }
+    }
+    expect_exact: "function f(a,b){return a< !--b}";
+}
+
+html_comment_in_left_shift: {
+    input: {
+        function f(a, b) { return a << !--b; }
+    }
+    expect_exact: "function f(a,b){return a<< !--b}";
+}
+
+html_comment_in_right_shift: {
+    input: {
+        function f(a, b) { return a-- >> b; }
+    }
+    expect_exact: "function f(a,b){return a-- >>b}";
+}
+
+html_comment_in_zero_fill_right_shift: {
+    input: {
+        function f(a, b) { return a-- >>> b; }
+    }
+    expect_exact: "function f(a,b){return a-- >>>b}";
+}
+
+html_comment_in_greater_than: {
+    input: {
+        function f(a, b) { return a-- > b; }
+    }
+    expect_exact: "function f(a,b){return a-- >b}";
+}
+
+html_comment_in_greater_than_or_equal: {
+    input: {
+        function f(a, b) { return a-- >= b; }
+    }
+    expect_exact: "function f(a,b){return a-- >=b}";
+}
+
+html_comment_in_right_shift_assign: {
+    input: {
+        // Note: illegal javascript
+        function f(a, b) { return a-- >>= b; }
+    }
+    expect_exact: "function f(a,b){return a-- >>=b}";
+}
+
+html_comment_in_zero_fill_right_shift_assign: {
+    input: {
+        // Note: illegal javascript
+        function f(a, b) { return a-- >>>= b; }
+    }
+    expect_exact: "function f(a,b){return a-- >>>=b}";
+}
+
 html_comment_in_string_literal: {
     input: {
         function f() { return "<!--HTML-->comment in<!--string literal-->"; }
     }
     expect_exact: 'function f(){return"\\x3c!--HTML--\\x3ecomment in\\x3c!--string literal--\\x3e"}';
 }
-
-


### PR DESCRIPTION
@mishoo @rvanvelzen Had missed some other operators that produced HTML comment delimiters. This should be all of them.