### PR TITLE
fix bug in collapse_vars for right side of "||" and "&&"

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -312,8 +312,11 @@ merge(Compressor.prototype, {
                                 || node instanceof AST_Try
                                 || node instanceof AST_With
                                 || node instanceof AST_IterationStatement
+                                || (parent instanceof AST_Binary
+                                    && (parent.operator == "&&" || parent.operator == "||")
+                                    && node === parent.right)
                                 || (parent instanceof AST_Switch && node !== parent.expression)) {
-                                return unwind = true, node;
+                                return side_effects_encountered = unwind = true, node;
                             }
                         },
                         function postorder(node) {

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -1045,3 +1045,45 @@ collapse_vars_arguments: {
     }
 }
 
+collapse_vars_short_circuit: {
+    options = {
+        collapse_vars:true, sequences:true, properties:true, dead_code:true, conditionals:true,
+        comparisons:true, evaluate:true, booleans:true, loops:true, unused:true, hoist_funs:true,
+        keep_fargs:true, if_return:true, join_vars:true, cascade:true, side_effects:true
+    }
+    input: {
+        function f0(x) { var a = foo(), b = bar(); return b || x; }
+        function f1(x) { var a = foo(), b = bar(); return b && x; }
+        function f2(x) { var a = foo(), b = bar(); return x && a && b; }
+        function f3(x) { var a = foo(), b = bar(); return a && x; }
+        function f4(x) { var a = foo(), b = bar(); return a && x && b; }
+        function f5(x) { var a = foo(), b = bar(); return x || a || b; }
+        function f6(x) { var a = foo(), b = bar(); return a || x || b; }
+        function f7(x) { var a = foo(), b = bar(); return a && b && x; }
+        function f8(x,y) { var a = foo(), b = bar(); return (x || a) && (y || b); }
+        function f9(x,y) { var a = foo(), b = bar(); return (x && a) || (y && b); }
+        function f10(x,y) { var a = foo(), b = bar(); return (x - a) || (y - b); }
+        function f11(x,y) { var a = foo(), b = bar(); return (x - b) || (y - a); }
+        function f12(x,y) { var a = foo(), b = bar(); return (x - y) || (b - a); }
+        function f13(x,y) { var a = foo(), b = bar(); return (a - b) || (x - y); }
+        function f14(x,y) { var a = foo(), b = bar(); return (b - a) || (x - y); }
+    }
+    expect: {
+        function f0(x) { foo(); return bar() || x; }
+        function f1(x) { foo(); return bar() && x; }
+        function f2(x) { var a = foo(), b = bar(); return x && a && b; }
+        function f3(x) { var a = foo(); bar(); return a && x; }
+        function f4(x) { var a = foo(), b = bar(); return a && x && b; }
+        function f5(x) { var a = foo(), b = bar(); return x || a || b; }
+        function f6(x) { var a = foo(), b = bar(); return a || x || b; }
+        function f7(x) { var a = foo(), b = bar(); return a && b && x; }
+        function f8(x,y) { var a = foo(), b = bar(); return (x || a) && (y || b); }
+        function f9(x,y) { var a = foo(), b = bar(); return (x && a) || (y && b); }
+        function f10(x,y) { var a = foo(), b = bar(); return (x - a) || (y - b); }
+        function f11(x,y) { var a = foo(); return (x - bar()) || (y - a); }
+        function f12(x,y) { var a = foo(), b = bar(); return (x - y) || (b - a); }
+        function f13(x,y) { return (foo() - bar()) || (x - y); }
+        function f14(x,y) { var a = foo(); return (bar() - a) || (x - y); }
+    }
+}
+


### PR DESCRIPTION
Cannot collapse non-constant vars on right side of "||" and "&&" due to their side effects not getting invoked if short circuited.