### PR TITLE
Retain comments before AST_Constants during mangle.

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -409,6 +409,7 @@ function OutputStream(options) {
 
     AST_Node.DEFMETHOD("print_to_string", function(options){
         var s = OutputStream(options);
+        if (!options) s._readonly = true;
         this.print(s);
         return s.get();
     });
@@ -416,6 +417,7 @@ function OutputStream(options) {
     /* -----[ comments ]----- */
 
     AST_Node.DEFMETHOD("add_comments", function(output){
+        if (output._readonly) return;
         var c = output.option("comments"), self = this;
         var start = self.start;
         if (start && !start._comments_dumped) {

--- a/test/mocha/comment_before_constant.js
+++ b/test/mocha/comment_before_constant.js
@@ -1,0 +1,27 @@
+var Uglify = require('../../');
+var assert = require("assert");
+
+describe("comment before constant", function() {
+    var js = 'function f() { /*c1*/ var /*c2*/ foo = /*c3*/ false; return foo; }';
+
+    it("Should test comment before constant is retained and output after mangle.", function() {
+        var result = Uglify.minify(js, {
+            fromString: true,
+            compress: { collapse_vars: false },
+            mangle: {},
+            output: { comments: true },
+        });
+        assert.strictEqual(result.code, 'function f(){/*c1*/var/*c2*/n=/*c3*/!1;return n}');
+    });
+
+    it("Should test code works when comments disabled.", function() {
+        var result = Uglify.minify(js, {
+            fromString: true,
+            compress: { collapse_vars: false },
+            mangle: {},
+            output: {},
+        });
+        assert.strictEqual(result.code, 'function f(){var n=!1;return n}');
+    });
+});
+


### PR DESCRIPTION
Remove side effects in `AST_Node.print_to_string()` used by mangle function `compute_char_frequency()`.

Fixes #1063 
