### PR TITLE
Allow sequences maximum length to be user configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,12 @@ you can pass a comma-separated list of options.  Options are in the form
 `foo=bar`, or just `foo` (the latter implies a boolean option that you want
 to set `true`; it's effectively a shortcut for `foo=true`).
 
-- `sequences` -- join consecutive simple statements using the comma operator
+- `sequences` (default: true) -- join consecutive simple statements using the
+  comma operator.  May be set to a positive integer to specify the maximum number
+  of consecutive comma sequences that will be generated. If this option is set to
+  `true` then the default sequences limit is `2000`. Set option to `false` or `0`
+  to disable. On rare occasions the default sequences limit leads to very slow
+  compress times in which case a value of `20` or less is recommended.
 
 - `properties` -- rewrite property access using the dot notation, for
   example `foo["bar"] → foo.bar`

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ to set `true`; it's effectively a shortcut for `foo=true`).
 - `sequences` (default: true) -- join consecutive simple statements using the
   comma operator.  May be set to a positive integer to specify the maximum number
   of consecutive comma sequences that will be generated. If this option is set to
-  `true` then the default sequences limit is `2000`. Set option to `false` or `0`
+  `true` then the default sequences limit is `200`. Set option to `false` or `0`
   to disable. On rare occasions the default sequences limit leads to very slow
   compress times in which case a value of `20` or less is recommended.
 

--- a/README.md
+++ b/README.md
@@ -292,9 +292,11 @@ to set `true`; it's effectively a shortcut for `foo=true`).
 - `sequences` (default: true) -- join consecutive simple statements using the
   comma operator.  May be set to a positive integer to specify the maximum number
   of consecutive comma sequences that will be generated. If this option is set to
-  `true` then the default sequences limit is `200`. Set option to `false` or `0`
-  to disable. On rare occasions the default sequences limit leads to very slow
-  compress times in which case a value of `20` or less is recommended.
+  `true` then the default `sequences` limit is `200`. Set option to `false` or `0`
+  to disable. The smallest `sequences` length is `2`. A `sequences` value of `1`
+  is grandfathered to be equivalent to `true` and as such means `200`. On rare
+  occasions the default sequences limit leads to very slow compress times in which
+  case a value of `20` or less is recommended.
 
 - `properties` -- rewrite property access using the dot notation, for
   example `foo["bar"] → foo.bar`

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -80,7 +80,7 @@ function Compressor(options, false_by_default) {
         passes        : 1,
     }, true);
     var sequences = this.options["sequences"];
-    this.sequences_limit = sequences == 1 ? 2000 : sequences | 0;
+    this.sequences_limit = sequences == 1 ? 200 : sequences | 0;
     this.warnings_produced = {};
 };
 

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -79,6 +79,8 @@ function Compressor(options, false_by_default) {
         global_defs   : {},
         passes        : 1,
     }, true);
+    var sequences = this.options["sequences"];
+    this.sequences_limit = sequences == 1 ? 2000 : sequences | 0;
     this.warnings_produced = {};
 };
 
@@ -266,7 +268,7 @@ merge(Compressor.prototype, {
             if (compressor.option("if_return")) {
                 statements = handle_if_return(statements, compressor);
             }
-            if (compressor.option("sequences")) {
+            if (compressor.sequences_limit > 0) {
                 statements = sequencesize(statements, compressor);
             }
             if (compressor.option("join_vars")) {
@@ -721,7 +723,7 @@ merge(Compressor.prototype, {
                 seq = [];
             };
             statements.forEach(function(stat){
-                if (stat instanceof AST_SimpleStatement && seqLength(seq) < 2000) {
+                if (stat instanceof AST_SimpleStatement && seqLength(seq) < compressor.sequences_limit) {
                     seq.push(stat.body);
                 } else {
                     push_seq();


### PR DESCRIPTION
Workaround for #1145

`sequences=1` is grandfathered to be the same as `sequences=true` which is the same as `sequences=2000`.