### PR TITLE
Escape \v like other special characters 

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -88,13 +88,14 @@ function OutputStream(options) {
 
     function make_string(str, quote) {
         var dq = 0, sq = 0;
-        str = str.replace(/[\\\b\f\n\r\t\x22\x27\u2028\u2029\0\ufeff]/g, function(s){
+        str = str.replace(/[\\\b\f\n\r\v\t\x22\x27\u2028\u2029\0\ufeff]/g, function(s){
             switch (s) {
               case "\\": return "\\\\";
               case "\b": return "\\b";
               case "\f": return "\\f";
               case "\n": return "\\n";
               case "\r": return "\\r";
+              case "\v": return "\\v";
               case "\u2028": return "\\u2028";
               case "\u2029": return "\\u2029";
               case '"': ++dq; return '"';


### PR DESCRIPTION
In parse.js read_escaped_char reads converts \v but output.js doesnt escape it back out meaning that actual Vertical Tabs are places in the code when they are read back in by some browsers. Meaning that ofter the sourcemaps are off by 1 or multiple lines depending on how many VT's are in the code.

Angular.js contains two and when currently minifed and source maped with uglify its breaks the the source maps are off by a couple of lines.

This one really does need merging. @ezzatron for pear programming and mostly finding the bug while i ate a pear.