### PR TITLE
Fix --mangle-props and --mangle-props=unquoted

### DIFF
--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -86,27 +86,22 @@ function mangle_properties(ast, options) {
 
     var names_to_mangle = [];
     var unmangleable = [];
+    var ignored = {};
 
     // step 1: find candidates to mangle
     ast.walk(new TreeWalker(function(node){
         if (node instanceof AST_ObjectKeyVal) {
-            if (!(ignore_quoted && node.quote))
-                add(node.key);
+            add(node.key, ignore_quoted && node.quote);
         }
         else if (node instanceof AST_ObjectProperty) {
             // setter or getter, since KeyVal is handled above
             add(node.key.name);
         }
         else if (node instanceof AST_Dot) {
-            if (this.parent() instanceof AST_Assign) {
-                add(node.property);
-            }
+            add(node.property);
         }
         else if (node instanceof AST_Sub) {
-            if (this.parent() instanceof AST_Assign) {
-                if (!ignore_quoted)
-                    addStrings(node.property);
-            }
+            addStrings(node.property, ignore_quoted);
         }
     }));
 
@@ -154,13 +149,19 @@ function mangle_properties(ast, options) {
     }
 
     function should_mangle(name) {
+        if (ignore_quoted && name in ignored) return false;
         if (regex && !regex.test(name)) return false;
         if (reserved.indexOf(name) >= 0) return false;
         return cache.props.has(name)
             || names_to_mangle.indexOf(name) >= 0;
     }
 
-    function add(name) {
+    function add(name, ignore) {
+        if (ignore) {
+            ignored[name] = true;
+            return;
+        }
+
         if (can_mangle(name))
             push_uniq(names_to_mangle, name);
 
@@ -184,7 +185,7 @@ function mangle_properties(ast, options) {
         return mangled;
     }
 
-    function addStrings(node) {
+    function addStrings(node, ignore) {
         var out = {};
         try {
             (function walk(node){
@@ -194,7 +195,7 @@ function mangle_properties(ast, options) {
                         return true;
                     }
                     if (node instanceof AST_String) {
-                        add(node.value);
+                        add(node.value, ignore);
                         return true;
                     }
                     if (node instanceof AST_Conditional) {

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -82,15 +82,22 @@ mangle_properties: {
         a["foo"] = "bar";
         a.color = "red";
         x = {"bar": 10};
+        a.run(x.bar, a.foo);
+        a['run']({color: "blue", foo: "baz"});
     }
     expect: {
         a["a"] = "bar";
         a.b = "red";
         x = {c: 10};
+        a.d(x.c, a.a);
+        a['d']({b: "blue", a: "baz"});
     }
 }
 
 mangle_unquoted_properties: {
+    options = {
+        properties: false
+    }
     mangle_props = {
         ignore_quoted: true
     }
@@ -100,27 +107,37 @@ mangle_unquoted_properties: {
         keep_quoted_props: true,
     }
     input: {
+        a.top = 1;
         function f1() {
             a["foo"] = "bar";
             a.color = "red";
-            x = {"bar": 10};
+            a.stuff = 2;
+            x = {"bar": 10, size: 7};
+            a.size = 9;
         }
         function f2() {
             a.foo = "bar";
             a['color'] = "red";
-            x = {bar: 10};
+            x = {bar: 10, size: 7};
+            a.size = 9;
+            a.stuff = 3;
         }
     }
     expect: {
+        a.a = 1;
         function f1() {
             a["foo"] = "bar";
-            a.a = "red";
-            x = {"bar": 10};
+            a.color = "red";
+            a.b = 2;
+            x = {"bar": 10, c: 7};
+            a.c = 9;
         }
         function f2() {
-            a.b = "bar";
+            a.foo = "bar";
             a['color'] = "red";
-            x = {c: 10};
+            x = {bar: 10, c: 7};
+            a.c = 9;
+            a.b = 3;
         }
     }
 }


### PR DESCRIPTION
Addresses Inconsistent Property Mangling #1247.

Also fix the `ignore_quoted=true` mangle properties option - known as `uglifyjs --mangle-props=unquoted` on the CLI.

When the same property name is used in both a quoted and a non-quoted context disallow it from being mangled anywhere in the code.

Given this JS:
```
$ echo 'o = {"foo": 2, bar: 3}; o.bar = o.foo;' | node -p
2
```
notice the incorrect result with `uglify-js@2.7.0` release:
```
$ echo 'o = {"foo": 2, bar: 3}; o.bar = o.foo;' | uglifyjs --mangle-props=unquoted
o={"foo":2,a:3};o.a=o.b;

$ echo 'o = {"foo": 2, bar: 3}; o.bar = o.foo;' | uglifyjs --mangle-props=unquoted | node -p
undefined
```
and the correct result with this fix:
```
$ echo 'o = {"foo": 2, bar: 3}; o.bar = o.foo;' | bin/uglifyjs --mangle-props=unquoted
o={"foo":2,a:3};o.a=o.foo;

$ echo 'o = {"foo": 2, bar: 3}; o.bar = o.foo;' | bin/uglifyjs --mangle-props=unquoted | node -p
2
```