### PR TITLE
[ES6] output parens for yield when parented by AST_Dot or AST_Sub

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -686,6 +686,12 @@ function OutputStream(options) {
         // -(yield 4)
         if (p instanceof AST_Unary)
             return true;
+        // (yield x).foo
+        if (p instanceof AST_Dot && p.expression === this)
+            return true;
+        // (yield x)['foo']
+        if (p instanceof AST_Sub && p.expression === this)
+            return true;
     });
 
     PARENS(AST_PropAccess, function(output){

--- a/test/compress/yield.js
+++ b/test/compress/yield.js
@@ -164,3 +164,29 @@ empty_generator_as_parameter_without_side_effects: {
     }
     expect_exact: "var GeneratorPrototype=Object.getPrototypeOf(Object.getPrototypeOf(function*(){}()));evaluate(GeneratorPrototype);"
 }
+
+yield_dot: {
+    options = {
+    }
+    input: {
+        function* foo(){
+            yield x.foo;
+            (yield x).foo;
+            yield (yield obj.foo()).bar();
+        }
+    }
+    expect_exact: "function*foo(){yield x.foo;(yield x).foo;yield(yield obj.foo()).bar()}"
+}
+
+yield_sub: {
+    options = {
+    }
+    input: {
+        function* foo(){
+            yield x['foo'];
+            (yield x)['foo'];
+            yield (yield obj.foo())['bar']();
+        }
+    }
+    expect_exact: 'function*foo(){yield x["foo"];(yield x)["foo"];yield(yield obj.foo())["bar"]()}'
+}


### PR DESCRIPTION
Fixes #1419