### PR TITLE
Fix regression in multiline comments with nlb

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -444,6 +444,7 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
         // update stream position
         forward(text.length /* doesn't count \r\n as 2 char while S.pos - i does */ + 2);
         S.comments_before.push(token("comment2", text, true));
+        S.newline_before = S.newline_before || text.indexOf("\n") >= 0;
         S.regex_allowed = regex_allowed;
         return next_token;
     });

--- a/test/compress/html_comments.js
+++ b/test/compress/html_comments.js
@@ -69,3 +69,12 @@ html_comment_in_string_literal: {
     }
     expect_exact: 'function f(){return"\\x3c!--HTML--\\x3ecomment in\\x3c!--string literal--\\x3e"}';
 }
+
+html_comment_after_multiline_comment: {
+    input: {
+        var foo; /*
+*/-->   var bar;
+        var foobar;
+    }
+    expect_exact: "var foo;var foobar;"
+}


### PR DESCRIPTION
Added test should make sure this doesn't happen again.