### PR TITLE
Create and map `bare-returns` into new `parse` property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ Other options:
   Pass an object to specify custom [compressor options][compressor].
 
 - `parse` (default `{}`) — pass an object if you wish to specify
-  additional [parser options][parser]
+  additional [parser options][parser].
 
 
 ##### mangleProperties options

--- a/README.md
+++ b/README.md
@@ -638,6 +638,10 @@ Other options:
 - `compress` (default `{}`) — pass `false` to skip compressing entirely.
   Pass an object to specify custom [compressor options][compressor].
 
+- `parse` (default `{}`) — pass an object if you wish to specify
+  additional [parser options][parser]
+
+
 ##### mangleProperties options
 
  - `regex` — Pass a RegExp to only mangle certain names (maps to the `--mange-regex` CLI arguments option)
@@ -801,3 +805,4 @@ The `source_map_options` (optional) can contain the following properties:
   [sm-spec]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit
   [codegen]: http://lisperator.net/uglifyjs/codegen
   [compressor]: http://lisperator.net/uglifyjs/compress
+  [parser]: http://lisperator.net/uglifyjs/parser

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ The available options are:
   --noerr                       Don't throw an error for unknown options in -c,
                                 -b or -m.
   --bare-returns                Allow return outside of functions.  Useful when
-                                minifying CommonJS modules.
+                                minifying CommonJS modules and Userscripts that
+                                may be anonymous function wrapped (IIFE) by the
+                                .user.js engine `caller`.
   --keep-fnames                 Do not mangle/drop function names.  Useful for
                                 code relying on Function.prototype.name.
   --reserved-file               File containing reserved names
@@ -654,6 +656,8 @@ properties are available:
 - `filename` — the name of the file where this code is coming from
 - `toplevel` — a `toplevel` node (as returned by a previous invocation of
   `parse`)
+- `bare_returns` — Allow return outside of functions. (maps to the
+  `--bare-returns` CLI arguments option)
 
 The last two options are useful when you'd like to minify multiple files and
 get a single file as the output and a proper source map.  Our CLI tool does

--- a/README.md
+++ b/README.md
@@ -660,11 +660,11 @@ properties are available:
 
 - `strict` — disable automatic semicolon insertion and support for trailing
   comma in arrays and objects
+- `bare_returns` — Allow return outside of functions. (maps to the
+  `--bare-returns` CLI arguments option)
 - `filename` — the name of the file where this code is coming from
 - `toplevel` — a `toplevel` node (as returned by a previous invocation of
   `parse`)
-- `bare_returns` — Allow return outside of functions. (maps to the
-  `--bare-returns` CLI arguments option)
 
 The last two options are useful when you'd like to minify multiple files and
 get a single file as the output and a proper source map.  Our CLI tool does

--- a/tools/node.js
+++ b/tools/node.js
@@ -40,7 +40,8 @@ exports.minify = function(files, options) {
         warnings     : false,
         mangle       : {},
         output       : null,
-        compress     : {}
+        compress     : {},
+        parse        : {}
     });
     UglifyJS.base54.reset();
 
@@ -60,7 +61,8 @@ exports.minify = function(files, options) {
             sourcesContent[file] = code;
             toplevel = UglifyJS.parse(code, {
                 filename: options.fromString ? i : file,
-                toplevel: toplevel
+                toplevel: toplevel,
+                bare_returns: options.parse ? options.parse.bare_returns : undefined
             });
         });
     }

--- a/tools/node.js
+++ b/tools/node.js
@@ -43,7 +43,7 @@ exports.minify = function(files, options) {
         nameCache        : null,
         output           : null,
         compress         : {},
-        parse        : {}
+        parse            : {}
     });
     UglifyJS.base54.reset();
 


### PR DESCRIPTION
* Following as much previous structure as possible... see analysis at https://github.com/mishoo/UglifyJS2/issues/935#issuecomment-180712909
* Using `undefined` as default since is technically assigned elsewhere
* Not entirely sure if https://github.com/mishoo/UglifyJS2/blob/master/test/compress/return_undefined.js is the test for this or not
* Change README.md to reflect and add additional sub-note about Userscript IIFE possibility

Applies to mishoo/UglifyJS2#935