### PR TITLE
Add debug option to mangle_properties()

### DIFF
--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -66,7 +66,8 @@ function mangle_properties(ast, options) {
         cache : null,
         only_cache : false,
         regex : null,
-        ignore_quoted : false
+        ignore_quoted : false,
+        debug : false
     });
 
     var reserved = options.reserved;
@@ -83,6 +84,7 @@ function mangle_properties(ast, options) {
 
     var regex = options.regex;
     var ignore_quoted = options.ignore_quoted;
+    var debug = options.debug;
 
     var names_to_mangle = [];
     var unmangleable = [];
@@ -174,6 +176,9 @@ function mangle_properties(ast, options) {
         if (!should_mangle(name)) {
             return name;
         }
+        
+        if (debug)
+            return "_$" + name + "$_";
 
         var mangled = cache.props.get(name);
         if (!mangled) {


### PR DESCRIPTION
Property mangling provides great compression and also helps make reverse engineering more difficult. However it easily breaks code and when it does it's often semi-impossible to figure out what happened. For example even after beautification, you just see "undefined is not a function" on a line like `a.b()`.

To mitigate this, this PR adds a new 'debug' option that can be passed to the mangle_properties options. When specified, mangling predictably transforms `name` to `_$name$_`. This means in the former example you now get an error on a line that looks like `a._$toastWaffles$_()`. Now you know you need to do something to protect the name `toastWaffles`, e.g. use quoted syntax, add it to your reserved properties list, etc. Basically since the mangled name is changed but contains the original name, you can see what's broken by mangling and easily debug it.

Closure Compiler has a similar debug mode.