### PR TITLE
Add keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
   "scripts": {
     "shrinkwrap": "rm ./npm-shrinkwrap.json; rm -rf ./node_modules; npm i && npm shrinkwrap && npm outdated",
     "test": "node test/run-tests.js"
-  }
+  },
+  "keywords": ["uglify", "uglify-js", "minify", "minifier"]
 }


### PR DESCRIPTION
Should hopefully bump up on the results of the npm site when searching `uglify`. Currently for the search `uglify`, the package shows up on page 3.