### PR TITLE
[ES6] Keep empty generator as parameter value

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2282,6 +2282,7 @@ merge(Compressor.prototype, {
         }
         if (compressor.option("side_effects")) {
             if (self.expression instanceof AST_Function
+                && !self.expression.is_generator
                 && self.args.length == 0
                 && !AST_Block.prototype.has_side_effects.call(self.expression, compressor)) {
                 return make_node(AST_Undefined, self).transform(compressor);

--- a/test/compress/yield.js
+++ b/test/compress/yield.js
@@ -140,3 +140,29 @@ yield_as_identifier_outside_strict_mode: {
         class yield {}
     }
 }
+
+empty_generator_as_parameter_with_side_effects: {
+    options = {
+        side_effects: true
+    }
+    input: {
+        var GeneratorPrototype = Object.getPrototypeOf(
+          Object.getPrototypeOf(function*() {}())
+        );
+        evaluate(GeneratorPrototype);
+    }
+    expect_exact: "var GeneratorPrototype=Object.getPrototypeOf(Object.getPrototypeOf(function*(){}()));evaluate(GeneratorPrototype);"
+}
+
+empty_generator_as_parameter_without_side_effects: {
+    options = {
+        side_effects: false
+    }
+    input: {
+        var GeneratorPrototype = Object.getPrototypeOf(
+          Object.getPrototypeOf(function*() {}())
+        );
+        evaluate(GeneratorPrototype);
+    }
+    expect_exact: "var GeneratorPrototype=Object.getPrototypeOf(Object.getPrototypeOf(function*(){}()));evaluate(GeneratorPrototype);"
+}


### PR DESCRIPTION
Fixes failing test262 test https://github.com/tc39/test262/blob/master/test/built-ins/GeneratorPrototype/Symbol.toStringTag.js