### PR TITLE
Harmony concise methods

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -473,6 +473,10 @@ var AST_Arrow = DEFNODE("Arrow", null, {
     $documentation: "An ES6 Arrow function ((a) => b)"
 }, AST_Lambda);
 
+var AST_ConciseMethod = DEFNODE("ConciseMethod", null, {
+    $documentation: "An ES6 concise method inside an object or class"
+}, AST_Lambda);
+
 var AST_Defun = DEFNODE("Defun", null, {
     $documentation: "A function definition"
 }, AST_Lambda);

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -991,6 +991,10 @@ var AST_SymbolDefun = DEFNODE("SymbolDefun", null, {
     $documentation: "Symbol defining a function",
 }, AST_SymbolDeclaration);
 
+var AST_SymbolMethod = DEFNODE("SymbolMethod", null, {
+    $documentation: "Symbol in an object defining a method",
+}, AST_Symbol);
+
 var AST_SymbolLambda = DEFNODE("SymbolLambda", null, {
     $documentation: "Symbol naming a function expression",
 }, AST_SymbolDeclaration);

--- a/lib/output.js
+++ b/lib/output.js
@@ -832,6 +832,9 @@ function OutputStream(options) {
         }
         if (needs_parens) { output.print(")") }
     });
+    DEFPRINT(AST_ConciseMethod, function(self, output){
+        self._do_print(output, true /* do not print "function" */);
+    });
 
     /* -----[ exits ]----- */
     AST_Exit.DEFMETHOD("_do_print", function(output, kind){

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1445,7 +1445,7 @@ function parse($TEXT, options) {
             var start = S.token;
             var type = start.type;
             var name = as_property_name();
-            if (type == "name" && !is("punc", ":")) {
+            if (type != "string" && type != "num" && !is("punc", ":")) {
                 if (is("punc", "(")) {
                     a.push(new AST_ConciseMethod({
                         start    : start,

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1446,6 +1446,16 @@ function parse($TEXT, options) {
             var type = start.type;
             var name = as_property_name();
             if (type == "name" && !is("punc", ":")) {
+                if (is("punc", "(")) {
+                    a.push(new AST_ConciseMethod({
+                        start    : start,
+                        name     : new AST_Symbol({ name: name }),  // TODO what symbol is this really?
+                        argnames : params_or_seq_().as_params(croak),
+                        body     : _function_body(true),
+                        end      : prev()
+                    }))
+                    continue;
+                }
                 if (name == "get") {
                     a.push(new AST_ObjectGetter({
                         start : start,

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1449,7 +1449,7 @@ function parse($TEXT, options) {
                 if (is("punc", "(")) {
                     a.push(new AST_ConciseMethod({
                         start    : start,
-                        name     : new AST_Symbol({ name: name }),  // TODO what symbol is this really?
+                        name     : new AST_SymbolMethod({ name: name }),
                         argnames : params_or_seq_().as_params(croak),
                         body     : _function_body(true),
                         end      : prev()

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -107,6 +107,9 @@ function mangle_properties(ast, options) {
                 addStrings(node.property);
             }
         }
+        else if (node instanceof AST_ConciseMethod) {
+            add(node.name.name);
+        }
     }));
 
     // step 2: transform the tree, renaming properties
@@ -128,6 +131,11 @@ function mangle_properties(ast, options) {
         }
         else if (node instanceof AST_Sub) {
             node.property = mangleStrings(node.property);
+        }
+        else if (node instanceof AST_ConciseMethod) {
+            if (should_mangle(node.name.name)) {
+                node.name.name = mangle(node.name.name);
+            }
         }
         // else if (node instanceof AST_String) {
         //     if (should_mangle(node.value)) {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -132,6 +132,22 @@ destructuring_arguments: {
     }
 }
 
+concise_methods: {
+    input: {
+        x = {
+            foo(a, b) {
+                return x;
+            }
+        }
+        y = {
+            foo([{a}]) {
+                return a;
+            }
+        }
+    }
+    expect_exact: "x={foo(a,b){return x}};y={foo([{a}]){return a}};"
+}
+
 number_literals: {
     input: {
         0b1001;

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -169,6 +169,18 @@ concise_methods_and_mangle_props: {
     }
 }
 
+concise_methods_and_keyword_names: {
+    input: {
+        x = {
+            catch() {},
+            throw() {}
+        }
+    }
+    expect: {
+        x={catch(){},throw(){}};
+    }
+}
+
 number_literals: {
     input: {
         0b1001;

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -142,10 +142,11 @@ concise_methods: {
         y = {
             foo([{a}]) {
                 return a;
-            }
+            },
+            bar(){}
         }
     }
-    expect_exact: "x={foo(a,b){return x}};y={foo([{a}]){return a}};"
+    expect_exact: "x={foo(a,b){return x}};y={foo([{a}]){return a},bar(){}};"
 }
 
 number_literals: {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -149,6 +149,26 @@ concise_methods: {
     expect_exact: "x={foo(a,b){return x}};y={foo([{a}]){return a},bar(){}};"
 }
 
+concise_methods_and_mangle_props: {
+    mangle_props = {
+        regex: /_/
+    };
+    input: {
+        function x() {
+            obj = {
+                _foo() { return 1; }
+            }
+        }
+    }
+    expect: {
+        function x() {
+            obj = {
+                a() { return 1; }
+            }
+        }
+    }
+}
+
 number_literals: {
     input: {
         0b1001;


### PR DESCRIPTION
Ok, so this covers concise methods. The beautiful bastards.

```
x = {
  foo() {
    return 6;
  }
};
```

They work with propmangle too!