### PR TITLE
fix mangling collision with keep_fnames

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -428,10 +428,11 @@ async.eachLimit(files, 1, function (file, cb) {
 
     var SCOPE_IS_NEEDED = COMPRESS || MANGLE || ARGS.lint
     var TL_CACHE = readNameCache("vars");
+    if (MANGLE) MANGLE.cache = TL_CACHE;
 
     if (SCOPE_IS_NEEDED) {
         time_it("scope", function(){
-            TOPLEVEL.figure_out_scope({ screw_ie8: screw_ie8, cache: TL_CACHE });
+            TOPLEVEL.figure_out_scope(MANGLE || { screw_ie8: screw_ie8, cache: TL_CACHE });
             if (ARGS.lint) {
                 TOPLEVEL.scope_warnings();
             }
@@ -446,7 +447,7 @@ async.eachLimit(files, 1, function (file, cb) {
 
     if (SCOPE_IS_NEEDED) {
         time_it("scope", function(){
-            TOPLEVEL.figure_out_scope({ screw_ie8: screw_ie8, cache: TL_CACHE });
+            TOPLEVEL.figure_out_scope(MANGLE || { screw_ie8: screw_ie8, cache: TL_CACHE });
             if (MANGLE && !TL_CACHE) {
                 TOPLEVEL.compute_char_frequency(MANGLE);
             }
@@ -454,7 +455,6 @@ async.eachLimit(files, 1, function (file, cb) {
     }
 
     if (MANGLE) time_it("mangle", function(){
-        MANGLE.cache = TL_CACHE;
         TOPLEVEL.mangle_names(MANGLE);
     });
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -224,7 +224,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
              || parent instanceof AST_Assign && parent.left === node) {
                 sym.modified = true;
             }
-            node.reference();
+            node.reference(options);
             return true;
         }
     });
@@ -255,13 +255,18 @@ AST_Lambda.DEFMETHOD("init_scope_vars", function(){
     this.variables.set(symbol.name, def);
 });
 
-AST_SymbolRef.DEFMETHOD("reference", function() {
+AST_SymbolRef.DEFMETHOD("reference", function(options) {
     var def = this.definition();
     def.references.push(this);
     var s = this.scope;
     while (s) {
         push_uniq(s.enclosed, def);
         if (s === def.scope) break;
+        if (options.keep_fnames) {
+            s.variables.each(function(d) {
+                push_uniq(def.scope.enclosed, d);
+            });
+        }
         s = s.parent_scope;
     }
     this.frame = this.scope.nesting - def.scope.nesting;
@@ -327,11 +332,6 @@ AST_Function.DEFMETHOD("next_mangled", function(options, def){
         if (!tricky_name || tricky_name != name)
             return name;
     }
-});
-
-AST_Scope.DEFMETHOD("references", function(sym){
-    if (sym instanceof AST_Symbol) sym = sym.definition();
-    return this.enclosed.indexOf(sym) < 0 ? null : sym;
 });
 
 AST_Symbol.DEFMETHOD("unmangleable", function(options){

--- a/test/compress/issue-1431.js
+++ b/test/compress/issue-1431.js
@@ -1,0 +1,122 @@
+level_one: {
+    options = {
+        keep_fnames: true
+    }
+    mangle = {
+        keep_fnames: true
+    }
+    input: {
+        function f(x) {
+            return function() {
+                function n(a) {
+                    return a * a;
+                }
+                return x(n);
+            };
+        }
+    }
+    expect: {
+        function f(r) {
+            return function() {
+                function n(n) {
+                    return n * n;
+                }
+                return r(n);
+            };
+        }
+    }
+}
+
+level_two: {
+    options = {
+        keep_fnames: true
+    }
+    mangle = {
+        keep_fnames: true
+    }
+    input: {
+        function f(x) {
+            return function() {
+                function r(a) {
+                    return a * a;
+                }
+                return function() {
+                    function n(a) {
+                        return a * a;
+                    }
+                    return x(n);
+                };
+            };
+        }
+    }
+    expect: {
+        function f(t) {
+            return function() {
+                function r(n) {
+                    return n * n;
+                }
+                return function() {
+                    function n(n) {
+                        return n * n;
+                    }
+                    return t(n);
+                };
+            };
+        }
+    }
+}
+
+level_three: {
+    options = {
+        keep_fnames: true
+    }
+    mangle = {
+        keep_fnames: true
+    }
+    input: {
+        function f(x) {
+            return function() {
+                function r(a) {
+                    return a * a;
+                }
+                return [
+                    function() {
+                        function t(a) {
+                            return a * a;
+                        }
+                        return t;
+                    },
+                    function() {
+                        function n(a) {
+                            return a * a;
+                        }
+                        return x(n);
+                    }
+                ];
+            };
+        }
+    }
+    expect: {
+        function f(t) {
+            return function() {
+                function r(n) {
+                    return n * n;
+                }
+                return [
+                    function() {
+                        function t(n) {
+                            return n * n;
+                        }
+                        return t;
+                    },
+                    function() {
+                        function n(n) {
+                            return n * n;
+                        }
+                        return t(n);
+                    }
+                ];
+            };
+        }
+    }
+}

--- a/test/input/issue-1431/sample.js
+++ b/test/input/issue-1431/sample.js
@@ -1,0 +1,14 @@
+function f(x) {
+    return function() {
+        function n(a) {
+            return a * a;
+        }
+        return x(n);
+    };
+}
+
+function g(op) {
+    return op(1) + op(2);
+}
+
+console.log(f(g)() == 5);

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -55,7 +55,7 @@ describe("bin/uglifyjs", function () {
        exec(command, function (err, stdout) {
            if (err) throw err;
 
-           assert.strictEqual(stdout, "var bar=function(){function foo(bar){return bar}return foo}();\n" + 
+           assert.strictEqual(stdout, "var bar=function(){function foo(bar){return bar}return foo}();\n" +
                "//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInRlc3QvaW5wdXQvaXNzdWUtMTMyMy9zYW1wbGUuanMiXSwibmFtZXMiOlsiYmFyIiwiZm9vIl0sIm1hcHBpbmdzIjoiQUFBQSxHQUFJQSxLQUFNLFdBQ04sUUFBU0MsS0FBS0QsS0FDVixNQUFPQSxLQUdYLE1BQU9DIn0=\n");
            done();
        });
@@ -69,5 +69,35 @@ describe("bin/uglifyjs", function () {
             assert.strictEqual(stdout, "var bar=function(){function foo(bar){return bar}return foo}();\n");
             done();
         });
+    });
+    it("Should work with --keep-fnames (mangle only)", function (done) {
+       var command = uglifyjscmd + ' test/input/issue-1431/sample.js --keep-fnames -m';
+
+       exec(command, function (err, stdout) {
+           if (err) throw err;
+
+           assert.strictEqual(stdout, "function f(r){return function(){function n(n){return n*n}return r(n)}}function g(n){return n(1)+n(2)}console.log(f(g)()==5);\n");
+           done();
+       });
+    });
+    it("Should work with --keep-fnames (mangle & compress)", function (done) {
+       var command = uglifyjscmd + ' test/input/issue-1431/sample.js --keep-fnames -m -c';
+
+       exec(command, function (err, stdout) {
+           if (err) throw err;
+
+           assert.strictEqual(stdout, "function f(r){return function(){function n(n){return n*n}return r(n)}}function g(n){return n(1)+n(2)}console.log(5==f(g)());\n");
+           done();
+       });
+    });
+    it("Should work with keep_fnames under mangler options", function (done) {
+       var command = uglifyjscmd + ' test/input/issue-1431/sample.js -m keep_fnames=true';
+
+       exec(command, function (err, stdout) {
+           if (err) throw err;
+
+           assert.strictEqual(stdout, "function f(r){return function(){function n(n){return n*n}return r(n)}}function g(n){return n(1)+n(2)}console.log(f(g)()==5);\n");
+           done();
+       });
     });
 });


### PR DESCRIPTION
Historically, `AST_Scope.enclosed` is used by [`AST_Scope.references()`](https://github.com/mishoo/UglifyJS2/blob/48284844a461e6113bb9911cdcdad7ab8a3d85de/lib/scope.js#L332-L335) and [`AST_Scope.next_mangled()`](https://github.com/mishoo/UglifyJS2/blob/48284844a461e6113bb9911cdcdad7ab8a3d85de/lib/scope.js#L293-L313), with the former (now) unused within the code base.

Removing this line [introduced years ago](https://github.com/mishoo/UglifyJS2/commit/5053a29bc0b723bbf468f50e0434c3eff38600e2) would ensure all child symbol references to be scanned by `next_mangled()` for possible name collision. Before this change, the scan would only work if all the children would rename itself after their parents settle down onto a mangled value, which cannot happen if the child is unmangleable, e.g. `keep_fnames = true`.

Fixes #1423 