### PR TITLE
Harmony: allow use of `of` as a name.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -44,7 +44,7 @@
 
 "use strict";
 
-var KEYWORDS = 'break case catch const continue debugger default delete do else finally for function if in of instanceof new return switch throw try typeof var let void while with';
+var KEYWORDS = 'break case catch const continue debugger default delete do else finally for function if in instanceof new return switch throw try typeof var let void while with';
 var KEYWORDS_ATOM = 'false null true';
 var RESERVED_WORDS = 'abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized this throws transient volatile yield'
     + " " + KEYWORDS_ATOM + " " + KEYWORDS;
@@ -969,7 +969,7 @@ function parse($TEXT, options) {
                 is("keyword", "let") ? (next(), let_(true)) :
                                        expression(true, true);
             var is_in = is("operator", "in");
-            var is_of = is("keyword", "of");
+            var is_of = is("name", "of");
             if (is_in || is_of) {
                 if ((init instanceof AST_Var || init instanceof AST_Let) &&
                         init.definitions.length > 1)

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -158,3 +158,20 @@ regression_cannot_destructure: {
     expect_exact: "var x={x:3};x({x:3});";
 }
 
+regression_cannot_use_of: {
+    input: {
+        function of() {
+        }
+        var of = "is a valid variable name";
+        of = { of: "is ok" };
+        x.of;
+        of: foo()
+    }
+    expect: {
+        function of(){}
+        var of="is a valid variable name";
+        of={of:"is ok"};
+        x.of;
+        foo();  /* Label statement missing? No prob. */
+    }
+}


### PR DESCRIPTION
`var of` and `function of` are acceptable javascript, but uglify was not allowing it. Caught this while minifying a react + relay application.

This fix makes `of` a "name" token instead of a "keyword" token.

I won't do this for `var let` and `function let` because Firefox stopped accepting them, and as such they shouldn't be used.