### PR TITLE
introduce reduce_vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,9 @@ to set `true`; it's effectively a shortcut for `foo=true`).
 - `collapse_vars` -- default `false`. Collapse single-use `var` and `const`
   definitions when possible.
 
+- `reduce_vars` -- default `false`. Improve optimization on variables assigned
+  with and used as constant values.
+
 - `warnings` -- display warnings when dropping unreachable code or unused
   declarations etc.
 

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1108,7 +1108,7 @@ merge(Compressor.prototype, {
             this._evaluating = true;
             try {
                 var d = this.definition();
-                if (d && (d.constant || compressor.option("reduce_vars") && !d.global && !d.modified) && d.init) {
+                if (d && (d.constant || compressor.option("reduce_vars") && !d.modified) && d.init) {
                     return ev(d.init, compressor);
                 }
             } finally {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -67,6 +67,7 @@ function Compressor(options, false_by_default) {
         if_return     : !false_by_default,
         join_vars     : !false_by_default,
         collapse_vars : false,
+        reduce_vars   : false,
         cascade       : !false_by_default,
         side_effects  : !false_by_default,
         pure_getters  : false,
@@ -1107,7 +1108,7 @@ merge(Compressor.prototype, {
             this._evaluating = true;
             try {
                 var d = this.definition();
-                if (d && d.constant && d.init) {
+                if (d && (d.constant || compressor.option("reduce_vars") && !d.global && !d.modified) && d.init) {
                     return ev(d.init, compressor);
                 }
             } finally {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -220,7 +220,8 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
                 }
             }
             node.thedef = sym;
-            if (parent instanceof AST_Assign || parent instanceof AST_Unary && (parent.operator === '++' || parent.operator === '--')) {
+            if (parent instanceof AST_Unary && (parent.operator === '++' || parent.operator === '--')
+             || parent instanceof AST_Assign && parent.left === node) {
                 sym.modified = true;
             }
             node.reference();

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -197,7 +197,8 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
         }
         if (node instanceof AST_SymbolRef) {
             var name = node.name;
-            if (name == "eval" && tw.parent() instanceof AST_Call) {
+            var parent = tw.parent();
+            if (name == "eval" && parent instanceof AST_Call) {
                 for (var s = node.scope; s && !s.uses_eval; s = s.parent_scope) {
                     s.uses_eval = true;
                 }
@@ -213,12 +214,14 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
                     g.global = true;
                     globals.set(name, g);
                 }
-                node.thedef = g;
+                sym = g;
                 if (func && name == "arguments") {
                     func.uses_arguments = true;
                 }
-            } else {
-                node.thedef = sym;
+            }
+            node.thedef = sym;
+            if (parent instanceof AST_Assign || parent instanceof AST_Unary && (parent.operator === '++' || parent.operator === '--')) {
+                sym.modified = true;
             }
             node.reference();
             return true;

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -58,3 +58,70 @@ reduce_vars: {
         console.log(A + 1);
     }
 }
+
+modified: {
+    options = {
+        conditionals  : true,
+        evaluate      : true,
+        reduce_vars   : true,
+        unused        : true
+    }
+    input: {
+        function f0() {
+            var a = 1, b = 2;
+            b++;
+            console.log(a + 1);
+            console.log(b + 1);
+        }
+
+        function f1() {
+            var a = 1, b = 2, c = 3;
+            b = c;
+            console.log(a + b);
+            console.log(b + c);
+            console.log(a + c);
+            console.log(a + b + c);
+        }
+
+        function f2() {
+            var a = 1, b = 2, c = 3;
+            if (a) {
+                b = c;
+            } else {
+                c = b;
+            }
+            console.log(a + b);
+            console.log(b + c);
+            // TODO: as "modified" is determined in "figure_out_scope",
+            // even "passes" would improve this any further
+            console.log(a + c);
+            console.log(a + b + c);
+        }
+    }
+    expect: {
+        function f0() {
+            var b = 2;
+            b++;
+            console.log(2);
+            console.log(b + 1);
+        }
+
+        function f1() {
+            var a = 1, b = 2, c = 3;
+            b = c;
+            console.log(a + b);
+            console.log(b + c);
+            console.log(4);
+            console.log(a + b + c);
+        }
+
+        function f2() {
+            var a = 1, b = 2, c = 3;
+            b = c;
+            console.log(a + b);
+            console.log(b + c);
+            console.log(a + c);
+            console.log(a + b + c);
+        }
+    }
+}

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -40,7 +40,7 @@ reduce_vars: {
         var A = 1;
         (function() {
             console.log(-3);
-            console.log(A - 5);
+            console.log(-4);
         })();
         (function f1() {
             var a = 2;
@@ -55,7 +55,7 @@ reduce_vars: {
         (function() {
             return "yes";
         })();
-        console.log(A + 1);
+        console.log(2);
     }
 }
 
@@ -75,6 +75,13 @@ modified: {
         }
 
         function f1() {
+            var a = 1, b = 2;
+            --b;
+            console.log(a + 1);
+            console.log(b + 1);
+        }
+
+        function f2() {
             var a = 1, b = 2, c = 3;
             b = c;
             console.log(a + b);
@@ -83,7 +90,16 @@ modified: {
             console.log(a + b + c);
         }
 
-        function f2() {
+        function f3() {
+            var a = 1, b = 2, c = 3;
+            b *= c;
+            console.log(a + b);
+            console.log(b + c);
+            console.log(a + c);
+            console.log(a + b + c);
+        }
+
+        function f4() {
             var a = 1, b = 2, c = 3;
             if (a) {
                 b = c;
@@ -97,6 +113,12 @@ modified: {
             console.log(a + c);
             console.log(a + b + c);
         }
+
+        function f5(a) {
+            B = a;
+            console.log(A ? 'yes' : 'no');
+            console.log(B ? 'yes' : 'no');
+        }
     }
     expect: {
         function f0() {
@@ -107,6 +129,13 @@ modified: {
         }
 
         function f1() {
+            var b = 2;
+            --b;
+            console.log(2);
+            console.log(b + 1);
+        }
+
+        function f2() {
             var a = 1, b = 2, c = 3;
             b = c;
             console.log(a + b);
@@ -115,7 +144,16 @@ modified: {
             console.log(a + b + c);
         }
 
-        function f2() {
+        function f3() {
+            var a = 1, b = 2, c = 3;
+            b *= c;
+            console.log(a + b);
+            console.log(b + c);
+            console.log(4);
+            console.log(a + b + c);
+        }
+
+        function f4() {
             var a = 1, b = 2, c = 3;
             b = c;
             console.log(a + b);
@@ -123,5 +161,11 @@ modified: {
             console.log(a + c);
             console.log(a + b + c);
         }
-    }
+
+        function f5(a) {
+            B = a;
+            console.log(A ? 'yes' : 'no');
+            console.log(B ? 'yes' : 'no');
+        }
+   }
 }

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -1,0 +1,60 @@
+reduce_vars: {
+    options = {
+        conditionals  : true,
+        evaluate      : true,
+        global_defs   : {
+            C : 0
+        },
+        reduce_vars   : true,
+        unused        : true
+    }
+    input: {
+        var A = 1;
+        (function f0() {
+            var a = 2;
+            console.log(a - 5);
+            console.log(A - 5);
+        })();
+        (function f1() {
+            var a = 2;
+            console.log(a - 5);
+            eval("console.log(a);");
+        })();
+        (function f2(eval) {
+            var a = 2;
+            console.log(a - 5);
+            eval("console.log(a);");
+        })(eval);
+        (function f3() {
+            var b = typeof C !== "undefined";
+            var c = 4;
+            if (b) {
+                return 'yes';
+            } else {
+                return 'no';
+            }
+        })();
+        console.log(A + 1);
+    }
+    expect: {
+        var A = 1;
+        (function() {
+            console.log(-3);
+            console.log(A - 5);
+        })();
+        (function f1() {
+            var a = 2;
+            console.log(-3);
+            eval("console.log(a);");
+        })();
+        (function f2(eval) {
+            var a = 2;
+            console.log(-3);
+            eval("console.log(a);");
+        })(eval);
+        (function() {
+            return "yes";
+        })();
+        console.log(A + 1);
+    }
+}

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -109,7 +109,7 @@ modified: {
             console.log(a + b);
             console.log(b + c);
             // TODO: as "modified" is determined in "figure_out_scope",
-            // even "passes" would improve this any further
+            // even "passes" wouldn't improve this any further
             console.log(a + c);
             console.log(a + b + c);
         }


### PR DESCRIPTION
With a variable which is only assigned a constant value at initialisation and never gets modified elsewhere, this new flag allows `evaluate` to treat occurrence of said variable as constant when performing optimisation.

Motivated by minification using `global_defs` for places such as [this](https://github.com/digitalbazaar/forge/blob/master/js/pbkdf2.js#L16-L47).