### PR TITLE
ES6 import and export statements

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -702,6 +702,13 @@ var AST_Const = DEFNODE("Const", null, {
     $documentation: "A `const` statement"
 }, AST_Definitions);
 
+var AST_Import = DEFNODE("Import", "module_name", {
+    $documentation: "An `import` statement",
+    $propdoc: {
+        module_name: "[AST_String] String literal describing where this module came from",
+    }
+});
+
 var AST_VarDef = DEFNODE("VarDef", "name value", {
     $documentation: "A variable declaration; only appears in a AST_Definitions node",
     $propdoc: {

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -738,6 +738,15 @@ var AST_Import = DEFNODE("Import", "imported_name imported_names module_name", {
     }
 });
 
+var AST_Export = DEFNODE("Export", "exported_definition exported_value is_default", {
+    $documentation: "An `export` statement",
+    $propdoc: {
+        exported_definition: "[AST_Defun|AST_Definitions|AST_DefClass?] An exported definition",
+        exported_value: "[AST_Node?] An exported value",
+        is_default: "[Boolean] Whether this is the default exported value of this module"
+    },
+}, AST_Statement);
+
 var AST_VarDef = DEFNODE("VarDef", "name value", {
     $documentation: "A variable declaration; only appears in a AST_Definitions node",
     $propdoc: {

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -707,6 +707,12 @@ var AST_NameImport = DEFNODE("NameImport", "foreign_name name", {
     $propdoc: {
         foreign_name: "[AST_SymbolImportForeign] The name being imported (as specified in the module)",
         name: "[AST_SymbolImport] The name as it becomes available to this module."
+    },
+    _walk: function (visitor) {
+        return visitor._visit(this, function() {
+            this.foreign_name._walk(visitor);
+            this.name._walk(visitor);
+        });
     }
 })
 
@@ -721,6 +727,11 @@ var AST_Import = DEFNODE("Import", "imported_name imported_names module_name", {
         return visitor._visit(this, function() {
             if (this.imported_name) {
                 this.imported_name._walk(visitor);
+            }
+            if (this.imported_names) {
+                this.imported_names.forEach(function (name_import) {
+                    name_import._walk(visitor);
+                });
             }
             this.module_name._walk(visitor);
         });

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -702,10 +702,19 @@ var AST_Const = DEFNODE("Const", null, {
     $documentation: "A `const` statement"
 }, AST_Definitions);
 
-var AST_Import = DEFNODE("Import", "module_name", {
+var AST_Import = DEFNODE("Import", "imported_name module_name", {
     $documentation: "An `import` statement",
     $propdoc: {
+        imported_name: "[AST_SymbolImport] The name of the variable holding the module's default export.",
         module_name: "[AST_String] String literal describing where this module came from",
+    },
+    _walk: function(visitor) {
+        return visitor._visit(this, function() {
+            if (this.imported_name) {
+                this.imported_name._walk(visitor);
+            }
+            this.module_name._walk(visitor);
+        });
     }
 });
 
@@ -1070,6 +1079,10 @@ var AST_SymbolClass = DEFNODE("SymbolClass", null, {
 
 var AST_SymbolCatch = DEFNODE("SymbolCatch", null, {
     $documentation: "Symbol naming the exception in catch",
+}, AST_SymbolDeclaration);
+
+var AST_SymbolImport = DEFNODE("SymbolImport", null, {
+    $documentation: "Symbol refering to an imported name",
 }, AST_SymbolDeclaration);
 
 var AST_Label = DEFNODE("Label", "references", {

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -702,10 +702,19 @@ var AST_Const = DEFNODE("Const", null, {
     $documentation: "A `const` statement"
 }, AST_Definitions);
 
-var AST_Import = DEFNODE("Import", "imported_name module_name", {
+var AST_NameImport = DEFNODE("NameImport", "foreign_name name", {
+    $documentation: "The part of the import statement that imports names from a module.",
+    $propdoc: {
+        foreign_name: "[AST_SymbolImportForeign] The name being imported (as specified in the module)",
+        name: "[AST_SymbolImport] The name as it becomes available to this module."
+    }
+})
+
+var AST_Import = DEFNODE("Import", "imported_name imported_names module_name", {
     $documentation: "An `import` statement",
     $propdoc: {
         imported_name: "[AST_SymbolImport] The name of the variable holding the module's default export.",
+        imported_names: "[AST_NameImport*] The names of non-default imported variables",
         module_name: "[AST_String] String literal describing where this module came from",
     },
     _walk: function(visitor) {
@@ -1084,6 +1093,10 @@ var AST_SymbolCatch = DEFNODE("SymbolCatch", null, {
 var AST_SymbolImport = DEFNODE("SymbolImport", null, {
     $documentation: "Symbol refering to an imported name",
 }, AST_SymbolDeclaration);
+
+var AST_SymbolImportForeign = DEFNODE("SymbolImportForeign", null, {
+    $documentation: "A symbol imported from a module, but it is defined in the other module, and its real name is irrelevant for this module's purposes",
+}, AST_Symbol);
 
 var AST_Label = DEFNODE("Label", "references", {
     $documentation: "Symbol naming a label (declaration)",

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -745,6 +745,16 @@ var AST_Export = DEFNODE("Export", "exported_definition exported_value is_defaul
         exported_value: "[AST_Node?] An exported value",
         is_default: "[Boolean] Whether this is the default exported value of this module"
     },
+    _walk: function (visitor) {
+        visitor._visit(this, function () {
+            if (this.exported_definition) {
+                this.exported_definition._walk(visitor);
+            }
+            if (this.exported_value) {
+                this.exported_value._walk(visitor);
+            }
+        });
+    }
 }, AST_Statement);
 
 var AST_VarDef = DEFNODE("VarDef", "name value", {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1775,6 +1775,10 @@ merge(Compressor.prototype, {
         return self;
     });
 
+    OPT(AST_Import, function(self, compressor) {
+        return self;
+    });
+
     OPT(AST_Function, function(self, compressor){
         self = AST_Lambda.prototype.optimize.call(self, compressor);
         if (compressor.option("unused") && !compressor.option("keep_fnames")) {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1025,6 +1025,7 @@ merge(Compressor.prototype, {
             var n = this.body.length;
             return n > 0 && aborts(this.body[n - 1]);
         };
+        def(AST_Import, function(){ return null; });
         def(AST_BlockStatement, block_aborts);
         def(AST_SwitchBranch, block_aborts);
         def(AST_If, function(){

--- a/lib/output.js
+++ b/lib/output.js
@@ -1037,6 +1037,12 @@ function OutputStream(options) {
     DEFPRINT(AST_Const, function(self, output){
         self._do_print(output, "const");
     });
+    DEFPRINT(AST_Import, function(self, output) {
+        output.print("import");
+        output.space();
+        self.module_name.print(output);
+        output.semicolon();
+    });
 
     function parenthesize_for_noin(node, output, noin) {
         if (!noin) node.print(output);

--- a/lib/output.js
+++ b/lib/output.js
@@ -1042,12 +1042,43 @@ function OutputStream(options) {
         output.space();
         if (self.imported_name) {
             self.imported_name.print(output);
+        }
+        if (self.imported_name && self.imported_names) {
+            output.print(",");
+            output.space();
+        }
+        if (self.imported_names) {
+            output.print("{");
+            self.imported_names.forEach(function(name_import, i) {
+                output.space();
+                name_import.print(output);
+                if (i < self.imported_names.length - 1) {
+                    output.print(",");
+                    output.space();
+                }
+            });
+            output.space();
+            output.print("}");
+        }
+        if (self.imported_name || self.imported_names) {
             output.space();
             output.print("from")
             output.space();
         }
         self.module_name.print(output);
         output.semicolon();
+    });
+
+    DEFPRINT(AST_NameImport, function(self, output) {
+        if (self.foreign_name) {
+            self.foreign_name.print(output);
+            output.space();
+            output.print("as");
+            output.space();
+            self.name.print(output);
+        } else {
+            self.name.print(output);
+        }
     });
 
     function parenthesize_for_noin(node, output, noin) {

--- a/lib/output.js
+++ b/lib/output.js
@@ -1085,6 +1085,21 @@ function OutputStream(options) {
         }
     });
 
+    DEFPRINT(AST_Export, function(self, output) {
+        output.print("export");
+        output.space();
+        if (self.is_default) {
+            output.print("default");
+            output.space();
+        }
+        if (self.exported_value) {
+            self.exported_value.print(output);
+        } else if (self.exported_definition) {
+            self.exported_definition.print(output);
+        }
+        output.semicolon();
+    });
+
     function parenthesize_for_noin(node, output, noin) {
         if (!noin) node.print(output);
         else try {

--- a/lib/output.js
+++ b/lib/output.js
@@ -1040,6 +1040,12 @@ function OutputStream(options) {
     DEFPRINT(AST_Import, function(self, output) {
         output.print("import");
         output.space();
+        if (self.imported_name) {
+            self.imported_name.print(output);
+            output.space();
+            output.print("from")
+            output.space();
+        }
         self.module_name.print(output);
         output.semicolon();
     });

--- a/lib/output.js
+++ b/lib/output.js
@@ -1070,8 +1070,12 @@ function OutputStream(options) {
     });
 
     DEFPRINT(AST_NameImport, function(self, output) {
-        if (self.foreign_name) {
-            self.foreign_name.print(output);
+        var definition = self.name.definition();
+        var names_are_different =
+            (definition && definition.mangled_name || self.name.name) !==
+            self.foreign_name.name;
+        if (names_are_different) {
+            output.print(self.foreign_name.name);
             output.space();
             output.print("as");
             output.space();

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1611,15 +1611,27 @@ function parse($TEXT, options) {
     }
 
     function import_() {
+        var start = prev();
+        var imported_name;
+        if (is("name")) {
+            imported_name = as_symbol(AST_SymbolImport);
+            expect_token("name", "from");
+        }
+        var mod_str = S.token;
+        if (mod_str.type !== 'string') {
+            unexpected();
+        }
+        next();
         return new AST_Import({
-            start: prev(),
+            start: start,
+            imported_name: imported_name,
             module_name: new AST_String({
-                start : S.token,
-                value : S.token.value,
-                quote : S.token.quote,
-                end   : S.token,
+                start: mod_str,
+                value: mod_str.value,
+                quote: mod_str.quote,
+                end: mod_str,
             }),
-            end: next(),
+            end: S.token,
         });
     }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1613,8 +1613,28 @@ function parse($TEXT, options) {
     function import_() {
         var start = prev();
         var imported_name;
+        var imported_names;
         if (is("name")) {
             imported_name = as_symbol(AST_SymbolImport);
+        }
+
+        if (is("punc", ",")) {
+            next();
+        }
+
+        if (is("punc", "{")) {
+            next();
+            imported_names = [];
+            while (!is("punc", "}")) {
+                imported_names.push(import_name());
+                if (is("punc", ",")) {
+                    next();
+                }
+            }
+            next();
+        }
+
+        if (imported_names || imported_name) {
             expect_token("name", "from");
         }
         var mod_str = S.token;
@@ -1625,6 +1645,7 @@ function parse($TEXT, options) {
         return new AST_Import({
             start: start,
             imported_name: imported_name,
+            imported_names: imported_names,
             module_name: new AST_String({
                 start: mod_str,
                 value: mod_str.value,
@@ -1633,6 +1654,25 @@ function parse($TEXT, options) {
             }),
             end: S.token,
         });
+    }
+
+    function import_name() {
+        var start = S.token;
+        var foreign_name;
+        var name;
+
+        if (peek().value === "as" && peek().type === "name") {
+            foreign_name = as_symbol(AST_SymbolImportForeign);
+            next();  // The "as" word
+        }
+        name = as_symbol(AST_SymbolImport);
+
+        return new AST_NameImport({
+            start: start,
+            foreign_name: foreign_name,
+            name: name,
+            end: prev(),
+        })
     }
 
     function as_property_name() {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -44,9 +44,9 @@
 
 "use strict";
 
-var KEYWORDS = 'break case catch class const continue debugger default delete do else extends finally for function if in instanceof new return switch throw try typeof var let void while with';
+var KEYWORDS = 'break case catch class const continue debugger default delete do else extends finally for function if in instanceof new return switch throw try typeof var let void while with import';
 var KEYWORDS_ATOM = 'false null true';
-var RESERVED_WORDS = 'abstract boolean byte char double enum export final float goto implements import int interface long native package private protected public short static super synchronized this throws transient volatile yield'
+var RESERVED_WORDS = 'abstract boolean byte char double enum export final float goto implements int interface long native package private protected public short static super synchronized this throws transient volatile yield'
     + " " + KEYWORDS_ATOM + " " + KEYWORDS;
 var KEYWORDS_BEFORE_EXPRESSION = 'return new delete throw else case';
 
@@ -909,6 +909,9 @@ function parse($TEXT, options) {
                     body       : statement()
                 });
 
+              case "import":
+                return tmp = import_(), semicolon(), tmp;
+
               default:
                 unexpected();
             }
@@ -1605,6 +1608,19 @@ function parse($TEXT, options) {
                 end   : prev()
             });
         }
+    }
+
+    function import_() {
+        return new AST_Import({
+            start: prev(),
+            module_name: new AST_String({
+                start : S.token,
+                value : S.token.value,
+                quote : S.token.quote,
+                end   : S.token,
+            }),
+            end: next(),
+        });
     }
 
     function as_property_name() {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -44,7 +44,7 @@
 
 "use strict";
 
-var KEYWORDS = 'break case catch class const continue debugger default delete do else extends finally for function if in instanceof new return switch throw try typeof var let void while with import';
+var KEYWORDS = 'break case catch class const continue debugger default delete do else extends finally for function if in instanceof new return switch throw try typeof var let void while with import export';
 var KEYWORDS_ATOM = 'false null true';
 var RESERVED_WORDS = 'abstract boolean byte char double enum export final float goto implements int interface long native package private protected public short static super synchronized this throws transient volatile yield'
     + " " + KEYWORDS_ATOM + " " + KEYWORDS;
@@ -912,6 +912,9 @@ function parse($TEXT, options) {
               case "import":
                 return tmp = import_(), semicolon(), tmp;
 
+              case "export":
+                return tmp = export_(), semicolon(), tmp;
+
               default:
                 unexpected();
             }
@@ -1681,6 +1684,36 @@ function parse($TEXT, options) {
             name: name,
             end: prev(),
         })
+    }
+
+    function export_() {
+        var start = S.token;
+        var is_default;
+        var exported_value;
+        var exported_definition;
+
+        if (is("keyword", "default")) {
+            is_default = true;
+            next();
+        }
+
+        var is_definition =
+            is("keyword", "var") || is("keyword", "let") || is("keyword", "const") ||
+            is("keyword", "class") || is("keyword", "function");
+
+        if (is_definition) {
+            exported_definition = statement();
+        } else {
+            exported_value = expression();
+        }
+
+        return new AST_Export({
+            start: start,
+            is_default: is_default,
+            exported_value: exported_value,
+            exported_definition: exported_definition,
+            end: prev(),
+        });
     }
 
     function as_property_name() {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1667,6 +1667,14 @@ function parse($TEXT, options) {
         }
         name = as_symbol(AST_SymbolImport);
 
+        if (foreign_name === undefined) {
+            foreign_name = new AST_SymbolImportForeign({
+                name: name.name,
+                start: name.start,
+                end: name.end,
+            });
+        }
+
         return new AST_NameImport({
             start: start,
             foreign_name: foreign_name,

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -171,6 +171,9 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
         else if (node instanceof AST_SymbolClass) {
             defun.def_variable(node);
         }
+        else if (node instanceof AST_SymbolImport) {
+            scope.def_variable(node);
+        }
         else if (node instanceof AST_SymbolDefClass) {
             // This deals with the name of the class being available
             // inside the class.
@@ -302,6 +305,12 @@ AST_Scope.DEFMETHOD("def_variable", function(symbol){
         this.variables.set(symbol.name, def);
         def.object_destructuring_arg = symbol.object_destructuring_arg;
         def.global = !this.parent_scope;
+        if (symbol instanceof AST_SymbolImport) {
+            // Imports are not global
+            def.global = false;
+            // TODO The real fix comes with block scoping being first class in uglifyJS,
+            // enabling import definitions to behave like module-level let declarations
+        }
     } else {
         def = this.variables.get(symbol.name);
         def.orig.push(symbol);

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -49,6 +49,7 @@ function SymbolDef(scope, index, orig) {
     this.scope = scope;
     this.references = [];
     this.global = false;
+    this.export = false;
     this.mangled_name = null;
     this.object_destructuring_arg = false;
     this.undeclared = false;
@@ -61,6 +62,7 @@ SymbolDef.prototype = {
         if (!options) options = {};
 
         return (this.global && !options.toplevel)
+            || this.export
             || this.object_destructuring_arg
             || this.undeclared
             || (!options.eval && (this.scope.uses_eval || this.scope.uses_with))
@@ -102,6 +104,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
     var defun = null;
     var nesting = 0;
     var in_destructuring = null;
+    var in_export;
     var tw = new TreeWalker(function(node, descend){
         if (options.screw_ie8 && node instanceof AST_Catch) {
             var save_scope = scope;
@@ -131,6 +134,11 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
             labels = save_labels;
             return true;        // don't descend again in TreeWalker
         }
+        if (node instanceof AST_Export) {
+            in_export = true;
+            descend();
+            in_export = false;
+        }
         if (node instanceof AST_LabeledStatement) {
             var l = node.label;
             if (labels.has(l.name)) {
@@ -151,14 +159,14 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
         }
         if (node instanceof AST_SymbolFunarg) {
             node.object_destructuring_arg = !!in_destructuring;
-            defun.def_variable(node);
+            defun.def_variable(node, in_export);
         }
         if (node instanceof AST_Label) {
             node.thedef = node;
             node.references = [];
         }
         if (node instanceof AST_SymbolLambda) {
-            defun.def_function(node);
+            defun.def_function(node, in_export);
         }
         else if (node instanceof AST_SymbolDefun) {
             // Careful here, the scope where this should be defined is
@@ -166,22 +174,22 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
             // scope when we encounter the AST_Defun node (which is
             // instanceof AST_Scope) but we get to the symbol a bit
             // later.
-            (node.scope = defun.parent_scope).def_function(node);
+            (node.scope = defun.parent_scope).def_function(node, in_export);
         }
         else if (node instanceof AST_SymbolClass) {
-            defun.def_variable(node);
+            defun.def_variable(node, in_export);
         }
         else if (node instanceof AST_SymbolImport) {
-            scope.def_variable(node);
+            scope.def_variable(node, in_export);
         }
         else if (node instanceof AST_SymbolDefClass) {
             // This deals with the name of the class being available
             // inside the class.
-            (node.scope = defun.parent_scope).def_function(node);
+            (node.scope = defun.parent_scope).def_function(node, in_export);
         }
         else if (node instanceof AST_SymbolVar
                  || node instanceof AST_SymbolConst) {
-            var def = defun.def_variable(node);
+            var def = defun.def_variable(node, in_export);
             def.constant = node instanceof AST_SymbolConst;
             def.destructuring = in_destructuring;
             def.init = tw.parent().value;
@@ -294,11 +302,11 @@ AST_Scope.DEFMETHOD("find_variable", function(name){
         || (this.parent_scope && this.parent_scope.find_variable(name));
 });
 
-AST_Scope.DEFMETHOD("def_function", function(symbol){
-    this.functions.set(symbol.name, this.def_variable(symbol));
+AST_Scope.DEFMETHOD("def_function", function(symbol, in_export){
+    this.functions.set(symbol.name, this.def_variable(symbol, in_export));
 });
 
-AST_Scope.DEFMETHOD("def_variable", function(symbol){
+AST_Scope.DEFMETHOD("def_variable", function(symbol, in_export){
     var def;
     if (!this.variables.has(symbol.name)) {
         def = new SymbolDef(this, this.variables.size(), symbol);
@@ -310,6 +318,10 @@ AST_Scope.DEFMETHOD("def_variable", function(symbol){
             def.global = false;
             // TODO The real fix comes with block scoping being first class in uglifyJS,
             // enabling import definitions to behave like module-level let declarations
+        }
+        if (!this.parent_scope && in_export) {
+            def.global = false;
+            def.export = true;
         }
     } else {
         def = this.variables.get(symbol.name);

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -308,9 +308,21 @@ number_literals: {
 import_statement: {
     input: {
         import "mod-name";
-        import "module2";
+        import Foo from "bar";
     }
-    expect_exact: "import\"mod-name\";import\"module2\";"
+    expect_exact: "import\"mod-name\";import Foo from\"bar\";"
+}
+
+import_statement_mangling: {
+    mangle = { };
+    input: {
+        import Foo from "foo";
+        Foo();
+    }
+    expect: {
+        import a from "foo";
+        a();
+    }
 }
 
 // Fabio: My patches accidentally caused a crash whenever

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -350,6 +350,22 @@ import_statement_mangling: {
     }
 }
 
+export_statement_mangling: {
+    mangle = { };
+    input: {
+        export var foo = 6;
+        export function bar() { }
+        export class Baz { }
+        bar(foo, Baz)
+    }
+    expect: {
+        export var foo = 6;
+        export function bar() { }
+        export class Baz { }
+        bar(foo, Baz)
+    }
+}
+
 // Fabio: My patches accidentally caused a crash whenever
 // there's an extraneous set of parens around an object.
 regression_cannot_destructure: {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -316,6 +316,18 @@ import_statement: {
     expect_exact: "import\"mod-name\";import Foo from\"bar\";import{Bar,Baz}from\"lel\";import Bar,{Foo}from\"lel\";import{Bar as kex,Baz as food}from\"lel\";"
 }
 
+export_statement: {
+    input: {
+        export default 1;
+        export var foo = 4;
+        export let foo = 6;
+        export const foo = 6;
+        export function foo() {};
+        export class foo { };
+    }
+    expect_exact: "export default 1;export var foo=4;export let foo=6;export const foo=6;export function foo(){};export class foo{};"
+}
+
 import_statement_mangling: {
     mangle = { };
     input: {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -305,6 +305,14 @@ number_literals: {
     }
 }
 
+import_statement: {
+    input: {
+        import "mod-name";
+        import "module2";
+    }
+    expect_exact: "import\"mod-name\";import\"module2\";"
+}
+
 // Fabio: My patches accidentally caused a crash whenever
 // there's an extraneous set of parens around an object.
 regression_cannot_destructure: {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -320,11 +320,21 @@ import_statement_mangling: {
     mangle = { };
     input: {
         import Foo from "foo";
+        import Bar, {Food} from "lel";
+        import {What as Whatever} from "lel";
         Foo();
+        Bar();
+        Food();
+        Whatever();
     }
     expect: {
         import a from "foo";
+        import b, {Food as c} from "lel";
+        import {What as d} from "lel";
         a();
+        b();
+        c();
+        d();
     }
 }
 

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -309,8 +309,11 @@ import_statement: {
     input: {
         import "mod-name";
         import Foo from "bar";
+        import { Bar, Baz } from 'lel';
+        import Bar, { Foo } from 'lel';
+        import { Bar as kex, Baz as food } from 'lel';
     }
-    expect_exact: "import\"mod-name\";import Foo from\"bar\";"
+    expect_exact: "import\"mod-name\";import Foo from\"bar\";import{Bar,Baz}from\"lel\";import Bar,{Foo}from\"lel\";import{Bar as kex,Baz as food}from\"lel\";"
 }
 
 import_statement_mangling: {


### PR DESCRIPTION
As the name indicates, this PR attempts to implement the new import and export statements.

Export statements are unmangleable, so a new argument was added to `def_variable` and `def_function`, because of that awkward "I can export any declaration" business.

Also, definitions coming from import statements were being considered global variables, but they're not. They're actually scoped to some module-wide block, so when you have a javascript file with just `import foo from "wherever"` foo doesn't become a global variable in the window. This has to be fixed when block-scoping comes along, but just asserting that these definitions are both "not global" and "unmangleable" at the same time has the same effect.