### PR TITLE
Fix: Uglified Number.prototype functions on big numbers

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -596,7 +596,7 @@ function OutputStream(options) {
 
     PARENS(AST_Number, function(output){
         var p = output.parent();
-        if (this.getValue() < 0 && p instanceof AST_PropAccess && p.expression === this)
+        if (p instanceof AST_PropAccess && p.expression === this && (this.getValue() < 0 || make_num(this.getValue()).match(/^0/)))
             return true;
     });
 
@@ -1026,7 +1026,7 @@ function OutputStream(options) {
         var expr = self.expression;
         expr.print(output);
         if (expr instanceof AST_Number && expr.getValue() >= 0) {
-            if (!/[xa-f.]/i.test(output.last())) {
+            if (!/[xa-f.)]/i.test(output.last())) {
                 output.print(".");
             }
         }

--- a/test/compress/numbers.js
+++ b/test/compress/numbers.js
@@ -1,0 +1,16 @@
+hex_numbers_in_parentheses_for_prototype_functions: {
+    input: {
+        (-2);
+        (-2).toFixed(0);
+
+        (2);
+        (2).toFixed(0);
+
+        (0.00000002);
+        (0.00000002).toFixed(0);
+
+        (1000000000000000128);
+        (1000000000000000128).toFixed(0);
+    }
+    expect_exact: "-2;(-2).toFixed(0);2;2..toFixed(0);2e-8;2e-8.toFixed(0);0xde0b6b3a7640080;(0xde0b6b3a7640080).toFixed(0);"
+}


### PR DESCRIPTION
I realized that the uglified [es5-shim](https://github.com/es-shims/es5-shim) doesn't run on the [Galio browser](https://en.wikipedia.org/wiki/Galio) (sadly still running on 2% of all SmartTVs in Germany and also used in new devices ...).

The snippet `(1000000000000000128).toFixed(0);` gets converted to `0xde0b6b3a7640080.toFixed(0);` which sadly crashes on Galio. During my analysis I realized that functions that are executed directly on an octal or hexadecimal number crash it. If the number is inside parentheses it works fine.

My fix puts parentheses around the number if the resulting number format is octal or hexadecimal (starting with `0`).