### PR TITLE
Upgrade to yargs v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "async": "~0.2.6",
     "source-map": "~0.5.1",
     "uglify-to-browserify": "~1.0.0",
-    "yargs": "~3.10.0"
+    "yargs": "~6.0.0"
   },
   "devDependencies": {
     "acorn": "~0.6.0",


### PR DESCRIPTION
`uglifyjs` appears to me to be unaffected by the breaking changes made in yargs v4 and yargs v5. Below is the breaking changes copied directly from the [yargs change log](https://github.com/yargs/yargs/blob/master/CHANGELOG.md) for your reference. I've also manually tested the CLI commands and see no difference compared to current output. I would love to see this merged, just let me know if there is anything else I can do.

from v5:
- fail is now applied globally.
- we now default to an empty builder function when command is executed with no builder.
- yargs-parser now better handles negative integer values, at the cost of handling numeric option names, e.g., -1 hello
- default: removed undocumented defaults alias for default.
- introduces a default help command which outputs help, as an alternative to a help flag.

from v4
- 376 breaking change, make help() method signature more consistent with other commands 
- 368 breaking change, overhaul to command handling API: introducing named positional arguments, commands as modules, introduces the concept of global options (options that don't reset).
- 330 breaking change, fix inconsistencies with .version() API.
