### PR TITLE
[ES6] Add more inconsistently and new defined globals

### DIFF
--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -45,15 +45,26 @@
 
 function find_builtins() {
 
-    // Compatibility fix for es5.1 and earlier where Symbol isn't defined
-    if (!global.Symbol) {
-        global.Symbol = new Function();
-    }
+    // Compatibility fix for some standard defined globals not defined on every js environment
+    var new_globals = ["Symbol", "Map", "Promise", "Proxy", "Reflect", "Set", "WeakMap", "WeakSet"];
+    var objects = {};
+
+    new_globals.forEach(function (new_global) {
+        objects[new_global] = global[new_global] || new Function();
+    });
 
     var a = [];
     [ Object, Array, Function, Number,
       String, Boolean, Error, Math,
-      Date, RegExp, Symbol
+      Date, RegExp, objects.Symbol, ArrayBuffer,
+      DataView, decodeURI, decodeURIComponent,
+      encodeURI, encodeURIComponent, eval, EvalError,
+      Float32Array, Float64Array, Int8Array, Int16Array,
+      Int32Array, isFinite, isNaN, JSON, objects.Map, parseFloat,
+      parseInt, objects.Promise, objects.Proxy, RangeError, ReferenceError,
+      objects.Reflect, objects.Set, SyntaxError, TypeError, Uint8Array,
+      Uint8ClampedArray, Uint16Array, Uint32Array, URIError,
+      objects.WeakMap, objects.WeakSet
     ].forEach(function(ctor){
         Object.getOwnPropertyNames(ctor).map(add);
         if (ctor.prototype) {

--- a/test/mocha/builtins.js
+++ b/test/mocha/builtins.js
@@ -4,7 +4,7 @@ var assert = require("assert");
 describe("builtins", function() {
     it ("Should not mangle builtins", function() {
         var test = "function foo(something){\n" +
-            "    return [Object,Array,Function,Number,String,Boolean,Error,Math,Date,RegExp,Symbol,something];\n" +
+            "    return [Object,Array,Function,Number,String,Boolean,Error,Math,Date,RegExp,Symbol,Map,Promise,Proxy,Reflect,Set,WeakMap,WeakSet,Float32Array,something];\n" +
             "};";
 
         var result = UglifyJS.minify(test, {fromString: true, parse: {bare_returns: true}}).code;
@@ -22,5 +22,13 @@ describe("builtins", function() {
         assert.notEqual(result.indexOf("Date"), -1);
         assert.notEqual(result.indexOf("RegExp"), -1);
         assert.notEqual(result.indexOf("Symbol"), -1);
+        assert.notEqual(result.indexOf("Promise"), -1);
+        assert.notEqual(result.indexOf("Proxy"), -1);
+        assert.notEqual(result.indexOf("Reflect"), -1);
+        assert.notEqual(result.indexOf("Set"), -1);
+        assert.notEqual(result.indexOf("WeakMap"), -1);
+        assert.notEqual(result.indexOf("WeakSet"), -1);
+        assert.notEqual(result.indexOf("Map"), -1);
+        assert.notEqual(result.indexOf("Float32Array"), -1);
     });
 });


### PR DESCRIPTION
Globals are defined on https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects.

Unstable globals are those not working on node 0.10. The list may be extended, but I do not have a good decision criteria (maybe we should add every global defined after es5.1 to that list).