### PR TITLE
Fix template string parsing

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1414,10 +1414,8 @@ function parse($TEXT, options) {
                 tokenizer_S.next();
                 next();
                 segments.push(expression());
-                expect("}");
-                if (is("punc", "`")) {
-                    break;
-                }
+                if (!is("punc", "}"))
+                    token_error(tokenizer_S.token, "Unexpected token " + tokenizer_S.token.type + " «" + tokenizer_S.token.value + "»" + ", expected punc «}»");
                 continue;
             }
             segment += ch;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1414,8 +1414,10 @@ function parse($TEXT, options) {
                 tokenizer_S.next();
                 next();
                 segments.push(expression());
-                if (!is("punc", "}"))
-                    token_error(tokenizer_S.token, "Unexpected token " + tokenizer_S.token.type + " «" + tokenizer_S.token.value + "»" + ", expected punc «}»");
+                if (!is("punc", "}")) {
+                    // force error message
+                    expect("}");
+                }
                 continue;
             }
             segment += ch;


### PR DESCRIPTION
Using `expect()` will internally call `next()`, which incorrectly attempts to parse a string as code. This will either cause a character to be skipped, or it'll throw an error.

This is what happened without this patch.
```
`<span>${contents}</span>` -> `<span>${contents}/span>`
`<a href="${url}">${text}</a>` -> Error("Unterminated string constant")
```

I suspect this isn't the best fix as I'm copy/pasting the error message from `expect`, but don't know a better way.