### PR TITLE
add support for --pure-funcs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ The available options are:
   --mangle-props                Mangle property names
   --mangle-regex                Only mangle property names matching the regex
   --name-cache                  File to hold mangled names mappings
+  --pure-funcs                  List of functions that can be safely removed if
+                                their return value is not used           [array]
 ```
 
 Specify `--output` (`-o`) to declare the output file.  Otherwise the output

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -72,6 +72,7 @@ You need to pass an argument to this option to specify the name that your module
     .describe("mangle-props", "Mangle property names")
     .describe("mangle-regex", "Only mangle property names matching the regex")
     .describe("name-cache", "File to hold mangled names mappings")
+    .describe("pure-funcs", "List of functions that can be safely removed if their return value is not used")
 
     .alias("p", "prefix")
     .alias("o", "output")
@@ -104,6 +105,7 @@ You need to pass an argument to this option to specify the name that your module
     .string("prefix")
     .string("name-cache")
     .array("reserved-file")
+    .array("pure-funcs")
 
     .boolean("expr")
     .boolean("source-map-include-sources")
@@ -173,6 +175,10 @@ if (ARGS.reserve_domprops) {
 
 if (ARGS.d) {
     if (COMPRESS) COMPRESS.global_defs = getOptions("d");
+}
+
+if (ARGS.pure_funcs) {
+    if (COMPRESS) COMPRESS.pure_funcs = ARGS.pure_funcs;
 }
 
 if (ARGS.r) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -115,9 +115,9 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
     },
     "yargs": {
-      "version": "3.5.4",
-      "from": "yargs@>=3.5.4 <3.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz"
+      "version": "3.10.0",
+      "from": "yargs@>=3.10.0 <3.11.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
     },
     "zeparser": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "async": "~0.2.6",
     "source-map": "~0.5.1",
     "uglify-to-browserify": "~1.0.0",
-    "yargs": "~3.5.4"
+    "yargs": "~3.10.0"
   },
   "devDependencies": {
     "acorn": "~0.6.0",


### PR DESCRIPTION
it has the same effect as specifying `pure_funcs` in `--compressor` option, however it's much easier to use

instead of:

    --compressor 'pure_func=["Math.floor","debug","console.logTime"]'

we can now do this:

    --compressor --pure-funcs Math.floor debug console.logTime

That should clear up some confusion described in #684 - which suggests that `pure_funcs` can be defined as a comma separated list. That kind of works, but if I am not mistaken uglify `getOptions` parses it as `String`. Since `indexOf` is supported by both `Array` and `String` everyone seems happy. Unfortunately passing `pure_funcs` as `"Math.floor,debug"` removes `Math.floor` as well as `or` and `bug` if one had a misfortune of having used them ;-)

`yargs` upgrade is needed for nicer array parsing in arguments - without it `--pure-funcs` needs to be repeated for each item.