### PR TITLE
Avoid syntax error in yield assignments

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1234,9 +1234,7 @@ function OutputStream(options) {
         }
 
         isYield = (self.right.operator == "yield" || self.right.operator === "yield*");
-        isYield && output.print("(");
         output.print(op);
-        isYield && output.print(")");
 
         if ((op == "<" || op == "<<")
             && self.right instanceof AST_UnaryPrefix

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -434,3 +434,13 @@ generators_yield: {
     }
     expect_exact: "function*fn(){yield remote()}"
 }
+
+generators_yield_assign: {
+    input: {
+      function* fn() {
+          var x = {};
+          x.prop = yield 5;
+      }
+    }
+    expect_exact: "function*fn(){var x={};x.prop=yield 5}"
+}


### PR DESCRIPTION
This removes unnecessary parentheses around operators in yield expression assignments, which were causing syntax errors. See #1054 for more details.

I am admittedly not extremely familiar with this implementation for parsing generators, but I don't think operators ever need to be surrounded by parentheses in the way that they are with the current implementation, so my fix was simply to remove the parentheses. However, it might be a good idea for someone familiar with the implementation to double-check this. (cc @dariocravero)

Related: #959