### PR TITLE
Export tokenizer function

### DIFF
--- a/tools/exports.js
+++ b/tools/exports.js
@@ -14,5 +14,6 @@ exports["merge"] = merge;
 exports["parse"] = parse;
 exports["push_uniq"] = push_uniq;
 exports["string_template"] = string_template;
+exports["tokenizer"] = tokenizer;
 exports["is_identifier"] = is_identifier;
 exports["SymbolDef"] = SymbolDef;


### PR DESCRIPTION
In `uglify-js@1`, both parser and tokenizer methods were exported.

This allows to use `tokenizer()` separately, e.g. to wrap or override it, as `parse()` method accepts not only text, but also tokenized functions.