### PR TITLE
Add preventive test involving non-ascii function identifiers

### DIFF
--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -1,0 +1,8 @@
+non_ascii_function_identifier_name: {
+    input: {
+        function fooλ(δλ) {}
+        function λ(δλ) {}
+        (function λ(δλ) {})()
+    }
+    expect_exact: "function fooλ(δλ){}function λ(δλ){}(function λ(δλ){})();"
+}


### PR DESCRIPTION
See #1390 (this pr is a backport patch)