### PR TITLE
[ES6] Fix regression with non-ascii function identifiers

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -951,11 +951,7 @@ function OutputStream(options) {
             }
         }
         if (self.name instanceof AST_Symbol) {
-            if (typeof self.name.name === "string" && !is_identifier_string(self.name.name)) {
-                output.print_string(self.name.name);
-            } else {
-                self.name.print(output);
-            }
+            self.name.print(output);
         } else if (nokeyword && self.name instanceof AST_Node) {
             output.with_square(function() {
                 self.name.print(output); // Computed method name

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -1,0 +1,8 @@
+non_ascii_function_identifier_name: {
+    input: {
+        function fooλ(δλ) {}
+        function λ(δλ) {}
+        (function λ(δλ) {})()
+    }
+    expect_exact: "function fooλ(δλ){}function λ(δλ){}(function λ(δλ){})();"
+}


### PR DESCRIPTION
Regression since 110a1ac885ba224cbc677e42695e252068edd267

#1391 backports the tests to master