### PR TITLE
fix(js-api): file value wrong within generated source map

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,15 +636,22 @@ To generate a source map with the fromString option, you can also use an object:
 ```javascript
 var result = UglifyJS.minify({"file1.js": "var a = function () {};"}, {
   outSourceMap: "out.js.map",
+  outFileName: "out.js",
   fromString: true
 });
 ```
 
 Note that the source map is not saved in a file, it's just returned in
-`result.map`.  The value passed for `outSourceMap` is only used to set the
-`file` attribute in the source map (see [the spec][sm-spec]). You can set 
-option `sourceMapInline` to be `true` and source map will be appended to 
-code.
+`result.map`.  The value passed for `outSourceMap` is only used to set
+`//# sourceMappingURL=out.js.map` in `result.code`. The value of
+`outFileName` is only used to set `file` attribute in source map file.
+
+The `file` attribute in the source map (see [the spec][sm-spec]) will
+use `outFileName` firstly, if it's falsy, then will be deduced from
+`outSourceMap` (by removing `'.map'`).
+
+You can set option `sourceMapInline` to be `true` and source map will
+be appended to code.
 
 You can also specify sourceRoot property to be included in source map:
 ```javascript

--- a/test/mocha/minify-file-map.js
+++ b/test/mocha/minify-file-map.js
@@ -7,10 +7,18 @@ describe("Input file as map", function() {
             '/scripts/foo.js': 'var foo = {"x": 1, y: 2, \'z\': 3};'
         };
         var result = Uglify.minify(jsMap, {fromString: true, outSourceMap: true});
-        
+
         var map = JSON.parse(result.map);
         assert.strictEqual(result.code, 'var foo={x:1,y:2,z:3};');
         assert.deepEqual(map.sources, ['/scripts/foo.js']);
+        assert.strictEqual(map.file, undefined);
+
+        result = Uglify.minify(jsMap, {fromString: true, outFileName: 'out.js'});
+        assert.strictEqual(result.map, null);
+
+        result = Uglify.minify(jsMap, {fromString: true, outFileName: 'out.js', outSourceMap: true});
+        map = JSON.parse(result.map);
+        assert.strictEqual(map.file, 'out.js');
     });
 
     it("Should accept array of objects and strings", function() {
@@ -19,7 +27,7 @@ describe("Input file as map", function() {
             'var bar = 15;'
         ];
         var result = Uglify.minify(jsSeq, {fromString: true, outSourceMap: true});
-        
+
         var map = JSON.parse(result.map);
         assert.strictEqual(result.code, 'var foo={x:1,y:2,z:3},bar=15;');
         assert.strictEqual(map.sources[0], '/scripts/foo.js');
@@ -31,7 +39,7 @@ describe("Input file as map", function() {
             'var bar = 15;'
         ];
         var result = Uglify.minify(jsSeq, {fromString: true, outSourceMap: true, sourceMapIncludeSources: true});
-        
+
         var map = JSON.parse(result.map);
         assert.strictEqual(result.code, 'var foo={x:1,y:2,z:3},bar=15;');
         assert.deepEqual(map.sourcesContent, ['var foo = {"x": 1, y: 2, \'z\': 3};', 'var bar = 15;']);

--- a/test/mocha/minify.js
+++ b/test/mocha/minify.js
@@ -63,13 +63,14 @@ describe("minify", function() {
     describe("inSourceMap", function() {
         it("Should read the given string filename correctly when sourceMapIncludeSources is enabled (#1236)", function() {
             var result = Uglify.minify('./test/input/issue-1236/simple.js', {
-                outSourceMap: "simple.js.min.map",
+                outSourceMap: "simple.min.js.map",
                 inSourceMap: "./test/input/issue-1236/simple.js.map",
                 sourceMapIncludeSources: true
             });
 
             var map = JSON.parse(result.map);
 
+            assert.equal(map.file, 'simple.min.js');
             assert.equal(map.sourcesContent.length, 1);
             assert.equal(map.sourcesContent[0],
                 'let foo = x => "foo " + x;\nconsole.log(foo("bar"));');

--- a/tools/node.js
+++ b/tools/node.js
@@ -41,6 +41,7 @@ exports.minify = function(files, options) {
     options = UglifyJS.defaults(options, {
         spidermonkey     : false,
         outSourceMap     : null,
+        outFileName      : null,
         sourceRoot       : null,
         inSourceMap      : null,
         sourceMapUrl     : null,
@@ -120,7 +121,8 @@ exports.minify = function(files, options) {
     }
     if (options.outSourceMap || options.sourceMapInline) {
         output.source_map = UglifyJS.SourceMap({
-            file: options.outSourceMap,
+            // prefer outFileName, otherwise use outSourceMap without .map suffix
+            file: options.outFileName || (typeof options.outSourceMap === 'string' ? options.outSourceMap.replace(/\.map$/i, '') : null),
             orig: inMap,
             root: options.sourceRoot
         });


### PR DESCRIPTION
add `option.destFileName` to set as `file` value within generated source map.

see issue #1350

If the proposal accepted, will add test and pass the CI.
