### PR TITLE
Fix warnings for referenced non-hoisted functions.

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -801,7 +801,9 @@ merge(Compressor.prototype, {
     };
 
     function extract_declarations_from_unreachable_code(compressor, stat, target) {
-        compressor.warn("Dropping unreachable code [{file}:{line},{col}]", stat.start);
+        if (!(stat instanceof AST_Defun)) {
+            compressor.warn("Dropping unreachable code [{file}:{line},{col}]", stat.start);
+        }
         stat.walk(new TreeWalker(function(node){
             if (node instanceof AST_Definitions) {
                 compressor.warn("Declarations in unreachable code! [{file}:{line},{col}]", node.start);

--- a/test/compress/issue-1034.js
+++ b/test/compress/issue-1034.js
@@ -1,4 +1,4 @@
-non_hoisted_function_def_after_return: {
+non_hoisted_function_after_return: {
     options = {
         hoist_funs: false, dead_code: true, conditionals: true, comparisons: true,
         evaluate: true, booleans: true, loops: true, unused: true, keep_fargs: true,
@@ -31,6 +31,107 @@ non_hoisted_function_def_after_return: {
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:14,16]",
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:17,12]",
         "WARN: Dropping unused function UnusedFunction [test/compress/issue-1034.js:18,21]"
+    ]
+}
+
+non_hoisted_function_after_return_2a: {
+    options = {
+        hoist_funs: false, dead_code: true, conditionals: true, comparisons: true,
+        evaluate: true, booleans: true, loops: true, unused: true, keep_fargs: true,
+        if_return: true, join_vars: true, cascade: true, side_effects: true,
+        collapse_vars: false
+    }
+    input: {
+        function foo(x) {
+            if (x) {
+                return bar(1);
+                var a = not_called(1);
+            } else {
+                return bar(2);
+                var b = not_called(2);
+            }
+            var c = bar(3);
+            function bar(x) { return 7 - x; }
+            function nope() {}
+            return b || c;
+        }
+    }
+    expect: {
+        // NOTE: Output is correct, but suboptimal. Not a regression. Can be improved in future.
+        //       This output is run through non_hoisted_function_after_return_2b with same flags.
+        function foo(x) {
+            if (x) {
+                return bar(1);
+            } else {
+                return bar(2);
+                var b;
+            }
+            var c = bar(3);
+            function bar(x) {
+                return 7 - x;
+            }
+            return b || c;
+        }
+    }
+    expect_warnings: [
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:48,16]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:48,16]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:51,16]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:51,16]",
+        "WARN: Dropping unused variable a [test/compress/issue-1034.js:48,20]",
+        "WARN: Dropping unused function nope [test/compress/issue-1034.js:55,21]"
+    ]
+}
+
+non_hoisted_function_after_return_2b: {
+    options = {
+        hoist_funs: false, dead_code: true, conditionals: true, comparisons: true,
+        evaluate: true, booleans: true, loops: true, unused: true, keep_fargs: true,
+        if_return: true, join_vars: true, cascade: true, side_effects: true,
+        collapse_vars: false
+    }
+    input: {
+        // Note: output of test non_hoisted_function_after_return_2a run through compress again
+        function foo(x) {
+            if (x) {
+                return bar(1);
+            } else {
+                return bar(2);
+                var b;
+            }
+            var c = bar(3);
+            function bar(x) {
+                return 7 - x;
+            }
+            return b || c;
+        }
+    }
+    expect: {
+        // the output we would have liked to see from non_hoisted_function_after_return_2a
+        function foo(x) {
+            return bar(x ? 1 : 2);
+            function bar(x) { return 7 - x; }
+        }
+    }
+    expect_warnings: [
+        // Notice that some warnings are repeated by multiple compress passes.
+        // Not a regression. There is room for improvement here.
+        // Warnings should be cached and only output if unique.
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:100,16]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:100,16]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:100,16]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:100,16]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:100,16]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:100,16]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:100,16]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:100,16]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:102,12]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:102,12]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:106,12]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:100,16]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:100,16]",
+        "WARN: Dropping unused variable b [test/compress/issue-1034.js:100,20]",
+        "WARN: Dropping unused variable c [test/compress/issue-1034.js:102,16]"
     ]
 }
 

--- a/test/compress/issue-1034.js
+++ b/test/compress/issue-1034.js
@@ -27,7 +27,7 @@ non_hoisted_function_def_after_return: {
         }
     }
     expect_warnings: [
-        "WARN: Dropping unreachable code [test/compress/issue-1034.js:11,16]",
+        'WARN: Dropping unreachable code [test/compress/issue-1034.js:11,16]',
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:14,16]",
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:17,12]",
         "WARN: Dropping unused function UnusedFunction [test/compress/issue-1034.js:18,21]"

--- a/test/compress/issue-1034.js
+++ b/test/compress/issue-1034.js
@@ -1,0 +1,36 @@
+non_hoisted_function_def_after_return: {
+    options = {
+        hoist_funs: false, dead_code: true, conditionals: true, comparisons: true,
+        evaluate: true, booleans: true, loops: true, unused: true, keep_fargs: true,
+        if_return: true, join_vars: true, cascade: true, side_effects: true
+    }
+    input: {
+        function foo(x) {
+            if (x) {
+                return bar();
+                not_called1();
+            } else {
+                return baz();
+                not_called2();
+            }
+            function bar() { return 7; }
+            return not_reached;
+            function UnusedFunction() {}
+            function baz() { return 8; }
+        }
+    }
+    expect: {
+        function foo(x) {
+            return x ? bar() : baz();
+            function bar() { return 7 }
+            function baz() { return 8 }
+        }
+    }
+    expect_warnings: [
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:11,16]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:14,16]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:17,12]",
+        "WARN: Dropping unused function UnusedFunction [test/compress/issue-1034.js:18,21]"
+    ]
+}
+

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -127,7 +127,10 @@ function run_compress_tests() {
             }
             else if (test.expect_warnings) {
                 U.AST_Node.warn_function = original_warn_function;
-                var expected_warnings = make_code(test.expect_warnings, { beautify: false });
+                var expected_warnings = make_code(test.expect_warnings, {
+                    beautify: false,
+                    quote_style: 2, // force double quote to match JSON
+                });
                 var actual_warnings = JSON.stringify(warnings_emitted);
                 actual_warnings = actual_warnings.split(process.cwd() + "/").join("");
                 if (expected_warnings != actual_warnings) {


### PR DESCRIPTION
Fixes #1034 Invalid warning with `hoist_funs=false`

Also added optional `expect_warnings` functionality to test framework.