### PR TITLE
fix #1021

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -979,11 +979,12 @@ function parse($TEXT, options) {
             init =
                 is("keyword", "var") ? (next(), var_(true)) :
                 is("keyword", "let") ? (next(), let_(true)) :
+                is("keyword", "const") ? (next(), const_(true)) :
                                        expression(true, true);
             var is_in = is("operator", "in");
             var is_of = is("name", "of");
             if (is_in || is_of) {
-                if ((init instanceof AST_Var || init instanceof AST_Let) &&
+                if ((init instanceof AST_Definitions) &&
                         init.definitions.length > 1)
                     croak("Only one variable declaration allowed in for..in loop");
                 next();
@@ -1012,7 +1013,7 @@ function parse($TEXT, options) {
     };
 
     function for_of(init) {
-        var lhs = init instanceof AST_Var ? init.definitions[0].name : null;
+        var lhs = init instanceof AST_Definitions ? init.definitions[0].name : null;
         var obj = expression(true);
         expect(")");
         return new AST_ForOf({
@@ -1024,7 +1025,7 @@ function parse($TEXT, options) {
     };
 
     function for_in(init) {
-        var lhs = init instanceof AST_Var ? init.definitions[0].name : null;
+        var lhs = init instanceof AST_Definitions ? init.definitions[0].name : null;
         var obj = expression(true);
         expect(")");
         return new AST_ForIn({

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -380,6 +380,17 @@ export_statement_mangling: {
     }
 }
 
+// https://github.com/mishoo/UglifyJS2/issues/1021
+regression_for_of_const: {
+    input: {
+        for (const x of y) {}
+        for (const x in y) {}
+    }
+    expect: {
+        for (const x of y);for (const x in y);
+    }
+}
+
 // Fabio: My patches accidentally caused a crash whenever
 // there's an extraneous set of parens around an object.
 regression_cannot_destructure: {


### PR DESCRIPTION
This allows the uglifyjs harmony branch to parse `for (const x of y);`. As of now the parser doesn't allow this due to a forgotten `is("keyword", "const")` check.