### PR TITLE
fix: don't fail if this.definition() is undefined while mangling es6 classes methods

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -350,7 +350,8 @@ AST_Scope.DEFMETHOD("references", function(sym){
 });
 
 AST_Symbol.DEFMETHOD("unmangleable", function(options){
-    return this.definition().unmangleable(options);
+    var def = this.definition();
+    return def && def.unmangleable(options);
 });
 
 // property accessors are not mangleable


### PR DESCRIPTION
Hi,

I run into this issue while working with the harmony branch #448.

Running `uglifyjs --verbose --compress --mangle --screw-ie8 class.js` with `class.js`:

```
class Foo {
  bar() {
  }
}
```

Fails with:

```
undefined:4041
  return this.definition().unmangleable(options);
TypeError: Cannot read property 'unmangleable' of undefined
    at AST_Node.eval [as unmangleable] (eval at <anonymous> (/Users/craverod/opensource/panels/panels/node_modules/uglify-js/tools/node.js:22:1), <anonymous>:4041:27)
    at Object.eval [as visit] (eval at <anonymous> (/Users/craverod/opensource/panels/panels/node_modules/uglify-js/tools/node.js:22:1), <anonymous>:4214:53)
    at Object.TreeWalker._visit (eval at <anonymous> (/Users/craverod/opensource/panels/panels/node_modules/uglify-js/tools/node.js:22:1), <anonymous>:1493:24)
    at AST_Node.DEFNODE._walk (eval at <anonymous> (/Users/craverod/opensource/panels/panels/node_modules/uglify-js/tools/node.js:22:1), <anonymous>:415:24)
    at AST_Node.eval (eval at <anonymous> (/Users/craverod/opensource/panels/panels/node_modules/uglify-js/tools/node.js:22:1), <anonymous>:775:38)
    at Object.TreeWalker._visit (eval at <anonymous> (/Users/craverod/opensource/panels/panels/node_modules/uglify-js/tools/node.js:22:1), <anonymous>:1497:21)
    at AST_Node.DEFNODE._walk (eval at <anonymous> (/Users/craverod/opensource/panels/panels/node_modules/uglify-js/tools/node.js:22:1), <anonymous>:774:24)
    at eval (eval at <anonymous> (/Users/craverod/opensource/panels/panels/node_modules/uglify-js/tools/node.js:22:1), <anonymous>:1303:22)
    at Array.forEach (native)
    at AST_Node.eval (eval at <anonymous> (/Users/craverod/opensource/panels/panels/node_modules/uglify-js/tools/node.js:22:1), <anonymous>:1302:29)
```

This PR sorts it out (it gives me: `class Foo{bar(){}}`) but it feels like the wrong hack.
I don't know what's best and whether we can even try to mangle the method or not, mainly because
it's the classes' external API and doing so would prevent others from using it outside the minified
source.

Thoughts?
Thanks!
Darío