### PR TITLE
Verify output of uglify tests is parseable

### DIFF
--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -132,24 +132,38 @@ function run_compress_tests() {
                 failures++;
                 failed_files[file] = 1;
             }
-            else if (test.expect_warnings) {
-                U.AST_Node.warn_function = original_warn_function;
-                var expected_warnings = make_code(test.expect_warnings, {
-                    beautify: false,
-                    quote_style: 2, // force double quote to match JSON
-                });
-                warnings_emitted = warnings_emitted.map(function(input) {
-                  return input.split(process.cwd() + path.sep).join("").split(path.sep).join("/");
-                });
-                var actual_warnings = JSON.stringify(warnings_emitted);
-                if (expected_warnings != actual_warnings) {
-                    log("!!! failed\n---INPUT---\n{input}\n---EXPECTED WARNINGS---\n{expected_warnings}\n---ACTUAL WARNINGS---\n{actual_warnings}\n\n", {
+            else {
+                // expect == output
+                try {
+                    var reparsed_ast = U.parse(output);
+                } catch (ex) {
+                    log("!!! Test matched expected result but cannot parse output\n---INPUT---\n{input}\n---OUTPUT---\n{output}\n--REPARSE ERROR--\n{error}\n\n", {
                         input: input_code,
-                        expected_warnings: expected_warnings,
-                        actual_warnings: actual_warnings,
+                        output: output,
+                        error: ex.toString(),
                     });
                     failures++;
                     failed_files[file] = 1;
+                }
+                if (test.expect_warnings) {
+                    U.AST_Node.warn_function = original_warn_function;
+                    var expected_warnings = make_code(test.expect_warnings, {
+                        beautify: false,
+                        quote_style: 2, // force double quote to match JSON
+                    });
+                    warnings_emitted = warnings_emitted.map(function(input) {
+                      return input.split(process.cwd() + path.sep).join("").split(path.sep).join("/");
+                    });
+                    var actual_warnings = JSON.stringify(warnings_emitted);
+                    if (expected_warnings != actual_warnings) {
+                        log("!!! failed\n---INPUT---\n{input}\n---EXPECTED WARNINGS---\n{expected_warnings}\n---ACTUAL WARNINGS---\n{actual_warnings}\n\n", {
+                            input: input_code,
+                            expected_warnings: expected_warnings,
+                            actual_warnings: actual_warnings,
+                        });
+                        failures++;
+                        failed_files[file] = 1;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Implementation of idea to improve testing from https://github.com/mishoo/UglifyJS2/pull/1229#issuecomment-234537339

Verify that the output of uglify tests is parseable by uglify.

This PR [exposed](https://github.com/mishoo/UglifyJS2/pull/1231) [failures](https://github.com/mishoo/UglifyJS2/issues/1237) in harmony tests. No errors present on master.

Please apply to master and (eventually) merge with harmony.