### PR TITLE
Space before an unary operator

### DIFF
--- a/test/mocha/minify.js
+++ b/test/mocha/minify.js
@@ -58,5 +58,14 @@ describe("minify", function() {
             assert.strictEqual(result.code,
                     'a["foo"]="bar",a.a="red",x={"bar":10};');
         });
+    }); 
+
+    describe('Unary operators', function () {
+        it('Should preserve a space before increment/decrement', function () {
+            var js = 'var a = 1 + ++1;var b = 2 - ++1;';
+            var result = Uglify.minify(js, { fromString: true });
+            assert.strictEqual(result.code, 'var a=1+ ++1,b=2- ++1;');
+        });
     });
+
 });


### PR DESCRIPTION
Hello there,

I was trying to find a way to preserve the parenthesis of my unary operation and I seen that my problem wasn't the parenthesis. :cry: 

A space will be added before the unary operation when the previous and the current one char aren't equals, as we can see at [line 211](https://github.com/mishoo/UglifyJS2/blob/master/lib/output.js#L211-L220). I created a simple unit test to simulate this problem.

I gave it a quick reading, but in order to preserve a space before the unary operation, we may use `output.print(' ')` instead `output.space()` at [line 1090](https://github.com/mishoo/UglifyJS2/blob/master/lib/output.js#L1090) or we may use `/^[\+\-\/]$/.test(prev)` instead `ch == prev` at [line 215](https://github.com/mishoo/UglifyJS2/blob/master/lib/output.js#L215).
