### PR TITLE
bugfix #1095

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -86,6 +86,12 @@ SymbolDef.prototype = {
             var s = this.scope;
             if (!options.screw_ie8 && this.orig[0] instanceof AST_SymbolLambda)
                 s = s.parent_scope;
+
+            // https://github.com/mishoo/UglifyJS2/issues/1095
+            // prevent mangle name conflict while using `let` or `const`
+            if (this.orig[0] instanceof AST_SymbolBlockDeclaration)
+                s = s.parent_scope;
+
             this.mangled_name = s.next_mangled(options, this);
             if (this.global && cache) {
                 cache.set(this.name, this.mangled_name);


### PR DESCRIPTION
If the variable type is `AST_SymbolBlockDeclaration`, use `scope.parent_scope` for mangle process to prevent name conflict.