### PR TITLE
Allow input files to be map (url->path) in Node

### DIFF
--- a/test/mocha/minify-file-map.js
+++ b/test/mocha/minify-file-map.js
@@ -1,0 +1,40 @@
+var Uglify = require('../../');
+var assert = require("assert");
+
+describe("Input file as map", function() {
+    it("Should accept object", function() {
+        var jsMap = {
+            '/scripts/foo.js': 'var foo = {"x": 1, y: 2, \'z\': 3};'
+        };
+        var result = Uglify.minify(jsMap, {fromString: true, outSourceMap: true});
+        
+        var map = JSON.parse(result.map);
+        assert.strictEqual(result.code, 'var foo={x:1,y:2,z:3};');
+        assert.deepEqual(map.sources, ['/scripts/foo.js']);
+    });
+
+    it("Should accept array of objects and strings", function() {
+        var jsSeq = [
+            {'/scripts/foo.js': 'var foo = {"x": 1, y: 2, \'z\': 3};'},
+            'var bar = 15;'
+        ];
+        var result = Uglify.minify(jsSeq, {fromString: true, outSourceMap: true});
+        
+        var map = JSON.parse(result.map);
+        assert.strictEqual(result.code, 'var foo={x:1,y:2,z:3},bar=15;');
+        assert.strictEqual(map.sources[0], '/scripts/foo.js');
+    });
+
+    it("Should correctly include source", function() {
+        var jsSeq = [
+            {'/scripts/foo.js': 'var foo = {"x": 1, y: 2, \'z\': 3};'},
+            'var bar = 15;'
+        ];
+        var result = Uglify.minify(jsSeq, {fromString: true, outSourceMap: true, sourceMapIncludeSources: true});
+        
+        var map = JSON.parse(result.map);
+        assert.strictEqual(result.code, 'var foo={x:1,y:2,z:3},bar=15;');
+        assert.deepEqual(map.sourcesContent, ['var foo = {"x": 1, y: 2, \'z\': 3};', 'var bar = 15;']);
+    });
+
+});

--- a/tools/node.js
+++ b/tools/node.js
@@ -61,18 +61,25 @@ exports.minify = function(files, options) {
     if (options.spidermonkey) {
         toplevel = UglifyJS.AST_Node.from_mozilla_ast(files);
     } else {
-        if (typeof files == "string")
-            files = [ files ];
-        files.forEach(function(file, i){
+        function addFile(file, fileUrl) {
             var code = options.fromString
                 ? file
                 : fs.readFileSync(file, "utf8");
-            sourcesContent[file] = code;
+            sourcesContent[fileUrl] = code;
             toplevel = UglifyJS.parse(code, {
-                filename: options.fromString ? i : file,
+                filename: fileUrl,
                 toplevel: toplevel,
                 bare_returns: options.parse ? options.parse.bare_returns : undefined
             });
+        }
+        [].concat(files).forEach(function (files, i) {
+            if (typeof files === 'string') {
+                addFile(files, options.fromString ? i : files);
+            } else {
+                for (var fileUrl in files) {
+                    addFile(files[fileUrl], fileUrl);
+                }
+            }
         });
     }
     if (options.wrap) {


### PR DESCRIPTION
The `"sources"` array in the sourcemap is currently based on the filename as passed into the module - this makes things difficult if your intended URL structure and folder structure are different.

This patch enables use of a map (URL -> file) as the `files` argument to Uglify:

```javascript
var Uglify = require('uglify-js');
var result = Uglify.minify({"/scripts/a.js": __dirname + "/static-scripts/a.js"}, {outSourceMap: true});
```

For when order is important, it supports an array of objects, or any mixture of objects and strings:

```javascript
var result = Uglify.minify([
    {"a.js": "vendor/a.js"},
    "b.js" // Equivalent to {"b.js": "b.js"}
], {outSourceMap: true});
```

It also works with string code (`fromString`):

```javascript
var result = Uglify.minify({
    "a.js": "function A(){...}",
    "b.js": "function B(){...}"
}, {
    fromString: true,
    outSourceMap: 'bundle.js.map',
    sourceMapIncludeSources: true /* sourcemap includes the source, with sensible names */
});
```

_____


Current workaround: patching the sourcemap after the fact:

```javascript
var result = Uglify.minify(['static-scripts/a.js'], {outSourceMap: 'bundle.js.map'});
var map = JSON.parse(result.map);
map.sources[0] = '/scripts/a.js';
result.map = JSON.stringify(map);
```