### PR TITLE
Screw IE by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The available options are:
   --in-source-map               Input source map, useful if you're compressing
                                 JS that was generated from some other original
                                 code.
-  --screw-ie8                   Pass this flag if you don't care about full
+  --support-old-ie              Pass this flag if you don't care about full
                                 compliance with Internet Explorer 6-8 quirks
                                 (by default UglifyJS will try to be IE-proof).
   --expr                        Parse a single expression, rather than a

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -24,7 +24,7 @@ mangling you need to use `-c` and `-m`.\
     .describe("source-map-url", "The path to the source map to be added in //# sourceMappingURL.  Defaults to the value passed with --source-map.")
     .describe("source-map-include-sources", "Pass this flag if you want to include the content of source files in the source map as sourcesContent property.")
     .describe("in-source-map", "Input source map, useful if you're compressing JS that was generated from some other original code.")
-    .describe("screw-ie8", "Pass this flag if you don't care about full compliance with Internet Explorer 6-8 quirks (by default UglifyJS will try to be IE-proof).")
+    .describe("support-old-ie", "Pass this flag if you care about full compliance with Internet Explorer 6-8 quirks (by default UglifyJS will try to be IE-proof).")
     .describe("expr", "Parse a single expression, rather than a program (for parsing JSON)")
     .describe("p", "Skip prefix for original filenames that appear in source maps. \
 For example -p 3 will drop 3 directories from file names and ensure they are relative paths. \
@@ -110,7 +110,7 @@ You need to pass an argument to this option to specify the name that your module
 
     .boolean("expr")
     .boolean("source-map-include-sources")
-    .boolean("screw-ie8")
+    .boolean("support-old-ie")
     .boolean("export-all")
     .boolean("self")
     .boolean("v")
@@ -219,10 +219,10 @@ var OUTPUT_OPTIONS = {
     quote_style : ARGS.quotes != null ? ARGS.quotes : 0
 };
 
-if (ARGS.screw_ie8) {
-    if (COMPRESS) COMPRESS.screw_ie8 = true;
-    if (MANGLE) MANGLE.screw_ie8 = true;
-    OUTPUT_OPTIONS.screw_ie8 = true;
+if (ARGS.support_old_ie) {
+    if (COMPRESS) COMPRESS.screw_ie8 = false;
+    if (MANGLE) MANGLE.screw_ie8 = false;
+    OUTPUT_OPTIONS.screw_ie8 = false;
 }
 
 if (ARGS.keep_fnames) {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -71,7 +71,7 @@ function Compressor(options, false_by_default) {
         pure_getters  : false,
         pure_funcs    : null,
         negate_iife   : !false_by_default,
-        screw_ie8     : false,
+        screw_ie8     : true,
         drop_console  : false,
         angular       : false,
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -62,7 +62,7 @@ function OutputStream(options) {
         comments         : false,
         shebang          : true,
         preserve_line    : false,
-        screw_ie8        : false,
+        screw_ie8        : true,
         preamble         : null,
         quote_style      : 0
     }, true);

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -85,7 +85,7 @@ SymbolDef.prototype = {
 
 AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
     options = defaults(options, {
-        screw_ie8: false,
+        screw_ie8: true,
         cache: null
     });
 
@@ -373,7 +373,7 @@ AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options){
         eval        : false,
         sort        : false,
         toplevel    : false,
-        screw_ie8   : false,
+        screw_ie8   : true,
         keep_fnames : false
     });
 });

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -12,7 +12,8 @@ keep_properties: {
 
 dot_properties: {
     options = {
-        properties: true
+        properties: true,
+        screw_ie8: false
     };
     input: {
         a["foo"] = "bar";
@@ -34,8 +35,7 @@ dot_properties: {
 
 dot_properties_es5: {
     options = {
-        properties: true,
-        screw_ie8: true
+        properties: true
     };
     input: {
         a["foo"] = "bar";


### PR DESCRIPTION
Guys it's happening. Microsoft discontinued support for IE 8 on **January 16, 2016**. The ride's over. 
This is a hard deadline. Only IE 9 and up will be supported for consumer versions of Windows.

See: https://www.microsoft.com/en-us/WindowsForBusiness/End-of-IE-support and https://support.microsoft.com/en-us/lifecycle#gp/Microsoft-Internet-Explorer

The `screw_ie8` option should be `true` by default. 

However, I do not think we should [actively remove IE 6-8–related](https://github.com/askmatey/UglifyJS2/tree/remove-ie-support) code quite yet, but the maintainers should *deprioritize* new IE bugs that are reported. This is just one man's opinion.