### PR TITLE
Enable --screw-ie8 by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ The available options are:
   --in-source-map               Input source map, useful if you're compressing
                                 JS that was generated from some other original
                                 code.
-  --screw-ie8                   Pass this flag if you don't care about full
-                                compliance with Internet Explorer 6-8 quirks
-                                (by default UglifyJS will try to be IE-proof).
+  --screw-ie8                   Use this flag if you don't wish to support
+                                Internet Explorer 6-8 quirks.
+                                By default UglifyJS will not try to be IE-proof.
+  --support-ie8                 Use this flag to support Internet Explorer 6-8 quirks.
+                                Note: may break standards compliant `catch` identifiers.
   --expr                        Parse a single expression, rather than a
                                 program (for parsing JSON)
   -p, --prefix                  Skip prefix for original filenames that appear

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -10,6 +10,7 @@ var fs = require("fs");
 var path = require("path");
 var async = require("async");
 var acorn;
+var screw_ie8 = true;
 var ARGS = yargs
     .usage("$0 input1.js [input2.js ...] [options]\n\
 Use a single dash to read input from the standard input.\
@@ -24,7 +25,8 @@ mangling you need to use `-c` and `-m`.\
     .describe("source-map-url", "The path to the source map to be added in //# sourceMappingURL.  Defaults to the value passed with --source-map.")
     .describe("source-map-include-sources", "Pass this flag if you want to include the content of source files in the source map as sourcesContent property.")
     .describe("in-source-map", "Input source map, useful if you're compressing JS that was generated from some other original code.")
-    .describe("screw-ie8", "Pass this flag if you don't care about full compliance with Internet Explorer 6-8 quirks (by default UglifyJS will try to be IE-proof).")
+    .describe("screw-ie8", "Do not support Internet Explorer 6-8 quirks. This flag is enabled by default.")
+    .describe("support-ie8", "Support non-standard Internet Explorer 6-8 javascript. Note: may break standards compliant `catch` identifiers.")
     .describe("expr", "Parse a single expression, rather than a program (for parsing JSON)")
     .describe("p", "Skip prefix for original filenames that appear in source maps. \
 For example -p 3 will drop 3 directories from file names and ensure they are relative paths. \
@@ -105,12 +107,14 @@ You need to pass an argument to this option to specify the name that your module
     .string("p")
     .string("prefix")
     .string("name-cache")
+
     .array("reserved-file")
     .array("pure-funcs")
 
     .boolean("expr")
     .boolean("source-map-include-sources")
     .boolean("screw-ie8")
+    .boolean("support-ie8")
     .boolean("export-all")
     .boolean("self")
     .boolean("v")
@@ -230,11 +234,13 @@ if (ARGS.mangle_props == 2) {
         COMPRESS.properties = false;
 }
 
-if (ARGS.screw_ie8) {
-    if (COMPRESS) COMPRESS.screw_ie8 = true;
-    if (MANGLE) MANGLE.screw_ie8 = true;
-    OUTPUT_OPTIONS.screw_ie8 = true;
+if (ARGS.support_ie8 === true && ARGS.screw_ie8 !== true) {
+    screw_ie8 = false;
 }
+
+if (COMPRESS) COMPRESS.screw_ie8 = screw_ie8;
+if (MANGLE) MANGLE.screw_ie8 = screw_ie8;
+OUTPUT_OPTIONS.screw_ie8 = screw_ie8;
 
 if (ARGS.keep_fnames) {
     if (COMPRESS) COMPRESS.keep_fnames = true;
@@ -426,7 +432,7 @@ async.eachLimit(files, 1, function (file, cb) {
 
     if (SCOPE_IS_NEEDED) {
         time_it("scope", function(){
-            TOPLEVEL.figure_out_scope({ screw_ie8: ARGS.screw_ie8, cache: TL_CACHE });
+            TOPLEVEL.figure_out_scope({ screw_ie8: screw_ie8, cache: TL_CACHE });
             if (ARGS.lint) {
                 TOPLEVEL.scope_warnings();
             }
@@ -441,7 +447,7 @@ async.eachLimit(files, 1, function (file, cb) {
 
     if (SCOPE_IS_NEEDED) {
         time_it("scope", function(){
-            TOPLEVEL.figure_out_scope({ screw_ie8: ARGS.screw_ie8, cache: TL_CACHE });
+            TOPLEVEL.figure_out_scope({ screw_ie8: screw_ie8, cache: TL_CACHE });
             if (MANGLE && !TL_CACHE) {
                 TOPLEVEL.compute_char_frequency(MANGLE);
             }

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -72,7 +72,7 @@ function Compressor(options, false_by_default) {
         pure_getters  : false,
         pure_funcs    : null,
         negate_iife   : !false_by_default,
-        screw_ie8     : false,
+        screw_ie8     : true,
         drop_console  : false,
         angular       : false,
         warnings      : true,

--- a/lib/output.js
+++ b/lib/output.js
@@ -64,7 +64,7 @@ function OutputStream(options) {
         comments         : false,
         shebang          : true,
         preserve_line    : false,
-        screw_ie8        : false,
+        screw_ie8        : true,
         preamble         : null,
         quote_style      : 0,
         keep_quoted_props: false
@@ -861,8 +861,8 @@ function OutputStream(options) {
         // adds the block brackets if needed.
         if (!self.body)
             return output.force_semicolon();
-        if (self.body instanceof AST_Do
-            && !output.option("screw_ie8")) {
+        if (self.body instanceof AST_Do) {
+            // Unconditionally use the if/do-while workaround for all browsers.
             // https://github.com/mishoo/UglifyJS/issues/#issue/57 IE
             // croaks with "syntax error" on code like this: if (foo)
             // do ... while(cond); else ...  we need block brackets

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -88,7 +88,7 @@ SymbolDef.prototype = {
 
 AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
     options = defaults(options, {
-        screw_ie8: false,
+        screw_ie8: true,
         cache: null
     });
 
@@ -377,7 +377,7 @@ AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options){
         eval        : false,
         sort        : false, // Ignored. Flag retained for backwards compatibility.
         toplevel    : false,
-        screw_ie8   : false,
+        screw_ie8   : true,
         keep_fnames : false
     });
 });

--- a/test/compress/ascii.js
+++ b/test/compress/ascii.js
@@ -2,6 +2,7 @@ ascii_only_true: {
     options = {}
     beautify = {
         ascii_only : true,
+        screw_ie8  : true,
         beautify   : false,
     }
     input: {
@@ -12,13 +13,14 @@ ascii_only_true: {
                    "\x20\x21\x22\x23 ... \x7d\x7e\x7f\x80\x81 ... \xfe\xff\u0fff\uffff";
         }
     }
-    expect_exact: 'function f(){return"\\x000\\x001\\x007\\08\\0"+"\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\b\\t\\n\\x0B\\f\\r\\x0e\\x0f"+"\\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f"+\' !"# ... }~\\x7f\\x80\\x81 ... \\xfe\\xff\\u0fff\\uffff\'}'
+    expect_exact: 'function f(){return"\\x000\\x001\\x007\\08\\0"+"\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\b\\t\\n\\v\\f\\r\\x0e\\x0f"+"\\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f"+\' !"# ... }~\\x7f\\x80\\x81 ... \\xfe\\xff\\u0fff\\uffff\'}'
 }
 
 ascii_only_false: {
     options = {}
     beautify = {
         ascii_only : false,
+        screw_ie8  : true,
         beautify   : false,
     }
     input: {
@@ -29,6 +31,6 @@ ascii_only_false: {
                    "\x20\x21\x22\x23 ... \x7d\x7e\x7f\x80\x81 ... \xfe\xff\u0fff\uffff";
         }
     }
-    expect_exact: 'function f(){return"\\x000\\x001\\x007\\08\\0"+"\\0\x01\x02\x03\x04\x05\x06\x07\\b\\t\\n\\x0B\\f\\r\x0e\x0f"+"\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f"+\' !"# ... }~\x7f\x80\x81 ... \xfe\xff\u0fff\uffff\'}'
+    expect_exact: 'function f(){return"\\x000\\x001\\x007\\08\\0"+"\\0\x01\x02\x03\x04\x05\x06\x07\\b\\t\\n\\v\\f\\r\x0e\x0f"+"\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f"+\' !"# ... }~\x7f\x80\x81 ... \xfe\xff\u0fff\uffff\'}'
 }
 

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -12,7 +12,8 @@ keep_properties: {
 
 dot_properties: {
     options = {
-        properties: true
+        properties: true,
+        screw_ie8: false
     };
     input: {
         a["foo"] = "bar";


### PR DESCRIPTION
`catch` argument is mangled correctly for ES5 standards-compliant JS engines by default.

Unconditionally use the ie8 if/do-while workaround whether or not `--screw-ie8` is enabled.

To support non-standard ie8 javascript use: `uglifyjs --support-ie8`