### PR TITLE
Fix escapes in dictionary keys. Place source token in sourceMap 

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -306,11 +306,13 @@ function OutputStream(options) {
 
     var add_mapping = options.source_map ? function(token, name) {
         try {
+            var originalSource = token.__HACK_CODE__.substring(token.pos, token.endpos)
+
             if (token) options.source_map.add(
                 token.file || "?",
                 current_line, current_col,
                 token.line, token.col,
-                (!name && token.type == "name") ? token.value : name
+                originalSource // (!name && token.type == "name") ? token.value : name
             );
         } catch(ex) {
             AST_Node.warn("Couldn't figure out mapping for {file}:{line},{col} → {cline},{ccol} [{name}]", {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -684,6 +684,10 @@ function parse($TEXT, options) {
         S.in_directives = S.in_directives && (
             S.token.type == "string" || is("punc", ";")
         );
+
+        // Hacks in the source code
+        S.token.__HACK_CODE__ = $TEXT
+
         return S.token;
     };
 


### PR DESCRIPTION
This will fix dict keys like the ones in lodash:

  var deburredLetters = {
    '\xc0': 'A',  '\xc1': 'A', '\xc2': 'A', '\xc3': 'A', '\xc4': 'A', '\xc5': 'A',
    '\xe0': 'a',  '\xe1': 'a', '\xe2': 'a', '\xe3': 'a', '\xe4': 'a', '\xe5': 'a',
    '\xc7': 'C',  '\xe7': 'c',
    '\xd0': 'D',  '\xf0': 'd',
    '\xc8': 'E',  '\xc9': 'E', '\xca': 'E', '\xcb': 'E',
    '\xe8': 'e',  '\xe9': 'e', '\xea': 'e', '\xeb': 'e',
    '\xcc': 'I',  '\xcd': 'I', '\xce': 'I', '\xcf': 'I',
    '\xec': 'i',  '\xed': 'i', '\xee': 'i', '\xef': 'i',
    '\xd1': 'N',  '\xf1': 'n',
    '\xd2': 'O',  '\xd3': 'O', '\xd4': 'O', '\xd5': 'O', '\xd6': 'O', '\xd8': 'O',
    '\xf2': 'o',  '\xf3': 'o', '\xf4': 'o', '\xf5': 'o', '\xf6': 'o', '\xf8': 'o',
    '\xd9': 'U',  '\xda': 'U', '\xdb': 'U', '\xdc': 'U',
    '\xf9': 'u',  '\xfa': 'u', '\xfb': 'u', '\xfc': 'u',
    '\xdd': 'Y',  '\xfd': 'y', '\xff': 'y',
    '\xc6': 'Ae', '\xe6': 'ae',
    '\xde': 'Th', '\xfe': 'th',
    '\xdf': 'ss'
  };

The keys are read in and converted to their actual character representation by the AST but not escaped back when they are placed in the sourcemap. This means that À gets inserted into the sourcemap when in reality the key is \xc0.

So its looking to map À at whatever offset it can only find '\xc0' in the source. And usually its trying to match 1 character so it attempts to to match À == '.

À should never get into the sourcemap because its not in the source.

@jmalloc might be able to add to this as he came up with the solution.

Solves #341 as well


