### PR TITLE
Fix uglify attempting to rewrite invalid new expressions

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -515,7 +515,8 @@ function OutputStream(options) {
 
     PARENS([ AST_Unary, AST_Undefined ], function(output){
         var p = output.parent();
-        return p instanceof AST_PropAccess && p.expression === this;
+        return p instanceof AST_PropAccess && p.expression === this
+            || p instanceof AST_New;
     });
 
     PARENS(AST_Seq, function(output){
@@ -1283,7 +1284,12 @@ function OutputStream(options) {
 
     // self should be AST_New.  decide if we want to show parens or not.
     function no_constructor_parens(self, output) {
-        return self.args.length == 0 && !output.option("beautify");
+        return self.args.length == 0 && !output.option("beautify") ||
+            !(self.expression instanceof AST_SymbolRef ||
+              self.expression instanceof AST_Call ||
+              self.expression instanceof AST_Function ||
+              self.expression instanceof AST_Assign
+            );
     };
 
     function best_of(a) {

--- a/test/compress/new.js
+++ b/test/compress/new.js
@@ -10,3 +10,11 @@ new_statement: {
     }
     expect_exact: "new x(1);new x(1)(2);new x(1)(2)(3);new new x(1);new new x(1)(2);new new x(1)(2);(new new x(1))(2);"
 }
+
+new_with_rewritten_true_value: {
+    options = { booleans: true }
+    input: {
+        new true;
+    }
+    expect_exact: "new(!0);"
+}

--- a/test/mocha/new.js
+++ b/test/mocha/new.js
@@ -1,0 +1,34 @@
+var assert = require("assert");
+var uglify = require("../../");
+
+describe("New", function() {
+    it("Should attach callback parens after some tokens", function() {
+        var tests = [
+            "new x(1);",
+            "new (function(foo){this.foo=foo;})(1);",
+            "new true;",
+            "new (0);",
+            "new (!0);",
+            "new (bar = function(foo) {this.foo=foo;})(123);"
+        ];
+        var expected = [
+            "new x(1);",
+            "new function(foo) {\n    this.foo = foo;\n}(1);",
+            "new true;",
+            "new 0;",
+            "new (!0);",
+            "new (bar = function(foo) {\n    this.foo = foo;\n})(123);"
+        ];
+        for (var i = 0; i < tests.length; i++) {
+            assert.strictEqual(
+                uglify.minify(tests[i], {
+                    fromString: true,
+                    output: {beautify: true},
+                    compress: false,
+                    mangle: false
+                }).code,
+                expected[i]
+            );
+        }
+    });
+});


### PR DESCRIPTION
Summary: `new true` shouldn't create a parse error, but a type error later on when being processed by the interpreter. This also means that it should be able that such statements/expressions should pass parsing. This also might mean that users will notice these errors later as this patch make UglifyJS minify them without complaining.

- Fixes https://github.com/tc39/test262/blob/es5-tests/test/suite/ch11/11.2/11.2.2/S11.2.2_A3_T1.js#L13
- Ran test262 on the patch with "new" as test filter, passed as long it's non-es6
- A creative one might hit new issues if one created new statements with `new`, but really, why would someone?