### PR TITLE
Prevent endless recursion when evaluating self-referencing consts

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1030,8 +1030,16 @@ merge(Compressor.prototype, {
                 : ev(this.alternative, compressor);
         });
         def(AST_SymbolRef, function(compressor){
-            var d = this.definition();
-            if (d && d.constant && d.init) return ev(d.init, compressor);
+            if (this._evaluating) throw def;
+            this._evaluating = true;
+            try {
+                var d = this.definition();
+                if (d && d.constant && d.init) {
+                    return ev(d.init, compressor);
+                }
+            } finally {
+                this._evaluating = false;
+            }
             throw def;
         });
         def(AST_Dot, function(compressor){

--- a/test/compress/issue-1041.js
+++ b/test/compress/issue-1041.js
@@ -1,0 +1,25 @@
+const_declaration: {
+    options = {
+        evaluate: true
+    };
+
+    input: {
+        const goog = goog || {};
+    }
+    expect: {
+        const goog = goog || {};
+    }
+}
+
+const_pragma: {
+    options = {
+        evaluate: true
+    };
+
+    input: {
+        /** @const */ var goog = goog || {};
+    }
+    expect: {
+        var goog = goog || {};
+    }
+}


### PR DESCRIPTION
Fix #1041