### PR TITLE
[ES6] Do not allow arrow functions in the middle of an expression

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2477,6 +2477,16 @@ function parse($TEXT, options) {
             return arrow_function([]);
         }
 
+        if (is("name") && is_token(peek(), "arrow")) {
+            var param = new AST_SymbolFunarg({
+                name: start.value,
+                start: start,
+                end: start,
+            });
+            next();
+            return arrow_function([param])
+        }
+
         var left = maybe_conditional(no_in);
         var val = S.token.value;
 
@@ -2492,14 +2502,6 @@ function parse($TEXT, options) {
                 });
             }
             croak("SyntaxError: Invalid assignment");
-        }
-        if (is("arrow")) {
-            left = new AST_SymbolFunarg({
-                name: left.name,
-                start: left.start,
-                end: left.end,
-            });
-            return arrow_function([left])
         }
         return left;
     };

--- a/test/mocha/arrow.js
+++ b/test/mocha/arrow.js
@@ -61,4 +61,23 @@ describe("Arrow functions", function() {
             assert.throws(test(tests[i]), error);
         }
     });
+    it("Should not accept arrow functions in the middle or end of an expression", function() {
+        var tests = [
+            "typeof x => 0",
+            "0 + x => 0"
+        ];
+        var test = function(code) {
+            return function() {
+                uglify.parse(code, {fromString: true});
+            }
+        }
+        var error = function(e) {
+            return e instanceof uglify.JS_Parse_Error &&
+                e.message === "SyntaxError: Unexpected token: arrow (=>)";
+        }
+
+        for (var i = 0; i < tests.length; i++) {
+            assert.throws(test(tests[i]), error);
+        }
+    });
 });


### PR DESCRIPTION
Fixes #1004
