### PR TITLE
Mark vars with /** @const */ pragma as consts so they can be eliminated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,8 @@ separate file and include it into the build.  For example you can have a
 ```javascript
 const DEBUG = false;
 const PRODUCTION = true;
+// Alternative for environments that don't support `const`
+/** @const */ var STAGING = false;
 // etc.
 ```
 
@@ -404,8 +406,8 @@ and build your code like this:
 
 UglifyJS will notice the constants and, since they cannot be altered, it
 will evaluate references to them to the value itself and drop unreachable
-code as usual.  The possible downside of this approach is that the build
-will contain the `const` declarations.
+code as usual.  The build will contain the `const` declarations if you use
+them. If you are targeting < ES6 environments, use `/** @const */ var`.
 
 <a name="codegen-options"></a>
 ## Beautifier options

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -154,7 +154,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
         else if (node instanceof AST_SymbolVar
                  || node instanceof AST_SymbolConst) {
             var def = defun.def_variable(node);
-            def.constant = node instanceof AST_SymbolConst;
+            def.constant = node instanceof AST_SymbolConst || node.has_const_pragma();
             def.init = tw.parent().value;
         }
         else if (node instanceof AST_SymbolCatch) {
@@ -356,6 +356,16 @@ AST_Symbol.DEFMETHOD("definition", function(){
 AST_Symbol.DEFMETHOD("global", function(){
     return this.definition().global;
 });
+
+AST_Symbol.DEFMETHOD("has_const_pragma", function() {
+    var token = this.scope.body[0] && this.scope.body[0].start;
+    var comments = token && token.comments_before;
+    if (comments && comments.length > 0) {
+        var last = comments[comments.length - 1];
+        return /@const/.test(last.value);
+    }
+    return false;
+})
 
 AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options){
     return defaults(options, {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -358,13 +358,31 @@ AST_Symbol.DEFMETHOD("global", function(){
 });
 
 AST_Symbol.DEFMETHOD("has_const_pragma", function() {
-    var token = this.scope.body[0] && this.scope.body[0].start;
-    var comments = token && token.comments_before;
-    if (comments && comments.length > 0) {
-        var last = comments[comments.length - 1];
-        return /@const/.test(last.value);
-    }
-    return false;
+    var symbol = this;
+    var symbol_has_pragma = false;
+    var pragma_found = false;
+    var found_symbol = false;
+    // Walk the current scope, looking for a comment with the @const pragma.
+    // If it exists, mark a bool that will remain true only for the next iteration.
+    // If the next iteration is this symbol, then we return true.
+    // Otherwise we stop descending and get out of here.
+    var tw = new TreeWalker(function(node, descend){
+        // This is our symbol. Was the pragma before this?
+        if (node.name === symbol) {
+            found_symbol = true;
+            symbol_has_pragma = pragma_found;
+        }
+
+        // Look for the /** @const */ pragma
+        var comments_before = node.start && node.start.comments_before;
+        var lastComment = comments_before && comments_before[comments_before.length - 1];
+        pragma_found = lastComment && /@const/.test(lastComment.value);
+
+        // no need to descend after finding our node
+        return found_symbol;
+    });
+    this.scope.walk(tw);
+    return symbol_has_pragma;
 })
 
 AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options){

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -94,6 +94,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
     var scope = self.parent_scope = null;
     var labels = new Dictionary();
     var defun = null;
+    var last_var_had_const_pragma = false;
     var nesting = 0;
     var tw = new TreeWalker(function(node, descend){
         if (options.screw_ie8 && node instanceof AST_Catch) {
@@ -151,10 +152,13 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
             // later.
             (node.scope = defun.parent_scope).def_function(node);
         }
+        else if (node instanceof AST_Var) {
+            last_var_had_const_pragma = node.has_const_pragma();
+        }
         else if (node instanceof AST_SymbolVar
                  || node instanceof AST_SymbolConst) {
             var def = defun.def_variable(node);
-            def.constant = node instanceof AST_SymbolConst || node.has_const_pragma();
+            def.constant = node instanceof AST_SymbolConst || last_var_had_const_pragma;
             def.init = tw.parent().value;
         }
         else if (node instanceof AST_SymbolCatch) {
@@ -357,33 +361,11 @@ AST_Symbol.DEFMETHOD("global", function(){
     return this.definition().global;
 });
 
-AST_Symbol.DEFMETHOD("has_const_pragma", function() {
-    var symbol = this;
-    var symbol_has_pragma = false;
-    var pragma_found = false;
-    var found_symbol = false;
-    // Walk the current scope, looking for a comment with the @const pragma.
-    // If it exists, mark a bool that will remain true only for the next iteration.
-    // If the next iteration is this symbol, then we return true.
-    // Otherwise we stop descending and get out of here.
-    var tw = new TreeWalker(function(node, descend){
-        // This is our symbol. Was the pragma before this?
-        if (node.name === symbol) {
-            found_symbol = true;
-            symbol_has_pragma = pragma_found;
-        }
-
-        // Look for the /** @const */ pragma
-        var comments_before = node.start && node.start.comments_before;
-        var lastComment = comments_before && comments_before[comments_before.length - 1];
-        pragma_found = lastComment && /@const/.test(lastComment.value);
-
-        // no need to descend after finding our node
-        return found_symbol;
-    });
-    this.scope.walk(tw);
-    return symbol_has_pragma;
-})
+AST_Var.DEFMETHOD("has_const_pragma", function() {
+    var comments_before = this.start && this.start.comments_before;
+    var lastComment = comments_before && comments_before[comments_before.length - 1];
+    return lastComment && /@const/.test(lastComment.value);
+});
 
 AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options){
     return defaults(options, {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -364,7 +364,7 @@ AST_Symbol.DEFMETHOD("global", function(){
 AST_Var.DEFMETHOD("has_const_pragma", function() {
     var comments_before = this.start && this.start.comments_before;
     var lastComment = comments_before && comments_before[comments_before.length - 1];
-    return lastComment && /@const/.test(lastComment.value);
+    return lastComment && /@const\b/.test(lastComment.value);
 });
 
 AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options){

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -87,3 +87,49 @@ dead_code_constant_boolean_should_warn_more: {
         var moo;
     }
 }
+
+dead_code_const_declaration: {
+    options = {
+        dead_code    : true,
+        loops        : true,
+        booleans     : true,
+        conditionals : true,
+        evaluate     : true
+    };
+    input: {
+        const CONST_FOO = false;
+        if (CONST_FOO) {
+            console.log("unreachable");
+            var moo;
+            function bar() {}
+        }
+    }
+    expect: {
+        const CONST_FOO = !1;
+        var moo;
+        function bar() {}
+    }
+}
+
+dead_code_const_annotation: {
+    options = {
+        dead_code    : true,
+        loops        : true,
+        booleans     : true,
+        conditionals : true,
+        evaluate     : true
+    };
+    input: {
+        /** @const*/ var CONST_FOO_ANN = false;
+        if (CONST_FOO_ANN) {
+            console.log("unreachable");
+            var moo;
+            function bar() {}
+        }
+    }
+    expect: {
+        var CONST_FOO_ANN = !1;
+        var moo;
+        function bar() {}
+    }
+}

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -97,6 +97,7 @@ dead_code_const_declaration: {
         evaluate     : true
     };
     input: {
+        var unused;
         const CONST_FOO = false;
         if (CONST_FOO) {
             console.log("unreachable");
@@ -105,6 +106,7 @@ dead_code_const_declaration: {
         }
     }
     expect: {
+        var unused;
         const CONST_FOO = !1;
         var moo;
         function bar() {}
@@ -120,7 +122,8 @@ dead_code_const_annotation: {
         evaluate     : true
     };
     input: {
-        /** @const*/ var CONST_FOO_ANN = false;
+        var unused;
+        /** @const */ var CONST_FOO_ANN = false;
         if (CONST_FOO_ANN) {
             console.log("unreachable");
             var moo;
@@ -128,8 +131,52 @@ dead_code_const_annotation: {
         }
     }
     expect: {
+        var unused;
         var CONST_FOO_ANN = !1;
         var moo;
         function bar() {}
+    }
+}
+
+dead_code_const_annotation_complex_scope: {
+    options = {
+        dead_code    : true,
+        loops        : true,
+        booleans     : true,
+        conditionals : true,
+        evaluate     : true
+    };
+    input: {
+        var unused_var;
+        /** @const */ var test = 'test';
+        /** @const */ var CONST_FOO_ANN = false;
+        var unused_var_2;
+        if (CONST_FOO_ANN) {
+            console.log("unreachable");
+            var moo;
+            function bar() {}
+        }
+        if (test === 'test') {
+            var beef = 'good';
+            /** @const */ var meat = 'beef';
+            var pork = 'bad';
+            if (meat === 'pork') {
+                console.log('also unreachable');
+            } else if (pork === 'good') {
+                console.log('reached, not const');
+            }
+        }
+    }
+    expect: {
+        var unused_var;
+        var test = 'test';
+        var CONST_FOO_ANN = !1;
+        var unused_var_2;
+        var moo;
+        function bar() {}
+        var beef = 'good';
+        var meat = 'beef';
+        var pork = 'bad';
+        'good' === pork && console.log('reached, not const');
     }
 }

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -138,6 +138,29 @@ dead_code_const_annotation: {
     }
 }
 
+dead_code_const_annotation_regex: {
+    options = {
+        dead_code    : true,
+        loops        : true,
+        booleans     : true,
+        conditionals : true,
+        evaluate     : true
+    };
+    input: {
+        var unused;
+        // @constraint this shouldn't be a constant
+        var CONST_FOO_ANN = false;
+        if (CONST_FOO_ANN) {
+            console.log("reachable");
+        }
+    }
+    expect: {
+        var unused;
+        var CONST_FOO_ANN = !1;
+        CONST_FOO_ANN && console.log('reachable');
+    }
+}
+
 dead_code_const_annotation_complex_scope: {
     options = {
         dead_code    : true,
@@ -149,7 +172,8 @@ dead_code_const_annotation_complex_scope: {
     input: {
         var unused_var;
         /** @const */ var test = 'test';
-        /** @const */ var CONST_FOO_ANN = false;
+        // @const
+        var CONST_FOO_ANN = false;
         var unused_var_2;
         if (CONST_FOO_ANN) {
             console.log("unreachable");


### PR DESCRIPTION
Fixes older browser support for consts and allows more flexibility
in dead code removal.

This means that this:

```js
/** @const */ var __DEV__ = false; // could be a NODE_ENV check with envify
if (__DEV__) {
  do_something_expensive();
}
```

will compile to:

```
var __DEV__ = false;
```

successfully removing the dead code without requiring the `const` keyword, which is not supported in many browsers.

This was born from https://github.com/nodejs/node/issues/3104#issuecomment-161444629, essentially mimicking Closure Compiler's behavior on this. This annotation will allow us to keep the bundle ES5-compliant, pre-compute the environment (to fix [Node's slow `process.env` performance](https://github.com/facebook/react/issues/812)), and successfully eliminate dead code in browser builds both built by the package maintainers and those consumed by webpack/browserify users who are using this version of UglifyJS2.

Please let me know if I'm not on the right track with this PR - I am not very familiar with this project.

Also fixes #133.