### PR TITLE
Do not produce `let` as a variable name in mangle.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -46,7 +46,7 @@
 
 var KEYWORDS = 'break case catch const continue debugger default delete do else finally for function if in instanceof new return switch throw try typeof var void while with';
 var KEYWORDS_ATOM = 'false null true';
-var RESERVED_WORDS = 'abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized this throws transient volatile yield'
+var RESERVED_WORDS = 'abstract boolean byte char class double enum export extends final float goto implements import int interface let long native package private protected public short static super synchronized this throws transient volatile yield'
     + " " + KEYWORDS_ATOM + " " + KEYWORDS;
 var KEYWORDS_BEFORE_EXPRESSION = 'return new delete throw else case';
 

--- a/test/mocha/let.js
+++ b/test/mocha/let.js
@@ -2,7 +2,9 @@ var Uglify = require('../../');
 var assert = require("assert");
 
 describe("let", function() {
-    it("Should not produce `let` as a variable name in mangle", function() {
+    it("Should not produce `let` as a variable name in mangle", function(done) {
+        this.timeout(10000);
+
         // Produce a lot of variables in a function and run it through mangle.
         var s = '"use strict"; function foo() {';
         for (var i = 0; i < 21000; ++i) {
@@ -21,6 +23,8 @@ describe("let", function() {
         // to show the test generated enough symbols.
         assert(result.code.indexOf("var ket=") >= 0);
         assert(result.code.indexOf("var met=") >= 0);
+
+        done();
     });
 });
 

--- a/test/mocha/let.js
+++ b/test/mocha/let.js
@@ -1,0 +1,26 @@
+var Uglify = require('../../');
+var assert = require("assert");
+
+describe("let", function() {
+    it("Should not produce `let` as a variable name in mangle", function() {
+        // Produce a lot of variables in a function and run it through mangle.
+        var s = '"use strict"; function foo() {';
+        for (var i = 0; i < 21000; ++i) {
+            s += "var v" + i + "=0;";
+        }
+        s += '}';
+        var result = Uglify.minify(s, {fromString: true, compress: false});
+
+        // Verify that select keywords and reserved keywords not produced
+        assert.strictEqual(result.code.indexOf("var let="), -1);
+        assert.strictEqual(result.code.indexOf("var do="), -1);
+        assert.strictEqual(result.code.indexOf("var var="), -1);
+
+        // Verify that the variable names that appeared immediately before
+        // and after the erroneously generated `let` variable name still exist
+        // to show the test generated enough symbols.
+        assert(result.code.indexOf("var ket=") >= 0);
+        assert(result.code.indexOf("var met=") >= 0);
+    });
+});
+


### PR DESCRIPTION
Fixes #986 based on [patch](https://github.com/pablocubico/UglifyJS2/commit/385aa6383da9996faade35fbb61e516e8c033c19) originally provided by @pablocubico.
Bug would previously occur in large generated functions with 21,000+ variables.
May have also happened with emscripten asm.js output.