### PR TITLE
[ES6] Throw error if new.target is like new.foo

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1448,7 +1448,7 @@ function parse($TEXT, options) {
         expect_token("operator", "new");
         if (is("punc", ".")) {
             next();
-            expect_token("name");
+            expect_token("name", "target");
             return subscripts(new AST_NewTarget({
                 start : start,
                 end   : prev()

--- a/test/mocha/new.js
+++ b/test/mocha/new.js
@@ -85,4 +85,11 @@ describe("New", function() {
             );
         }
     });
+
+    it("Should check target in new.target", function() {
+        assert.throws(function() {uglify.parse("new.blah")}, function(e) {
+            return e instanceof uglify.JS_Parse_Error
+                && e.message === "SyntaxError: Unexpected token name «blah», expected name «target»";
+        });
+    });
 });


### PR DESCRIPTION
Obvious small parser fix

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target