### PR TITLE
collapse_vars: Do not consider RegExp literals to be constants

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -338,7 +338,7 @@ merge(Compressor.prototype, {
                     if (ref.scope.uses_eval || ref.scope.uses_with) break;
 
                     // Constant single use vars can be replaced in any scope.
-                    if (var_decl.value.is_constant(compressor)) {
+                    if (!(var_decl.value instanceof AST_RegExp) && var_decl.value.is_constant(compressor)) {
                         var ctt = new TreeTransformer(function(node) {
                             if (node === ref)
                                 return replace_var(node, ctt.parent(), true);

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -1153,3 +1153,59 @@ collapse_vars_short_circuited_conditions: {
     }
 }
 
+collapse_vars_regexp: {
+    options = {
+        collapse_vars: true,
+        loops:         false,
+        sequences:     true,
+        dead_code:     true,
+        conditionals:  true,
+        comparisons:   true,
+        evaluate:      true,
+        booleans:      true,
+        unused:        true,
+        hoist_funs:    true,
+        keep_fargs:    true,
+        if_return:     true,
+        join_vars:     true,
+        cascade:       true,
+        side_effects:  true,
+    }
+    input: {
+        function f1() {
+            var k = 9;
+            var rx = /[A-Z]+/;
+            return [rx, k];
+        }
+        function f2() {
+            var rx = /[abc123]+/;
+            return function(s) {
+                return rx.exec(s);
+            };
+        }
+        (function(){
+            var result;
+            var s = 'acdabcdeabbb';
+            var rx = /ab*/g;
+            while (result = rx.exec(s)) {
+                console.log(result[0]);
+            }
+        })();
+    }
+    expect: {
+        function f1() {
+            return [/[A-Z]+/, 9];
+        }
+        function f2() {
+            var rx = /[abc123]+/;
+            return function(s) {
+                return rx.exec(s);
+            };
+        }
+        (function(){
+            var result, rx = /ab*/g;
+            while (result = rx.exec('acdabcdeabbb'))
+                console.log(result[0]);
+        })();
+    }
+}


### PR DESCRIPTION
Fixes #1100