### PR TITLE
add missing LHS cases which global_defs should avoid

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -970,6 +970,11 @@ merge(Compressor.prototype, {
         node.DEFMETHOD("is_string", func);
     });
 
+    function isLHS(node, parent) {
+        return parent instanceof AST_Unary && (parent.operator === "++" || parent.operator === "--")
+            || parent instanceof AST_Assign && parent.left === node;
+    }
+
     function best_of(ast1, ast2) {
         return ast1.print_to_string().length >
             ast2.print_to_string().length
@@ -2608,14 +2613,6 @@ merge(Compressor.prototype, {
     });
 
     OPT(AST_SymbolRef, function(self, compressor){
-        function isLHS(symbol, parent) {
-            return (
-                parent instanceof AST_Binary &&
-                parent.operator === '=' &&
-                parent.left === symbol
-            );
-        }
-
         if (self.undeclared() && !isLHS(self, compressor.parent())) {
             var defines = compressor.option("global_defs");
             if (defines && HOP(defines, self.name)) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -220,7 +220,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
                 sym = g;
             }
             node.thedef = sym;
-            if (parent instanceof AST_Unary && (parent.operator === '++' || parent.operator === '--')
+            if (parent instanceof AST_Unary && (parent.operator === "++" || parent.operator === "--")
              || parent instanceof AST_Assign && parent.left === node) {
                 sym.modified = true;
             }

--- a/test/compress/issue-208.js
+++ b/test/compress/issue-208.js
@@ -1,11 +1,29 @@
 do_not_update_lhs: {
-    options = { global_defs: { DEBUG: false } };
-    input: { DEBUG = false; }
-    expect: { DEBUG = false; }
+    options = {
+        global_defs: { DEBUG: 0 }
+    }
+    input: {
+        DEBUG++;
+        DEBUG += 1;
+        DEBUG = 1;
+    }
+    expect: {
+        DEBUG++;
+        DEBUG += 1;
+        DEBUG = 1;
+    }
 }
 
 do_update_rhs: {
-    options = { global_defs: { DEBUG: false } };
-    input: { MY_DEBUG = DEBUG; }
-    expect: { MY_DEBUG = false; }
+    options = {
+        global_defs: { DEBUG: 0 }
+    }
+    input: {
+        MY_DEBUG = DEBUG;
+        MY_DEBUG += DEBUG;
+    }
+    expect: {
+        MY_DEBUG = 0;
+        MY_DEBUG += 0;
+    }
 }


### PR DESCRIPTION
#208 missed a few cases.

This PR is good on its own, though it's also part of my bigger plan to allow `global_defs` to accept objects and arrays. The next step after this and #1425 is to move https://github.com/mishoo/UglifyJS2/blob/master/lib/compress.js#L2620-L2623 into `evaluate()`.