### PR TITLE
Add simple input file globbing to minify() and bin/uglifyjs

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -273,6 +273,9 @@ if (ARGS.comments != null) {
 
 var files = ARGS._.slice();
 
+if (process.platform === "win32")
+    files = UglifyJS.simple_glob(files);
+
 if (ARGS.self) {
     if (files.length > 0) {
         print_error("WARN: Ignoring input files since --self was passed");

--- a/test/input/issue-1242/bar.es5
+++ b/test/input/issue-1242/bar.es5
@@ -1,0 +1,4 @@
+function bar(x) {
+    var triple = x * (2 + 1);
+    return triple;
+}

--- a/test/input/issue-1242/baz.es5
+++ b/test/input/issue-1242/baz.es5
@@ -1,0 +1,4 @@
+function baz(x) {
+    var half = x / 2;
+    return half;
+}

--- a/test/input/issue-1242/foo.es5
+++ b/test/input/issue-1242/foo.es5
@@ -1,0 +1,5 @@
+var print = console.log.bind(console);
+function foo(x) {
+    var twice = x * 2;
+    print('Foo:', twice);
+}

--- a/test/input/issue-1242/qux.js
+++ b/test/input/issue-1242/qux.js
@@ -1,0 +1,4 @@
+var a = bar(1+2);
+var b = baz(3+9);
+print('q' + 'u' + 'x', a, b);
+foo(5+6);

--- a/test/mocha/glob.js
+++ b/test/mocha/glob.js
@@ -1,0 +1,28 @@
+var Uglify = require('../../');
+var assert = require("assert");
+
+describe("minify() with input file globs", function() {
+    it("minify() with one input file glob string.", function() {
+        var result = Uglify.minify("test/input/issue-1242/foo.*", {
+            compress: { collapse_vars: true }
+        });
+        assert.strictEqual(result.code, 'function foo(o){print("Foo:",2*o)}var print=console.log.bind(console);');
+    });
+    it("minify() with an array of one input file glob.", function() {
+        var result = Uglify.minify([
+            "test/input/issue-1242/b*.es5",
+        ], {
+            compress: { collapse_vars: true }
+        });
+        assert.strictEqual(result.code, 'function bar(n){return 3*n}function baz(n){return n/2}');
+    });
+    it("minify() with an array of multiple input file globs.", function() {
+        var result = Uglify.minify([
+            "test/input/issue-1242/???.es5",
+            "test/input/issue-1242/*.js",
+        ], {
+            compress: { collapse_vars: true }
+        });
+        assert.strictEqual(result.code, 'function bar(n){return 3*n}function baz(n){return n/2}function foo(n){print("Foo:",2*n)}var print=console.log.bind(console);print("qux",bar(3),baz(12)),foo(11);');
+    });
+});

--- a/tools/node.js
+++ b/tools/node.js
@@ -73,6 +73,7 @@ exports.minify = function(files, options) {
                 bare_returns: options.parse ? options.parse.bare_returns : undefined
             });
         }
+        if (!options.fromString) files = UglifyJS.simple_glob(files);
         [].concat(files).forEach(function (files, i) {
             if (typeof files === 'string') {
                 addFile(files, options.fromString ? i : files);


### PR DESCRIPTION
Fixes: #1033

Add simple input file glob support to:
- `minify()` for all platforms.
- `bin/uglifyjs` on Windows (not needed on UNIX).

Note: external `glob` module not used to reduce external dependencies for `uglifyjs`