### PR TITLE
Ignore mangle sort option

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,6 @@ input files from the command line.
 To enable the mangler you need to pass `--mangle` (`-m`).  The following
 (comma-separated) options are supported:
 
-- `sort` — to assign shorter names to most frequently used variables.  This
-  saves a few hundred bytes on jQuery before gzip, but the output is
-  _bigger_ after gzip (and seems to happen for other libraries I tried it
-  on) therefore it's not enabled by default.
-
 - `toplevel` — mangle names declared in the toplevel scope (disabled by
   default).
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -372,7 +372,7 @@ AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options){
     return defaults(options, {
         except      : [],
         eval        : false,
-        sort        : false,
+        sort        : false, // Ignored. Flag retained for backwards compatibility.
         toplevel    : false,
         screw_ie8   : false,
         keep_fnames : false
@@ -414,9 +414,6 @@ AST_Toplevel.DEFMETHOD("mangle_names", function(options){
                 if (options.except.indexOf(symbol.name) < 0) {
                     a.push(symbol);
                 }
-            });
-            if (options.sort) a.sort(function(a, b){
-                return b.references.length - a.references.length;
             });
             to_mangle.push.apply(to_mangle, a);
             return;


### PR DESCRIPTION
Due to erroneous code generation: #877, duplicate #990.

Mangle `sort` option still retained but ignored for backwards compatibility.