### PR TITLE
[ES6] fix parsing spread arguments that are expressions

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2371,7 +2371,7 @@ function parse($TEXT, options) {
                 next();
                 args.push(new AST_Expansion({
                     start: prev(),
-                    expression: as_symbol(AST_SymbolFunarg)
+                    expression: expression(false)
                 }));
             } else {
                 args.push(expression(false));

--- a/test/compress/expansions.js
+++ b/test/compress/expansions.js
@@ -7,6 +7,17 @@ expand_arguments: {
     expect_exact: "func(a,...rest);func(...all);"
 }
 
+expand_expression_arguments: {
+    input: {
+        f(...a.b);
+        f(...a.b());
+        f(...(a));
+        f(...(a.b));
+        f(...a[i]);
+    }
+    expect_exact: "f(...a.b);f(...a.b());f(...a);f(...a.b);f(...a[i]);"
+}
+
 expand_parameters: {
     input: {
         (function (a, ...b){});


### PR DESCRIPTION
Fixes: #1178 #1308 