### PR TITLE
fixes #845: \v escaping should be restricted to "screw_ie8" mode

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -95,7 +95,7 @@ function OutputStream(options) {
               case "\f": return "\\f";
               case "\n": return "\\n";
               case "\r": return "\\r";
-              case "\v": return "\\v";
+              case "\x0B": return output.option("screw_ie8") ? "\\v" : "\\x0B";
               case "\u2028": return "\\u2028";
               case "\u2029": return "\\u2029";
               case '"': ++dq; return '"';


### PR DESCRIPTION
Fixes #845. Related: #6.