### PR TITLE
[ES6][Regression] Fix case where a lonely var is used as computed property

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1508,7 +1508,7 @@ function OutputStream(options) {
         ) {
             self.print_property_name(self.key, self.quote, output);
         } else {
-            if (!(self.key instanceof AST_Node) || self.key instanceof AST_Symbol) {
+            if (!(self.key instanceof AST_Node)) {
                 self.print_property_name(self.key, self.quote, output);
             } else {
                 output.with_square(function() {

--- a/test/compress/object.js
+++ b/test/compress/object.js
@@ -491,3 +491,14 @@ allow_assignments_to_property_values: {
         var foo = {123: foo = 123} = {foo: "456"};
     }
 }
+
+variable_as_computed_property: {
+    input: {
+        function getLine(header) {
+            return {
+                [header]: {}
+            };
+        }
+    }
+    expect_exact: "function getLine(header){return{[header]:{}}}"
+}


### PR DESCRIPTION
Fixes #1340

Regression from #1333