### PR TITLE
collapse_vars: fix if/else and ternary operator side effects

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -321,6 +321,8 @@ merge(Compressor.prototype, {
                                 || node instanceof AST_Try
                                 || node instanceof AST_With
                                 || node instanceof AST_IterationStatement
+                                || (parent instanceof AST_If          && node !== parent.condition)
+                                || (parent instanceof AST_Conditional && node !== parent.condition)
                                 || (parent instanceof AST_Binary
                                     && (parent.operator == "&&" || parent.operator == "||")
                                     && node === parent.right)

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -320,6 +320,7 @@ merge(Compressor.prototype, {
                             if (node instanceof AST_Lambda
                                 || node instanceof AST_Try
                                 || node instanceof AST_With
+                                || node instanceof AST_Case
                                 || node instanceof AST_IterationStatement
                                 || (parent instanceof AST_If          && node !== parent.condition)
                                 || (parent instanceof AST_Conditional && node !== parent.condition)

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -1103,3 +1103,53 @@ collapse_vars_short_circuit: {
     }
 }
 
+collapse_vars_short_circuited_conditions: {
+    options = {
+        collapse_vars: true,
+        sequences:     false,
+        dead_code:     true,
+        conditionals:  false,
+        comparisons:   false,
+        evaluate:      true,
+        booleans:      true,
+        loops:         true,
+        unused:        true,
+        hoist_funs:    true,
+        keep_fargs:    true,
+        if_return:     false,
+        join_vars:     true,
+        cascade:       true,
+        side_effects:  true,
+    }
+    input: {
+        function c1(x) { var a = foo(), b = bar(), c = baz(); return a ? b : c; }
+        function c2(x) { var a = foo(), b = bar(), c = baz(); return a ? c : b; }
+        function c3(x) { var a = foo(), b = bar(), c = baz(); return b ? a : c; }
+        function c4(x) { var a = foo(), b = bar(), c = baz(); return b ? c : a; }
+        function c5(x) { var a = foo(), b = bar(), c = baz(); return c ? a : b; }
+        function c6(x) { var a = foo(), b = bar(), c = baz(); return c ? b : a; }
+
+        function i1(x) { var a = foo(), b = bar(), c = baz(); if (a) return b; else return c; }
+        function i2(x) { var a = foo(), b = bar(), c = baz(); if (a) return c; else return b; }
+        function i3(x) { var a = foo(), b = bar(), c = baz(); if (b) return a; else return c; }
+        function i4(x) { var a = foo(), b = bar(), c = baz(); if (b) return c; else return a; }
+        function i5(x) { var a = foo(), b = bar(), c = baz(); if (c) return a; else return b; }
+        function i6(x) { var a = foo(), b = bar(), c = baz(); if (c) return b; else return a; }
+    }
+    expect: {
+        function c1(x) { var a = foo(), b = bar(), c = baz(); return a ? b : c; }
+        function c2(x) { var a = foo(), b = bar(), c = baz(); return a ? c : b; }
+        function c3(x) { var a = foo(), b = bar(), c = baz(); return b ? a : c; }
+        function c4(x) { var a = foo(), b = bar(), c = baz(); return b ? c : a; }
+        function c5(x) { var a = foo(), b = bar(); return baz() ? a : b; }
+        function c6(x) { var a = foo(), b = bar(); return baz() ? b : a; }
+
+        function i1(x) { var a = foo(), b = bar(), c = baz(); if (a) return b; else return c; }
+        function i2(x) { var a = foo(), b = bar(), c = baz(); if (a) return c; else return b; }
+        function i3(x) { var a = foo(), b = bar(), c = baz(); if (b) return a; else return c; }
+        function i4(x) { var a = foo(), b = bar(), c = baz(); if (b) return c; else return a; }
+        function i5(x) { var a = foo(), b = bar(); if (baz()) return a; else return b; }
+        function i6(x) { var a = foo(), b = bar(); if (baz()) return b; else return a; }
+    }
+}
+


### PR DESCRIPTION
Ugh. I'm surprised I missed this one when I fixed the `&&` and `||` short circuiting yesterday.