### PR TITLE
Catch errors when compression test fails to parse

### DIFF
--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -159,9 +159,16 @@ function run_compress_tests() {
 
 function parse_test(file) {
     var script = fs.readFileSync(file, "utf8");
-    var ast = U.parse(script, {
-        filename: file
-    });
+    // TODO try/catch can be removed after fixing https://github.com/mishoo/UglifyJS2/issues/348
+    try {
+        var ast = U.parse(script, {
+            filename: file
+        });
+    } catch (e) {
+        console.log("Caught error while parsing tests in " + file + "\n");
+        console.log(e);
+        throw e;
+    }
     var tests = {};
     var tw = new U.TreeWalker(function(node, descend){
         if (node instanceof U.AST_LabeledStatement


### PR DESCRIPTION
Adds more information when a compression test fails to ease debugging. Can be tested by inserting a `}` before one of these tests.