### PR TITLE
[ES6] fix template string escaping of `\${...}`

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -409,7 +409,7 @@ function OutputStream(options) {
             print(encoded);
         },
         print_template_string_chars: function(str) {
-            var encoded = encode_string(str, '`');
+            var encoded = encode_string(str, '`').replace(/\${/g, "\\${");
             return print(encoded.substr(1, encoded.length - 2));
         },
         encode_string   : encode_string,

--- a/test/compress/template-string.js
+++ b/test/compress/template-string.js
@@ -329,3 +329,15 @@ check_escaped_chars: {
     }
     expect_exact: "var foo=`       `;";
 }
+
+escape_dollar_curly: {
+    options = {
+        evaluate: true
+    }
+    input: {
+        console.log(`\$\{ beep \}`)
+        console.log(`${1-0}\${2-0}$\{3-0}${4-0}`)
+        console.log(`$${""}{not an expression}`)
+    }
+    expect_exact: "console.log(`\\${ beep }`);console.log(`1\\${2-0}\\${3-0}4`);console.log(`\\${not an expression}`);"
+}


### PR DESCRIPTION
Fixes: #1300 