### PR TITLE
Enabling multiple input JS files using a source folder(s)

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -254,7 +254,22 @@ if (ARGS.comments != null) {
     }
 }
 
-var files = ARGS._.slice();
+var files = (function expand_folder_of_JS_files( arrFiles) {
+    var arrJS_files = [];
+    arrFiles.forEach( function(filename) {
+        var fsStats = fs.statSync(filename);
+        if (fsStats.isFile() && filename.match(/.js$/i)) { arrJS_files.push(filename);}
+        else if (fsStats.isDirectory()) {
+            var strFolder = fs.realpathSync(filename)+ "/";
+            var arrDir = fs.readdirSync(strFolder,'utf8');
+            arrDir.forEach( function(dirFile) {
+                var arrFile = expand_folder_of_JS_files( [strFolder+ dirFile]);
+                if (arrFile && arrFile.length) { arrJS_files.push(arrFile[0]);}
+            });
+        }
+    });
+    return arrJS_files;
+})(ARGS._.slice());
 
 if (ARGS.self) {
     if (files.length > 0) {

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -258,7 +258,7 @@ var files = (function expand_folder_of_JS_files( arrFiles) {
     var arrJS_files = [];
     arrFiles.forEach( function(filename) {
         var fsStats = fs.statSync(filename);
-        if (fsStats.isFile() && filename.match(/.js$/i)) { arrJS_files.push(filename);}
+        if (fsStats.isFile() && filename.match(/\.js$/i)) { arrJS_files.push(filename);}
         else if (fsStats.isDirectory()) {
             var strFolder = fs.realpathSync(filename)+ "/";
             var arrDir = fs.readdirSync(strFolder,'utf8');


### PR DESCRIPTION
Revised the input parameters to allow for the JS source to be folders containing JS files as well as just JS files.

The expand_folder_of_JS_files function is supplied with the input list of files/folders and recursively trawls the folders for JS files. A list of all JavaScript files discovered is compiled and used from then on.