### PR TITLE
Enable mangling of global references

### DIFF
--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -83,7 +83,8 @@ function mangle_properties(ast, options) {
         cache : null,
         only_cache : false,
         regex : null,
-        ignore_quoted : false
+        ignore_quoted : false,
+        treat_as_global : []
     });
 
     var reserved = options.reserved;
@@ -104,7 +105,21 @@ function mangle_properties(ast, options) {
     var names_to_mangle = [];
     var unmangleable = [];
     var ignored = {};
-
+    
+    if (!cache.global_defs) cache.global_defs = {};
+    
+    var treat_as_global = options.treat_as_global;
+    var mangle_globals = !!treat_as_global.length;
+    
+    function is_global_alias(name)
+    {
+        return treat_as_global.indexOf(name) >= 0;
+    }
+    
+    // TODO: don't know if this is necessary to get scope information?
+    //if (mangle_globals)
+    //    ast.figure_out_scope();
+    
     // step 1: find candidates to mangle
     ast.walk(new TreeWalker(function(node){
         if (node instanceof AST_ObjectKeyVal) {
@@ -116,12 +131,33 @@ function mangle_properties(ast, options) {
         }
         else if (node instanceof AST_Dot) {
             add(node.property);
+            
+            // if the left side of the dot is a global alias (e.g. window.foo), and the left side
+            // does not refer to a local variable, add it to a list of global definitions.
+            if (mangle_globals &&
+                node.expression instanceof AST_SymbolRef &&
+                node.expression.global() &&
+                is_global_alias(node.expression.name) &&
+                !is_global_alias(node.property))
+            {
+                cache.global_defs[node.property] = true;
+            }
         }
         else if (node instanceof AST_Sub) {
             addStrings(node.property, ignore_quoted);
         }
         else if (node instanceof AST_ConciseMethod) {
             add(node.name.name);
+        }
+        else if (node instanceof AST_SymbolRef) {
+            // if this term stands alone (e.g. just 'foo' where 'foo' cannot be shown to
+            // be a local variable in scope), also treat it as a global definition.
+            if (mangle_globals &&
+                node.global() &&
+                !is_global_alias(node.name))
+            {
+                cache.global_defs[node.name] = true;
+            }
         }
     }));
 
@@ -145,6 +181,18 @@ function mangle_properties(ast, options) {
         else if (node instanceof AST_ConciseMethod) {
             if (should_mangle(node.name.name)) {
                 node.name.name = mangle(node.name.name);
+            }
+        }
+        else if (node instanceof AST_SymbolRef) {
+            // if this is a standalone global reference which does not refer to a local variable in scope,
+            // and it's on our list of global definitions, then mangle it.
+            if (mangle_globals &&
+                node.global() &&
+                node.name in cache.global_defs)
+            {
+                var mangled_name = mangle(node.name);
+                node.name = mangled_name;
+                node.definition().mangled_name = mangled_name;
             }
         }
         // else if (node instanceof AST_String) {
@@ -178,7 +226,8 @@ function mangle_properties(ast, options) {
         if (regex && !regex.test(name)) return false;
         if (reserved.indexOf(name) >= 0) return false;
         return cache.props.has(name)
-            || names_to_mangle.indexOf(name) >= 0;
+            || names_to_mangle.indexOf(name) >= 0
+            || (mangle_globals && name in cache.global_defs);
     }
 
     function add(name, ignore) {
@@ -205,6 +254,12 @@ function mangle_properties(ast, options) {
             do {
                 mangled = base54(++cache.cname);
             } while (!can_mangle(mangled));
+            
+            // HACK: to avoid mangled global references colliding with local variable names, use
+            // a prefix on all mangled global names to effectively move them to a different namespace.
+            if (mangle_globals && name in cache.global_defs)
+                mangled = "g_" + mangled;
+            
             cache.props.set(name, mangled);
         }
         return mangled;

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -143,6 +143,52 @@ mangle_unquoted_properties: {
     }
 }
 
+mangle_global_properties: {
+    mangle_props = {
+        treat_as_global: ["window"],
+        reserved: ["console", "log"]
+    }
+    input: {
+        window.foo = {};
+        foo.bar = 1;
+        external.baz = 2;
+        console.log(external);
+    }
+    expect: {
+        window.g_a = {};
+        g_a.b = 1;
+        g_d.c = 2;
+        console.log(g_d);
+    }
+}
+
+mangle_global_properties_not_local: {
+    options = {
+    }
+    mangle_props = {
+        treat_as_global: ["self"],
+        reserved: ["console", "log"]
+    }
+    input: {
+        self.foo = {};
+        function test()
+        {
+            var self = this;
+            console.log(self.bar);
+        };
+        console.log(typeof bar);
+    }
+    expect: {
+        self.g_a = {};
+        function test()
+        {
+            var self = this;
+            console.log(self.b);
+        };
+        console.log(typeof g_b);
+    }
+}
+
 first_256_chars_as_properties: {
     beautify = {
         ascii_only: true,


### PR DESCRIPTION
This is an experimental work-in-progress patch to fix issue #1313.

The problem is currently `window.Foo` will mangle "Foo", but then `Foo.bar` will not mangle "Foo", breaking code. This patch attempts to recognise global references which are not identified as referencing any local variables, then also mangle them. The intent is to mangle "Foo" in both cases in the previous example.

The caller must pass a new `treat_as_global` array. If this is non-empty it enables the new mode. The caller can pass e.g. `window` to then recognise `window.Foo` as declaring "Foo" as global.

I don't really understand how the existing APIs work and a failing test is also included because I can't figure out how to get it to work. The intent is that if the left side of a dot expression refers to a local variable, then it should not treat it as defining a global property. For example if the caller passes "self" in `treat_as_global`, then the following should work:

```
// treat "Foo" as global
self.Foo = {};

function test() {
 var self = this;
 
 // do not treat "Bar" as global - 'self' refers to local var
 self.Bar = {};
};
```

To try to identify this I call `node.global()` but it does not seem to properly identify this case. I am also unsure as to whether to call `figure_out_scope`, which seems to be a destructive operation that appeared to partially undo previous mangling in my testing, so I'm not sure what's happening there.

There is also one more big hack: renaming globals opens the possibility of name collisions with local variables. For example:

```
window.Foo = {};

function test(p) {
 Foo.bar();
};
```

could be mangled as:

```
window.p = {};

function test(p) {
 p.bar(); // oops - now collides with parameter
};
```

To avoid this I simply prefix all globally-mangled names with `g_`, in the hope that `g_XYZ` will never collide with local variables (which I assume possibly incorrectly can never start with `g_`). Obviously this isn't a great solution and there are a range of alternative ways to solve this. For example local variables could use only lowercase names, and globals uppercase. Alternatively local and global mangling could share dictionaries of the names they use so globals will never mangle to the name of a local variable used anywhere in the program. These require wider changes though, and I would prefer to hear from other devs before implementing one of them.

Sorry about the partial state of all this, it's a complex codebase which I am unfamiliar with.