### PR TITLE
Allow cli options to be specified in separate definitions

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -504,6 +504,8 @@ function getOptions(x, constants) {
     if (x == null) return null;
     var ret = {};
     if (x !== "") {
+        if (Array.isArray(x)) x = x.map(function (v) { return "(" + v + ")"; }).join(", ");
+
         var ast;
         try {
             ast = UglifyJS.parse(x, { expression: true });


### PR DESCRIPTION
Fix for #963. This allows stuff like `--define a=1 --define b=1` besides only `--define a=1,b=1`