### PR TITLE
Do not allow newlines in string literals

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -399,6 +399,7 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
                 if (octal_len > 0) ch = String.fromCharCode(parseInt(ch, 8));
                 else ch = read_escaped_char(true);
             }
+            else if (ch == "\n") parse_error("Unterminated string constant");
             else if (ch == quote) break;
             ret += ch;
         }


### PR DESCRIPTION
- Fixes #901
- Requires minor bump for UglifyJS since this patch adds stricter requirements to the input
- No test yet (normal tests don't test for syntax errors)