### PR TITLE
Pass mangle options to figure_out_scope before mangling in tests

### DIFF
--- a/test/compress/screw-ie8.js
+++ b/test/compress/screw-ie8.js
@@ -16,3 +16,115 @@ dont_screw: {
     input: f("\v");
     expect_exact: 'f("\\x0B");';
 }
+
+do_screw_try_catch: {
+    options = { screw_ie8: true };
+    mangle = { screw_ie8: true };
+    beautify = { screw_ie8: true };
+    input: {
+        good = function(e){
+            return function(error){
+                try{
+                    e()
+                } catch(e) {
+                    error(e)
+                }
+            }
+        };
+    }
+    expect: {
+        good = function(n){
+            return function(t){
+                try{
+                    n()
+                } catch(n) {
+                    t(n)
+                }
+            }
+        };
+    }
+}
+
+dont_screw_try_catch: {
+    options = { screw_ie8: false };
+    mangle = { screw_ie8: false };
+    beautify = { screw_ie8: false };
+    input: {
+        bad = function(e){
+            return function(error){
+                try{
+                    e()
+                } catch(e) {
+                    error(e)
+                }
+            }
+        };
+    }
+    expect: {
+        bad = function(n){
+            return function(n){
+                try{
+                    t()
+                } catch(t) {
+                    n(t)
+                }
+            }
+        };
+    }
+}
+
+do_screw_try_catch_undefined: {
+    options = { screw_ie8: true };
+    mangle = { screw_ie8: true };
+    beautify = { screw_ie8: true };
+    input: {
+        function a(b){
+            try {
+                throw 'Stuff';
+            } catch (undefined) {
+                console.log('caught: ' + undefined);
+            }
+            console.log('undefined is ' + undefined);
+            return b === undefined;
+        };
+    }
+    expect: {
+        function a(o){
+            try{
+                throw "Stuff"
+            } catch (o) {
+                console.log("caught: "+o)
+            }
+            console.log("undefined is " + void 0);
+            return void 0===o
+        }
+    }
+}
+
+dont_screw_try_catch_undefined: {
+    options = { screw_ie8: false };
+    mangle = { screw_ie8: false };
+    beautify = { screw_ie8: false };
+    input: {
+        function a(b){
+            try {
+                throw 'Stuff';
+            } catch (undefined) {
+                console.log('caught: ' + undefined);
+            }
+            console.log('undefined is ' + undefined);
+            return b === undefined;
+        };
+    }
+    expect: {
+        function a(o){
+            try{
+                throw "Stuff"
+            } catch (n) {
+                console.log("caught: "+n)
+            }
+            console.log("undefined is " + void 0);
+            return void 0===o
+        }
+    }
+}

--- a/test/mocha/screw-ie8.js
+++ b/test/mocha/screw-ie8.js
@@ -1,0 +1,23 @@
+var assert = require("assert");
+var uglify = require("../../");
+
+describe("screw-ie8", function () {
+    it("Should be able to minify() with undefined as catch parameter in a try...catch statement", function () {
+        assert.strictEqual(
+            uglify.minify(
+                "function a(b){\
+                    try {\
+                        throw 'Stuff';\
+                    } catch (undefined) {\
+                        console.log('caught: ' + undefined);\
+                    }\
+                    console.log('undefined is ' + undefined);\
+                    return b === undefined;\
+                };", {
+                    fromString: true
+                }
+            ).code,
+            'function a(o){try{throw"Stuff"}catch(o){console.log("caught: "+o)}return console.log("undefined is "+void 0),void 0===o}'
+        );
+    });
+});

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -117,7 +117,7 @@ function run_compress_tests() {
                 input = U.mangle_properties(input, test.mangle_props);
             }
             var output = cmp.compress(input);
-            output.figure_out_scope();
+            output.figure_out_scope(test.mangle);
             if (test.mangle) {
                 output.compute_char_frequency(test.mangle);
                 output.mangle_names(test.mangle);


### PR DESCRIPTION
Make sure that figure_out_scope is aware of the `screw_ie8` option.
