### PR TITLE
make sure expression is AST_Binary

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2592,9 +2592,10 @@ merge(Compressor.prototype, {
         }
         // x && (y && z)  ==>  x && y && z
         // x || (y || z)  ==>  x || y || z
-        if (self.right instanceof AST_Binary
-            && self.right.operator == self.operator
-            && (self.operator == "&&" || self.operator == "||"))
+        if (self instanceof AST_Binary
+            && self.right instanceof AST_Binary
+            && self.right.operator === self.operator
+            && (self.operator === "&&" || self.operator === "||"))
         {
             self.left = make_node(AST_Binary, self.left, {
                 operator : self.operator,


### PR DESCRIPTION
This section of code which optimises chained Boolean expressions currently does not check if `self` remains an instance of `AST_Binary`. [This line](https://github.com/mishoo/UglifyJS2/blob/master/lib/compress.js#L2523) for example breaks that condition - seems like an accident waiting to happen.