### PR TITLE
[ES6] Fix flag name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ can pass additional arguments that control the code output:
   - `3` -- always use the original quotes
 - `keep_quoted_props` (default `false`) -- when turned on, prevents stripping
   quotes from property names in object literals.
-- `es` (default `5`) -- set output printing mode.  This will only change the
+- `ecma` (default `5`) -- set output printing mode.  This will only change the
   output in direct control of the beautifier.  Non-compatible features in the
   abstract syntax tree will still be outputted as is.
 


### PR DESCRIPTION
`es` to `ecma` as can be observed on https://github.com/mishoo/UglifyJS2/blob/7e80a979a7f6bad21f54c63612dd4217ef5a7ca8/lib/output.js#L73