### PR TITLE
Have mozilla AST RegExpLiteral parser use regex.pattern and regex.flags

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -149,10 +149,7 @@
                 var rx = M.regex;
                 if (rx && rx.pattern) {
                     // RegExpLiteral as per ESTree AST spec
-                    args.value = "/" + rx.pattern + "/";
-                    if (rx.flags) {
-                        args.value += rx.flags;
-                    }
+                    args.value = new RegExp(rx.pattern, rx.flags).toString();
                 } else {
                     // support legacy RegExp
                     args.value = M.regex && M.raw ? M.raw : val;

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -146,7 +146,17 @@
               case "boolean":
                 return new (val ? AST_True : AST_False)(args);
               default:
-                args.value = M.regex && M.raw ? M.raw : val;
+                var rx = M.regex;
+                if (rx && rx.pattern) {
+                    // RegExpLiteral as per ESTree AST spec
+                    args.value = "/" + rx.pattern + "/";
+                    if (rx.flags) {
+                        args.value += rx.flags;
+                    }
+                } else {
+                    // support legacy RegExp
+                    args.value = M.regex && M.raw ? M.raw : val;
+                }
                 return new AST_RegExp(args);
             }
         },
@@ -334,7 +344,7 @@
         };
     });
 
-    def_to_moz(AST_RegExp, function To_Moz_RegExp(M) {
+    def_to_moz(AST_RegExp, function To_Moz_RegExpLiteral(M) {
         var value = M.value;
         return {
             type: "Literal",


### PR DESCRIPTION
Have mozilla AST RegExpLiteral parser prefer use of `regex.pattern` and `regex.flags` over non-standard `raw` property. Still support `raw` and `value` as fallbacks. See #852 and #853