### PR TITLE
Revert "using the original sourcemap as the base"

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -53,16 +53,11 @@ function SourceMap(options) {
         orig_line_diff : 0,
         dest_line_diff : 0,
     });
+    var generator = new MOZ_SourceMap.SourceMapGenerator({
+        file       : options.file,
+        sourceRoot : options.root
+    });
     var orig_map = options.orig && new MOZ_SourceMap.SourceMapConsumer(options.orig);
-    var generator;
-    if (orig_map) {
-      generator = MOZ_SourceMap.SourceMapGenerator.fromSourceMap(orig_map);
-    } else {
-        generator = new MOZ_SourceMap.SourceMapGenerator({
-            file       : options.file,
-            sourceRoot : options.root
-        });
-    }
     function add(source, gen_line, gen_col, orig_line, orig_col, name) {
         if (orig_map) {
             var info = orig_map.originalPositionFor({
@@ -83,7 +78,7 @@ function SourceMap(options) {
             source    : source,
             name      : name
         });
-    }
+    };
     return {
         add        : add,
         get        : function() { return generator },


### PR DESCRIPTION
This reverts commit ad18689d926d25c7a25b95c630c2ad05b7b5f5b5.

Reason for revert: introduce issue #882

Currently, generated sourcemap contains copy of all existing mappings and new mappings from uglified code to original one.
However, previous mapping are no longer valid and shouldn't be added in the new source.