### PR TITLE
[ES6] Allow get and set in shorthand properties in object literals

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1622,6 +1622,8 @@ function parse($TEXT, options) {
             }
             ret = _make_symbol(AST_SymbolRef);
             break;
+          default:
+            return undefined;
         }
         next();
         return ret;
@@ -1865,19 +1867,21 @@ function parse($TEXT, options) {
             });
         }
         if (name == "get") {
-            return new AST_ObjectGetter({
+            var atom = as_atom_node();
+            if (atom) return new AST_ObjectGetter({
                 start : start,
                 static: is_static,
-                key   : as_atom_node(),
+                key   : atom,
                 value : function_(AST_Accessor),
                 end   : prev()
             });
         }
-        if (name == "set") {
-            return new AST_ObjectSetter({
+        else if (name == "set") {
+            var atom = as_atom_node();
+            if (atom) return new AST_ObjectSetter({
                 start : start,
                 static: is_static,
-                key   : as_atom_node(),
+                key   : atom,
                 value : function_(AST_Accessor),
                 end   : prev()
             });

--- a/test/compress/object.js
+++ b/test/compress/object.js
@@ -1,0 +1,106 @@
+getter_setter: {
+    input: {
+        var get = "bar";
+        var a = {
+            get,
+            set: "foo",
+            get bar() {
+                return this.get;
+            },
+            get 5() {
+                return "five";
+            },
+            get 0xf55() {
+                return "f five five";
+            },
+            get "five"() {
+                return 5;
+            },
+            set one(value) {
+                this._one = value;
+            },
+            set 9(value) {
+                this._nine = value;
+            },
+            set 0b1010(value) {
+                this._ten = value;
+            },
+            set "eleven"(value) {
+                this._eleven = value;
+            }
+        };
+        var b = {
+            get() { return "gift"; },
+            set: function(code) { return "Storing code " + code; }
+        };
+        var c = {
+            ["get"]: "foo",
+            ["set"]: "bar"
+        };
+        var d = {
+            get: "foo",
+            set: "bar"
+        };
+    }
+    expect: {
+        var get = "bar";
+        var a = {
+            get,
+            set: "foo",
+            get bar() {
+                return this.get;
+            },
+            get 5() {
+                return "five";
+            },
+            get 0xf55() {
+                return "f five five";
+            },
+            get "five"() {
+                return 5;
+            },
+            set one(value) {
+                this._one = value;
+            },
+            set 9(value) {
+                this._nine = value;
+            },
+            set 0b1010(value) {
+                this._ten = value;
+            },
+            set "eleven"(value) {
+                this._eleven = value;
+            }
+        };
+        var b = {
+            get() { return "gift"; },
+            set: function(code) { return "Storing code " + code; }
+        };
+        var c = {
+            ["get"]: "foo",
+            ["set"]: "bar"
+        };
+        var d = {
+            get: "foo",
+            set: "bar"
+        };
+    }
+}
+
+getter_setter_mangler: {
+    mangle = {}
+    input: {
+        function f(get,set) {
+            return {
+                get,
+                set,
+                get g(){},
+                set s(n){},
+                c,
+                a:1,
+                m(){}
+            };
+        }
+    }
+    expect_exact: "function f(t,e){return{get:t,set:e,get g(){},set s(t){},c,a:1,m(){}}}"
+}


### PR DESCRIPTION
Fixed by @kzc
Fixes #1146

Note: there is a small conflict, but should be easy to resolve (with #1208)