### PR TITLE
[ES6]Remove AST_ObjectComputedKeyVal

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -401,9 +401,7 @@ var AST_ArrowParametersOrSeq = DEFNODE("ArrowParametersOrSeq", "expressions", {
                     default: default_seen_above,
                     names: ex.properties.map(to_fun_args)
                 });
-            } else if (ex instanceof AST_ObjectKeyVal ||
-                ex instanceof AST_ObjectComputedKeyVal
-            ) {
+            } else if (ex instanceof AST_ObjectKeyVal) {
                 if (ex.key instanceof AST_SymbolRef) {
                     ex.key = to_fun_args(ex.key, 0, [ex.key], ex.default);
                 }
@@ -1012,10 +1010,6 @@ var AST_ObjectKeyVal = DEFNODE("ObjectKeyVal", "quote default", {
         quote: "[string] the original quote character",
         default: "[AST_Expression] The default parameter value, only used when nested inside a binding pattern"
     }
-}, AST_ObjectProperty);
-
-var AST_ObjectComputedKeyVal = DEFNODE("ObjectComputedKeyVal", null, {
-    $documentation: "An object property whose key is computed. Like `[Symbol.iterator]: function...` or `[routes.homepage]: renderHomepage`",
 }, AST_ObjectProperty);
 
 var AST_ObjectSetter = DEFNODE("ObjectSetter", "quote static", {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1279,7 +1279,7 @@ merge(Compressor.prototype, {
             return false;
         });
         def(AST_ObjectProperty, function(compressor){
-            if (this instanceof AST_ObjectComputedKeyVal &&
+            if (this.key instanceof AST_ObjectKeyVal &&
                     this.key.has_side_effects(compressor))
                 return true;
             return this.value.has_side_effects(compressor);

--- a/lib/output.js
+++ b/lib/output.js
@@ -1466,7 +1466,13 @@ function OutputStream(options) {
         ) {
             self.print_property_name(self.key, self.quote, output);
         } else {
-            self.print_property_name(self.key, self.quote, output);
+            if (!(self.key instanceof AST_Node) || self.key instanceof AST_Symbol) {
+                self.print_property_name(self.key, self.quote, output);
+            } else {
+                output.with_square(function() {
+                    self.key.print(output);
+                });
+            }
             output.colon();
             self.value.print(output);
         }
@@ -1516,19 +1522,6 @@ function OutputStream(options) {
             });
         }
         self.value._do_print(output, true);
-    });
-    DEFPRINT(AST_ObjectComputedKeyVal, function(self, output) {
-        output.print("[");
-        self.key.print(output);
-        output.print("]:");
-        output.space();
-        self.value.print(output);
-        if (self.default) {
-            output.space();
-            output.print('=');
-            output.space();
-            self.default.print(output);
-        }
     });
     AST_Symbol.DEFMETHOD("_do_print", function(output){
         var def = this.definition();

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1507,14 +1507,6 @@ function parse($TEXT, options) {
                             name: property_token,
                             end: prev()
                         }));
-                    } else if (property instanceof AST_Node) {
-                        expect(":");
-                        elements.push(new AST_ObjectComputedKeyVal({
-                            start: property_token,
-                            key: property,
-                            value: binding_element(used_parameters, symbol_type),
-                            end: prev()
-                        }));
                     } else {
                         expect(":");
                         elements.push(new AST_ObjectKeyVal({
@@ -1989,7 +1981,7 @@ function parse($TEXT, options) {
 
             if (type == "punc" && start.value == "[") {
                 expect(":");
-                a.push(new AST_ObjectComputedKeyVal({
+                a.push(new AST_ObjectKeyVal({
                     start: start,
                     key: name,
                     value: expression(false),


### PR DESCRIPTION
Cleanup patch.

Depends on #1290 (have to rebase after merge and remove some references there).

TODO:

- ~~Investigate compression behaviour and compression related code.~~
- ~~Eventually add more test cases for compressed object properties related code.~~
- [x] Rebase after #1290 got merged (and cleanup last references to AST_ObjectComputedKeyVal).