### PR TITLE
collapse_vars: fix bug in repeated var defs of same name

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -255,16 +255,25 @@ merge(Compressor.prototype, {
                 var var_defs = prev_stat.definitions;
                 if (var_defs == null) continue;
 
-                // Scan variable definitions from right to left.
+                var var_names_seen = {};
                 var side_effects_encountered = false;
                 var lvalues_encountered = false;
                 var lvalues = {};
+
+                // Scan variable definitions from right to left.
                 for (var var_defs_index = var_defs.length; --var_defs_index >= 0;) {
+
+                    // Obtain var declaration and var name with basic sanity check.
                     var var_decl = var_defs[var_defs_index];
-                    if (var_decl.value == null) continue;
+                    if (var_decl.value == null) break;
+                    var var_name = var_decl.name.name;
+                    if (!var_name || !var_name.length) break;
+
+                    // Bail if we've seen a var definition of same name before.
+                    if (var_name in var_names_seen) break;
+                    var_names_seen[var_name] = true;
 
                     // Only interested in cases with just one reference to the variable.
-                    var var_name = var_decl.name.name;
                     var def = self.find_variable && self.find_variable(var_name);
                     if (!def || !def.references || def.references.length !== 1 || var_name == "arguments") {
                         side_effects_encountered = true;

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -685,19 +685,35 @@ collapse_vars_repeated: {
             var dummy = 3, a = 5, unused = 2, a = 1, a = 3;
             return -a;
         }
-        function f2() {
-            var a = 3, a = a + 2;
+        function f2(x) {
+            var a = 3, a = x;
             return a;
         }
+        (function(x){
+             var a = "GOOD" + x, e = "BAD", k = "!", e = a;
+             console.log(e + k);
+        })("!"),
+
+        (function(x){
+            var a = "GOOD" + x, e = "BAD" + x, k = "!", e = a;
+            console.log(e + k);
+        })("!");
     }
     expect: {
         function f1() {
             return -3
         }
-        function f2() {
-            var a = 3, a = a + 2;
-            return a
+        function f2(x) {
+            return x
         }
+        (function(x){
+             var a = "GOOD" + x, e = "BAD", e = a;
+             console.log(e + "!");
+        })("!"),
+        (function(x){
+            var a = "GOOD" + x, e = "BAD" + x, e = a;
+            console.log(e + "!");
+        })("!");
     }
 }
 
@@ -1084,36 +1100,6 @@ collapse_vars_short_circuit: {
         function f12(x,y) { var a = foo(), b = bar(); return (x - y) || (b - a); }
         function f13(x,y) { return (foo() - bar()) || (x - y); }
         function f14(x,y) { var a = foo(); return (bar() - a) || (x - y); }
-    }
-}
-
-collapse_vars_repeat_of_same_var_name: {
-    options = {
-        collapse_vars:true, sequences:true, properties:true, dead_code:true, conditionals:true,
-        comparisons:true, evaluate:true, booleans:true, loops:true, unused:true, hoist_funs:true,
-        keep_fargs:true, if_return:true, join_vars:true, cascade:true, side_effects:true
-    }
-    input: {
-        (function(x){
-             var a = "GOOD" + x, e = "BAD", k = "?", e = a;
-             console.log(e + k);
-        })("!"),
-
-        (function(x){
-            var a = "GOOD" + x, e = "BAD" + x, k = "?", e = a;
-            console.log(e + k);
-        })("!");
-    }
-    expect: {
-        (function(x){
-             var a = "GOOD" + x, e = "BAD", e = a;
-             console.log(e + "?");
-        })("!"),
-
-        (function(x){
-            var a = "GOOD" + x, e = "BAD" + x, e = a;
-            console.log(e + "?");
-        })("!");
     }
 }
 

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -1087,3 +1087,33 @@ collapse_vars_short_circuit: {
     }
 }
 
+collapse_vars_repeat_of_same_var_name: {
+    options = {
+        collapse_vars:true, sequences:true, properties:true, dead_code:true, conditionals:true,
+        comparisons:true, evaluate:true, booleans:true, loops:true, unused:true, hoist_funs:true,
+        keep_fargs:true, if_return:true, join_vars:true, cascade:true, side_effects:true
+    }
+    input: {
+        (function(x){
+             var a = "GOOD" + x, e = "BAD", k = "?", e = a;
+             console.log(e + k);
+        })("!"),
+
+        (function(x){
+            var a = "GOOD" + x, e = "BAD" + x, k = "?", e = a;
+            console.log(e + k);
+        })("!");
+    }
+    expect: {
+        (function(x){
+             var a = "GOOD" + x, e = "BAD", e = a;
+             console.log(e + "?");
+        })("!"),
+
+        (function(x){
+            var a = "GOOD" + x, e = "BAD" + x, e = a;
+            console.log(e + "?");
+        })("!");
+    }
+}
+


### PR DESCRIPTION
Found this bug from JS in the wild. See new test case for details.