### PR TITLE
Have minify() and tests use figure_out_scope() as uglifyjs CLI does

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,13 @@ The available options are:
                                 JS that was generated from some other original
                                 code.
   --screw-ie8                   Use this flag if you don't wish to support
-                                Internet Explorer 6-8 quirks.
+                                Internet Explorer 6/7/8.
                                 By default UglifyJS will not try to be IE-proof.
-  --support-ie8                 Use this flag to support Internet Explorer 6-8 quirks.
-                                Note: may break standards compliant `catch` identifiers.
+  --support-ie8                 Use this flag to support Internet Explorer 6/7/8.
+                                Equivalent to setting `screw_ie8: false` in `minify()`
+                                for `compress`, `mangle` and `output` options.
+                                Note: `--support-ie8` may generate incorrect code
+                                for `try`/`catch` in ES5 compliant browsers.
   --expr                        Parse a single expression, rather than a
                                 program (for parsing JSON)
   -p, --prefix                  Skip prefix for original filenames that appear

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -26,8 +26,8 @@ mangling you need to use `-c` and `-m`.\
     .describe("source-map-inline", "Write base64-encoded source map to the end of js output.  Disabled by default")
     .describe("source-map-include-sources", "Pass this flag if you want to include the content of source files in the source map as sourcesContent property.")
     .describe("in-source-map", "Input source map, useful if you're compressing JS that was generated from some other original code.")
-    .describe("screw-ie8", "Do not support Internet Explorer 6-8 quirks. This flag is enabled by default.")
-    .describe("support-ie8", "Support non-standard Internet Explorer 6-8 javascript. Note: may break standards compliant `catch` identifiers.")
+    .describe("screw-ie8", "Do not support Internet Explorer 6/7/8. This flag is enabled by default.")
+    .describe("support-ie8", "Support non-standard Internet Explorer 6/7/8 javascript. Note: may generate incorrect code for try/catch in ES5 compliant browsers.")
     .describe("expr", "Parse a single expression, rather than a program (for parsing JSON)")
     .describe("p", "Skip prefix for original filenames that appear in source maps. \
 For example -p 3 will drop 3 directories from file names and ensure they are relative paths. \

--- a/test/compress/screw-ie8.js
+++ b/test/compress/screw-ie8.js
@@ -46,6 +46,8 @@ do_screw_try_catch: {
 }
 
 dont_screw_try_catch: {
+    // This test is known to generate incorrect code for screw_ie8=false.
+    // Update expected result in the event this bug is ever fixed.
     options = { screw_ie8: false };
     mangle = { screw_ie8: false };
     beautify = { screw_ie8: false };
@@ -102,6 +104,8 @@ do_screw_try_catch_undefined: {
 }
 
 dont_screw_try_catch_undefined: {
+    // This test is known to generate incorrect code for screw_ie8=false.
+    // Update expected result in the event this bug is ever fixed.
     options = { screw_ie8: false };
     mangle = { screw_ie8: false };
     beautify = { screw_ie8: false };
@@ -123,8 +127,8 @@ dont_screw_try_catch_undefined: {
             } catch (n) {
                 console.log("caught: "+n)
             }
-            console.log("undefined is " + void 0);
-            return void 0===o
+            console.log("undefined is " + n);
+            return o === n
         }
     }
 }

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -70,12 +70,12 @@ function test_directory(dir) {
     return path.resolve(tests_dir, dir);
 }
 
-function as_toplevel(input) {
+function as_toplevel(input, mangle_options) {
     if (input instanceof U.AST_BlockStatement) input = input.body;
     else if (input instanceof U.AST_Statement) input = [ input ];
     else throw new Error("Unsupported input syntax");
     var toplevel = new U.AST_Toplevel({ body: input });
-    toplevel.figure_out_scope();
+    toplevel.figure_out_scope(mangle_options);
     return toplevel;
 }
 
@@ -103,11 +103,11 @@ function run_compress_tests() {
             var output_options = test.beautify || {};
             var expect;
             if (test.expect) {
-                expect = make_code(as_toplevel(test.expect), output_options);
+                expect = make_code(as_toplevel(test.expect, test.mangle), output_options);
             } else {
                 expect = test.expect_exact;
             }
-            var input = as_toplevel(test.input);
+            var input = as_toplevel(test.input, test.mangle);
             var input_code = make_code(test.input, {
                 beautify: true,
                 quote_style: 3,

--- a/tools/node.js
+++ b/tools/node.js
@@ -94,7 +94,7 @@ exports.minify = function(files, options) {
     if (options.compress) {
         var compress = { warnings: options.warnings };
         UglifyJS.merge(compress, options.compress);
-        toplevel.figure_out_scope();
+        toplevel.figure_out_scope(options.mangle);
         var sq = UglifyJS.Compressor(compress);
         toplevel = sq.compress(toplevel);
     }


### PR DESCRIPTION
This PR started out as a doc fix: 

* Hopefully this PR will address the confusion over the use of `--support-ie8` and `screw_ie8=false`.

But then I noticed that both `minify()` and a test for `screw_ie8=false` were producing different results than the `uglifyjs` CLI with `--support-ie8`. It turns out that `figure_out_scope()` was called with different parameters in `minify()` and `test/run-tests.js` than in `bin/uglifyjs`. This PR unifies the behavior of `figure_out_scope()` in `bin/uglifyjs`, `minify()` and the test framework.

Warning: this will make `minify()` more bug compatible with `bin/uglifyjs` - for better or worse. In my view it's better to have one uniform behavior rather than two different ones given the same inputs - the divergence of `minify()` and `bin/uglifyjs` behavior was never intended.