### PR TITLE
Fix input source maps

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -58,6 +58,16 @@ function SourceMap(options) {
         sourceRoot : options.root
     });
     var orig_map = options.orig && new MOZ_SourceMap.SourceMapConsumer(options.orig);
+
+    if (orig_map && Array.isArray(options.orig.sources)) {
+        options.orig.sources.forEach(function(source) {
+            var sourceContent = orig_map.sourceContentFor(source, true);
+            if (sourceContent) {
+                generator.setSourceContent(source, sourceContent);
+            }
+        });
+    }
+
     function add(source, gen_line, gen_col, orig_line, orig_col, name) {
         if (orig_map) {
             var info = orig_map.originalPositionFor({

--- a/test/mocha/input-sourcemaps.js
+++ b/test/mocha/input-sourcemaps.js
@@ -1,0 +1,43 @@
+var Uglify = require('../../');
+var assert = require("assert");
+var SourceMapConsumer = require("source-map").SourceMapConsumer;
+
+describe("input sourcemaps", function() {
+    var transpiled = '"use strict";\n\n' +
+        'var foo = function foo(x) {\n  return "foo " + x;\n};\n' +
+        'console.log(foo("bar"));\n\n' +
+        '//# sourceMappingURL=bundle.js.map';
+
+    var transpilemap = {
+        "version": 3,
+        "sources": ["index.js"],
+        "names": [],
+        "mappings": ";;AAAA,IAAI,MAAM,SAAN,GAAM;AAAA,SAAK,SAAS,CAAd;AAAA,CAAV;AACA,QAAQ,GAAR,CAAY,IAAI,KAAJ,CAAZ",
+        "file": "bundle.js",
+        "sourcesContent": ["let foo = x => \"foo \" + x;\nconsole.log(foo(\"bar\"));"]
+    };
+
+    var result = Uglify.minify(transpiled, {
+        fromString: true,
+        inSourceMap: transpilemap,
+        outSourceMap: true
+    });
+    var map = new SourceMapConsumer(result.map);
+
+    it("Should copy over original sourcesContent", function() {
+        assert.equal(map.sourceContentFor("index.js"), transpilemap.sourcesContent[0]);
+    });
+
+    it("Final sourcemap should not have invalid mappings from inputSourceMap (issue #882) ", function() {
+        // The original source has only 2 lines, check that mappings don't have more lines
+
+        var msg = "Mapping should not have higher line number than the original file had";
+        map.eachMapping(function(mapping) {
+            assert.ok(mapping.originalLine <= 2, msg)
+        });
+
+        map.allGeneratedPositionsFor({source: "index.js", line: 1, column: 1}).forEach(function(pos) {
+            assert.ok(pos.line <= 2, msg);
+        })
+    });
+});


### PR DESCRIPTION
Support for using input-source-map as base was added initially in ad18689. Unfortunately the implementation introduced bugs as discovered in #882, and the code was subsequently removed in #966.

The original approach copied the whole sourcemap using SourceMapGenerator.fromSourceMap, including all of the mappings, which caused duplicate/incorrect mappings to be present on the final map.

This copies only sourcesContents from the original source map and leaves the actual mappings alone. Should fix the remaining issues in  #882.