### PR TITLE
Add 'let' to the keywords list.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -44,7 +44,7 @@
 
 "use strict";
 
-var KEYWORDS = 'break case catch const continue debugger default delete do else finally for function if in instanceof new return switch throw try typeof var void while with';
+var KEYWORDS = 'break case catch const continue debugger default delete do else finally for function if in instanceof let new return switch throw try typeof var void while with';
 var KEYWORDS_ATOM = 'false null true';
 var RESERVED_WORDS = 'abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized this throws transient volatile yield'
     + " " + KEYWORDS_ATOM + " " + KEYWORDS;


### PR DESCRIPTION
Uglyfied code could reach "var let=...something..." in some cases, as discovered by: https://twitter.com/colinmegill/status/702191711494144000 , so the compiled file breaks.

I don't know about UglifyJS internals but this little trick did it for me.