### PR TITLE
[fix] map from normalized files

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -60,7 +60,7 @@ function SourceMap(options) {
     var orig_map = options.orig && new MOZ_SourceMap.SourceMapConsumer(options.orig);
 
     if (orig_map && Array.isArray(options.orig.sources)) {
-        options.orig.sources.forEach(function(source) {
+        orig_map._sources.toArray().forEach(function(source) {
             var sourceContent = orig_map.sourceContentFor(source, true);
             if (sourceContent) {
                 generator.setSourceContent(source, sourceContent);

--- a/test/mocha/input-sourcemaps.js
+++ b/test/mocha/input-sourcemaps.js
@@ -3,32 +3,55 @@ var assert = require("assert");
 var SourceMapConsumer = require("source-map").SourceMapConsumer;
 
 describe("input sourcemaps", function() {
-    var transpiled = '"use strict";\n\n' +
-        'var foo = function foo(x) {\n  return "foo " + x;\n};\n' +
-        'console.log(foo("bar"));\n\n' +
-        '//# sourceMappingURL=bundle.js.map';
+    var transpilemap, map;
 
-    var transpilemap = {
-        "version": 3,
-        "sources": ["index.js"],
-        "names": [],
-        "mappings": ";;AAAA,IAAI,MAAM,SAAN,GAAM;AAAA,SAAK,SAAS,CAAd;AAAA,CAAV;AACA,QAAQ,GAAR,CAAY,IAAI,KAAJ,CAAZ",
-        "file": "bundle.js",
-        "sourcesContent": ["let foo = x => \"foo \" + x;\nconsole.log(foo(\"bar\"));"]
-    };
+    function getMap() {
+      return {
+          "version": 3,
+          "sources": ["index.js"],
+          "names": [],
+          "mappings": ";;AAAA,IAAI,MAAM,SAAN,GAAM;AAAA,SAAK,SAAS,CAAd;AAAA,CAAV;AACA,QAAQ,GAAR,CAAY,IAAI,KAAJ,CAAZ",
+          "file": "bundle.js",
+          "sourcesContent": ["let foo = x => \"foo \" + x;\nconsole.log(foo(\"bar\"));"]
+      };
+    }
 
-    var result = Uglify.minify(transpiled, {
-        fromString: true,
-        inSourceMap: transpilemap,
-        outSourceMap: true
+    function prepareMap(sourceMap) {
+        var transpiled = '"use strict";\n\n' +
+            'var foo = function foo(x) {\n  return "foo " + x;\n};\n' +
+            'console.log(foo("bar"));\n\n' +
+            '//# sourceMappingURL=bundle.js.map';
+
+        transpilemap = sourceMap || getMap();
+
+        var result = Uglify.minify(transpiled, {
+            fromString: true,
+            inSourceMap: transpilemap,
+            outSourceMap: true
+        });
+
+        map = new SourceMapConsumer(result.map);
+    }
+
+    beforeEach(function () {
+      prepareMap();
     });
-    var map = new SourceMapConsumer(result.map);
 
     it("Should copy over original sourcesContent", function() {
         assert.equal(map.sourceContentFor("index.js"), transpilemap.sourcesContent[0]);
     });
 
-    it("Final sourcemap should not have invalid mappings from inputSourceMap (issue #882) ", function() {
+    it("Should copy sourcesContent if sources are relative", function () {
+        var relativeMap = getMap();
+        relativeMap.sources = ['./index.js'];
+
+        prepareMap(relativeMap);
+        assert.notEqual(map.sourcesContent, null);
+        assert.equal(map.sourcesContent.length, 1);
+        assert.equal(map.sourceContentFor("index.js"), transpilemap.sourcesContent[0]);
+    });
+
+    it("Final sourcemap should not have invalid mappings from inputSourceMap (issue #882)", function() {
         // The original source has only 2 lines, check that mappings don't have more lines
 
         var msg = "Mapping should not have higher line number than the original file had";


### PR DESCRIPTION
If using `inSourceMap` this fix will ensure the copying of `sourcesContent` is based on potentially normalized `sources` values (https://github.com/mozilla/source-map/blob/master/lib/source-map-consumer.js#L304-L309). 

For example `normalize` (https://github.com/mozilla/source-map/blob/master/lib/util.js#L80-L123) will rewrite `./dist/mySource.js` to `dist/mySource.js` in the target `_sources` of the `SourceMapConsumer`. As a result `orig_map.sourceContentFor(source, true);` would return `null` since the orginal `source` was no longer available in the consumer. By using the keys generating from the `SourceMapConsumer.constructor` consistency is ensured.