### PR TITLE
fix #1003

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -395,9 +395,9 @@ var AST_ArrowParametersOrSeq = DEFNODE("ArrowParametersOrSeq", "expressions", {
                     default: default_seen_above,
                     names: ex.properties.map(to_fun_args)
                 });
-            } else if (ex instanceof AST_ObjectSymbol) {
+            } else if (ex instanceof AST_ObjectKeyVal && ex.shorthand) {
                 return new AST_SymbolFunarg({
-                    name: ex.symbol.name,
+                    name: ex.key,
                     start: ex.start,
                     end: ex.end
                 });
@@ -981,10 +981,11 @@ var AST_ObjectProperty = DEFNODE("ObjectProperty", "key value", {
     }
 });
 
-var AST_ObjectKeyVal = DEFNODE("ObjectKeyVal", "quote", {
+var AST_ObjectKeyVal = DEFNODE("ObjectKeyVal", "quote shorthand", {
     $documentation: "A key: value object property",
     $propdoc: {
-        quote: "[string] the original quote character"
+        quote: "[string] the original quote character",
+        shorthand: "[boolean] whether this is a shorthand key:value pair, expressed as just the key."
     }
 }, AST_ObjectProperty);
 
@@ -994,18 +995,6 @@ var AST_ObjectComputedKeyVal = DEFNODE("ObjectComputedKeyVal", null, {
         return visitor._visit(this, function(){
             this.key._walk(visitor);
             this.value._walk(visitor);
-        });
-    }
-}, AST_ObjectProperty);
-
-var AST_ObjectSymbol = DEFNODE("ObjectSymbol", "symbol", {
-    $propdoc: {
-        symbol: "[AST_SymbolRef] what symbol it is"
-    },
-    $documentation: "A symbol in an object",
-    _walk: function (visitor) {
-        return visitor._visit(this, function(){
-            this.symbol._walk(visitor);
         });
     }
 }, AST_ObjectProperty);

--- a/lib/output.js
+++ b/lib/output.js
@@ -1301,6 +1301,14 @@ function OutputStream(options) {
     DEFPRINT(AST_ObjectKeyVal, function(self, output){
         var key = self.key;
         var quote = self.quote;
+        var print_as_shorthand = self.shorthand &&
+            self.value instanceof AST_Symbol &&
+            self.key == self.value.print_to_string();
+
+        if (print_as_shorthand) {
+            output.print_name(key);
+            return;
+        }
         if (output.option("quote_keys")) {
             output.print_string(key + "");
         } else if ((typeof key == "number"
@@ -1357,23 +1365,6 @@ function OutputStream(options) {
             output.print('=');
             output.space();
             self.default.print(output)
-        }
-    });
-    DEFPRINT(AST_ObjectSymbol, function(self, output){
-        var name = self.mangled_key || self.symbol.name;
-        var def = self.symbol.definition();
-        if (def && def.mangled_name) {
-            output.print(name);
-            output.print(':');
-            output.space();
-            output.print(def.mangled_name);
-        } else if (!(def && def.mangled_name) && self.mangled_key) {
-            output.print(name);
-            output.print(':');
-            output.space();
-            output.print(def.name);
-        } else {
-            output.print(name);
         }
     });
     DEFPRINT(AST_Undefined, function(self, output){

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1514,14 +1514,16 @@ function parse($TEXT, options) {
                 }));
             } else if (!is("punc", ":")) {
                 // It's one of those object destructurings, the value is its own name
-                a.push(new AST_ObjectSymbol({
+                a.push(new AST_ObjectKeyVal({
                     start: start,
                     end: start,
-                    symbol: new AST_SymbolRef({
+                    key: name,
+                    value: new AST_SymbolRef({
                         start: start,
                         end: start,
                         name: name
-                    })
+                    }),
+                    shorthand: true,
                 }));
             } else {
                 expect(":");

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -90,9 +90,6 @@ function mangle_properties(ast, options) {
         if (node instanceof AST_ObjectKeyVal) {
             add(node.key);
         }
-        else if (node instanceof AST_ObjectSymbol) {
-            add(node.symbol.name);
-        }
         else if (node instanceof AST_ObjectProperty) {
             // setter or getter, since KeyVal is handled above
             add(node.key.name);
@@ -116,11 +113,6 @@ function mangle_properties(ast, options) {
     return ast.transform(new TreeTransformer(function(node){
         if (node instanceof AST_ObjectKeyVal) {
             node.key = mangle(node.key);
-        }
-        else if (node instanceof AST_ObjectSymbol) {
-            if (should_mangle(node.symbol.name)) {
-                node.mangled_key = mangle(node.symbol.name)
-            }
         }
         else if (node instanceof AST_ObjectProperty) {
             // setter or getter

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -219,10 +219,6 @@ TreeTransformer.prototype = new TreeWalker;
         self.properties = do_list(self.properties, tw);
     });
 
-    _(AST_ObjectSymbol, function(self, tw){
-        self.symbol = self.symbol.transform(tw);
-    });
-
     _(AST_ObjectProperty, function(self, tw){
         self.value = self.value.transform(tw);
     });


### PR DESCRIPTION
This also changes the way shorthand object properties are stored.

They used to be stored as an `AST_ObjectSymbol`, but that is a bit too complex. It is also weird because when the key or the value change because of the mangler and propmangle the output has to print it like a regular Key/value prop.

The new way to store them is by setting a boolean property `shorthand` on an AST_ObjectKeyVal, which signals that the key/value pair was written as a shorthand. The ObjectKeyVal looks exactly the same, only its output changes. It prints as a shorthand if and only if the value still retains the same name as the key.