### PR TITLE
Safely check for operators as object property key

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1747,7 +1747,7 @@ function parse($TEXT, options) {
                     a.push(concise);
                     continue;
                 }
-            } else if (start.value === "*") {
+            } else if (type === "operator") {
                 unexpected(prev());
             }
 


### PR DESCRIPTION
To prevent valid objects from raising syntax errors:
```js
({"*": true})
```