### PR TITLE
Fix the document of keep_fnames option

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,8 +379,7 @@ to set `true`; it's effectively a shortcut for `foo=true`).
 
 - `keep_fnames` -- default `false`.  Pass `true` to prevent the
   compressor from discarding function names.  Useful for code relying on
-  `Function.prototype.name`. You may also would like to refer to
-  [the mangle option](#mangle).
+  `Function.prototype.name`. See also [the mangle option](#mangle).
 
 - `passes` -- default `1`. Number of times to run compress. Use an
   integer argument larger than 1 to further reduce code size in some cases.

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ to set `true`; it's effectively a shortcut for `foo=true`).
 
 - `keep_fnames` -- default `false`.  Pass `true` to prevent the
   compressor from discarding function names.  Useful for code relying on
-  `Function.prototype.name`. See also [the mangle option](#mangle).
+  `Function.prototype.name`. See also: the `keep_fnames` [mangle option](#mangle).
 
 - `passes` -- default `1`. Number of times to run compress. Use an
   integer argument larger than 1 to further reduce code size in some cases.
@@ -698,6 +698,7 @@ Other options:
 
 - `keep_fnames` -- default `false`.  Pass `true` when you'd not like to mangle
   function names.  Useful for code relying on `Function.prototype.name`.
+  See also: the `keep_fnames` [compress option](#compressor-options).
 
   Examples:
 

--- a/README.md
+++ b/README.md
@@ -693,10 +693,10 @@ Other options:
  - `toplevel` — mangle names declared in the toplevel scope (disabled by
   default).
 
-  - `eval` — mangle names visible in scopes where eval or with are used
+   - `eval` — mangle names visible in scopes where eval or with are used
   (disabled by default).
 
-- `keep_fnames` -- default `false`.  Pass `true` when you'd not like to mangle
+ - `keep_fnames` -- default `false`.  Pass `true` to not mangle
   function names.  Useful for code relying on `Function.prototype.name`.
   See also: the `keep_fnames` [compress option](#compressor-options).
 

--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ The available options are:
   --reserved-file               File containing reserved names
   --reserve-domprops            Make (most?) DOM properties reserved for
                                 --mangle-props
-  --mangle-props                Mangle property names (default `0`). Set to 
+  --mangle-props                Mangle property names (default `0`). Set to
                                 `true` or `1` to mangle all property names. Set
-                                to `unquoted` or `2` to only mangle unquoted 
+                                to `unquoted` or `2` to only mangle unquoted
                                 property names. Mode `2` also enables the
-                                `keep_quoted_props` beautifier option to 
+                                `keep_quoted_props` beautifier option to
                                 preserve the quotes around property names and
                                 disables the `properties` compressor option to
                                 prevent rewriting quoted properties with dot
@@ -378,8 +378,9 @@ to set `true`; it's effectively a shortcut for `foo=true`).
   for code which relies on `Function.length`.
 
 - `keep_fnames` -- default `false`.  Pass `true` to prevent the
-  compressor from mangling/discarding function names.  Useful for code relying on
-  `Function.prototype.name`.
+  compressor from discarding function names.  Useful for code relying on
+  `Function.prototype.name`. You may also would like to refer to
+  [the mangle option](#mangle).
 
 - `passes` -- default `1`. Number of times to run compress. Use an
   integer argument larger than 1 to further reduce code size in some cases.
@@ -695,6 +696,9 @@ Other options:
 
   - `eval` — mangle names visible in scopes where eval or with are used
   (disabled by default).
+
+- `keep_fnames` -- default `false`.  Pass `true` when you'd not like to mangle
+  function names.  Useful for code relying on `Function.prototype.name`.
 
   Examples:
 

--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ Other options:
  - `toplevel` — mangle names declared in the toplevel scope (disabled by
   default).
 
-   - `eval` — mangle names visible in scopes where eval or with are used
+ - `eval` — mangle names visible in scopes where eval or with are used
   (disabled by default).
 
  - `keep_fnames` -- default `false`.  Pass `true` to not mangle


### PR DESCRIPTION
In the document of the compress option, it is written that the `keep_fnames` option prevents the compressor from mangling/discarding function names.
But in fact, it only prevents the compressor from discarding function names, and if you'd like to keep function names intact, you also have to set `mangle.keep_fnames` true.

I fixed the compress option's document and add the explanation of the `keep_fnames` option to the mangle option's section.