### PR TITLE
Fix regression causing tests to fail on windows

### DIFF
--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -132,8 +132,10 @@ function run_compress_tests() {
                     beautify: false,
                     quote_style: 2, // force double quote to match JSON
                 });
+                warnings_emitted = warnings_emitted.map(function(input) {
+                  return input.split(process.cwd() + path.sep).join("").split(path.sep).join("/");
+                });
                 var actual_warnings = JSON.stringify(warnings_emitted);
-                actual_warnings = actual_warnings.split(process.cwd() + "/").join("");
                 if (expected_warnings != actual_warnings) {
                     log("!!! failed\n---INPUT---\n{input}\n---EXPECTED WARNINGS---\n{expected_warnings}\n---ACTUAL WARNINGS---\n{actual_warnings}\n\n", {
                         input: input_code,


### PR DESCRIPTION
Should make tests work again on windows. Tested on local computer.

Info: Contains 1 side effect: all directory separators will be replaced in the message. Since the only known directory separators are `/` and `\` this might not be a big issue. The real fix would be to filter both output and expected message on directory separators.

Fixes #1065