### PR TITLE
fix uses_arguments handling (broken since 6605d1578351)

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -204,6 +204,9 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
                 }
             }
             var sym = node.scope.find_variable(name);
+            if (node.scope instanceof AST_Lambda && name == "arguments") {
+                node.scope.uses_arguments = true;
+            }
             if (!sym) {
                 var g;
                 if (globals.has(name)) {
@@ -215,9 +218,6 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
                     globals.set(name, g);
                 }
                 sym = g;
-                if (func && name == "arguments") {
-                    func.uses_arguments = true;
-                }
             }
             node.thedef = sym;
             if (parent instanceof AST_Unary && (parent.operator === '++' || parent.operator === '--')

--- a/test/mocha/arguments.js
+++ b/test/mocha/arguments.js
@@ -19,4 +19,12 @@ describe("arguments", function() {
             value // Select function as scope
         );
     });
+
+    it("Should recognize when a function uses arguments", function() {
+        var ast = UglifyJS.parse("function a(){function b(){function c(){}; return arguments[0];}}");
+        ast.figure_out_scope();
+        assert.strictEqual(ast.body[0].uses_arguments, false);
+        assert.strictEqual(ast.body[0].body[0].uses_arguments, true);
+        assert.strictEqual(ast.body[0].body[0].body[0].uses_arguments, false);
+    });
 });


### PR DESCRIPTION
Using the symbol declaration tracking of UglifyJS doesn't make sense here anyway, `arguments` always comes from something in the current scope.

fixes #1299