### PR TITLE
Only allow `var` definitions to be moved into the for-init clause

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -802,7 +802,7 @@ merge(Compressor.prototype, {
                     CHANGED = true;
                 }
                 else if (stat instanceof AST_For
-                         && prev instanceof AST_Definitions
+                         && prev instanceof AST_Var
                          && (!stat.init || stat.init.TYPE == prev.TYPE)) {
                     CHANGED = true;
                     a.pop();

--- a/test/compress/join-vars.js
+++ b/test/compress/join-vars.js
@@ -1,0 +1,40 @@
+only_vars: {
+    options = { join_vars: true };
+    input: {
+        let netmaskBinary = '';
+        for (let i = 0; i < netmaskBits; ++i) {
+            netmaskBinary += '1';
+        }
+    }
+    expect: {
+        let netmaskBinary = '';
+        for (let i = 0; i < netmaskBits; ++i) netmaskBinary += '1';
+    }
+}
+
+issue_1079_with_vars: {
+    options = { join_vars: true };
+    input: {
+        var netmaskBinary = '';
+        for (var i = 0; i < netmaskBits; ++i) {
+            netmaskBinary += '1';
+        }
+    }
+    expect: {
+        for (var netmaskBinary = '', i = 0; i < netmaskBits; ++i) netmaskBinary += '1';
+    }
+}
+
+issue_1079_with_mixed: {
+    options = { join_vars: true };
+    input: {
+        var netmaskBinary = '';
+        for (let i = 0; i < netmaskBits; ++i) {
+            netmaskBinary += '1';
+        }
+    }
+    expect: {
+        var netmaskBinary = ''
+        for (let i = 0; i < netmaskBits; ++i) netmaskBinary += '1';
+    }
+}


### PR DESCRIPTION
Fixes #1079