### PR TITLE
Workaround for process.exit() tty output truncation.

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -1,3 +1,9 @@
+// workaround for tty output truncation upon process.exit()
+[process.stdout, process.stderr].forEach(function(stream){
+    if (stream._handle && stream._handle.setBlocking)
+        stream._handle.setBlocking(true);
+});
+
 var path = require("path");
 var fs = require("fs");
 


### PR DESCRIPTION
Fixes #1055