### PR TITLE
"reorder_funs" - sort function declarations by complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,10 @@ to set `true`; it's effectively a shortcut for `foo=true`).
 
 - `hoist_funs` -- hoist function declarations
 
+- `reorder_funs` -- rearrange function declarations in order of increasing
+  complexity.  This has no effect on size before gzip, but often reduces size
+  after gzip.
+
 - `hoist_vars` (default: false) -- hoist `var` declarations (this is `false`
   by default because it seems to increase the size of the output in general)
 

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -61,6 +61,7 @@ function Compressor(options, false_by_default) {
         loops         : !false_by_default,
         unused        : !false_by_default,
         hoist_funs    : !false_by_default,
+        reorder_funs  : !false_by_default,
         keep_fargs    : true,
         keep_fnames   : false,
         hoist_vars    : false,
@@ -108,14 +109,12 @@ merge(Compressor.prototype, {
     },
     before: function(node, descend, in_list) {
         if (node._squeezed) return node;
-        var was_scope = false;
-        if (node instanceof AST_Scope) {
-            node = node.hoist_declarations(this);
-            was_scope = true;
-        }
+        var was_scope = node instanceof AST_Scope;
         descend(node, this);
         node = node.optimize(this);
         if (was_scope && node instanceof AST_Scope) {
+            node = node.ast_complexity(this);
+            node = node.hoist_declarations(this);
             node.drop_unused(this);
             descend(node, this);
         }
@@ -152,8 +151,24 @@ merge(Compressor.prototype, {
             if (!(node instanceof AST_Directive || node instanceof AST_Constant)) {
                 node._squeezed = false;
                 node._optimized = false;
+                node._complexity = 0;
             }
         }));
+    });
+
+    AST_Node.DEFMETHOD("ast_complexity", function(){
+        var self = this;
+        var complexity = 0;
+        self.walk(new TreeWalker(function(node){
+            if (node._complexity) {
+                complexity += node._complexity;
+                return true;
+            } else {
+                complexity++;
+            }
+        }));
+        self._complexity = complexity;
+        return self;
     });
 
     function make_node(ctor, orig, props) {
@@ -1574,6 +1589,14 @@ merge(Compressor.prototype, {
                 }
             );
             self = self.transform(tt);
+            if (compressor.option('reorder_funs')) {
+                // Moving simpler functions earlier tends to give better gzip compression
+                hoisted.sort(function (a, b) {
+                    var aComplexity = a._complexity;
+                    var bComplexity = b._complexity;
+                    return (aComplexity - bComplexity) || (a.start.pos - b.start.pos);
+                });
+            }
             if (vars_found > 0) {
                 // collect only vars which don't show up in self's arguments list
                 var defs = [];

--- a/test/compress/reorder-funs.js
+++ b/test/compress/reorder-funs.js
@@ -1,0 +1,33 @@
+reorder_functions_after_optimize: {
+    options = {
+        collapse_vars:true, sequences:true, properties:true, dead_code:true, conditionals:true,
+        comparisons:true, evaluate:true, booleans:true, loops:true, unused:true, hoist_funs:true,
+        reorder_funs:true, keep_fargs:true, if_return:true, join_vars:true, cascade:true, side_effects:true
+    }
+    input: {
+        function longFun(x, y) {
+            return [x, y].map(function (x) {
+                return x*x;
+            });
+        }
+        function medFun(x) {
+            return 15*x;
+        }
+        function shortFun() {
+            return 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10;
+        }
+    }
+    expect: {
+        function shortFun() {
+            return 55;
+        }
+        function medFun(x) {
+            return 15*x;
+        }
+        function longFun(x, y) {
+            return [x, y].map(function (x) {
+                return x*x;
+            });
+        }
+    }
+}


### PR DESCRIPTION
If you reorder function declarations such that shorter functions are earlier, then gzip compression seems to be more effective.  As far as I'm aware, function declarations have no side-effects so order should not matter.

The proposed new feature/option is `reorder_funs` (only works if you also have `hoist_funs`):

```shell
# It has no effect on the size before gzip
$ uglifyjs jquery-3.0.0.js -c reorder_funs=false | wc -c
130586
$ uglifyjs jquery-3.0.0.js -c reorder_funs=true | wc -c
130586
# But it has a (small) effect on the size after gzip
$ uglifyjs jquery-3.0.0.js -c reorder_funs=false | gzip | wc -c
38226
$ uglifyjs jquery-3.0.0.js -c reorder_funs=true | gzip | wc -c
38184
```

I've verified it with a fairly limited set of inputs - is there some kind of benchmark suite of reference scripts that I can test against?