### PR TITLE
fix mangling collision with keep_fnames (take 2)

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -224,7 +224,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
              || parent instanceof AST_Assign && parent.left === node) {
                 sym.modified = true;
             }
-            node.reference();
+            node.reference(options);
             return true;
         }
     });
@@ -255,13 +255,18 @@ AST_Lambda.DEFMETHOD("init_scope_vars", function(){
     this.variables.set(symbol.name, def);
 });
 
-AST_SymbolRef.DEFMETHOD("reference", function() {
+AST_SymbolRef.DEFMETHOD("reference", function(options) {
     var def = this.definition();
     def.references.push(this);
     var s = this.scope;
     while (s) {
         push_uniq(s.enclosed, def);
         if (s === def.scope) break;
+        if (options.keep_fnames) {
+            s.variables.each(function(d) {
+                push_uniq(def.scope.enclosed, d);
+            });
+        }
         s = s.parent_scope;
     }
     this.frame = this.scope.nesting - def.scope.nesting;
@@ -327,11 +332,6 @@ AST_Function.DEFMETHOD("next_mangled", function(options, def){
         if (!tricky_name || tricky_name != name)
             return name;
     }
-});
-
-AST_Scope.DEFMETHOD("references", function(sym){
-    if (sym instanceof AST_Symbol) sym = sym.definition();
-    return this.enclosed.indexOf(sym) < 0 ? null : sym;
 });
 
 AST_Symbol.DEFMETHOD("unmangleable", function(options){

--- a/test/compress/issue-1423.js
+++ b/test/compress/issue-1423.js
@@ -1,0 +1,122 @@
+level_one: {
+    options = {
+        keep_fnames: true
+    }
+    mangle = {
+        keep_fnames: true
+    }
+    input: {
+        function f(x) {
+            return function() {
+                function n(a) {
+                    return a * a;
+                }
+                return x(n);
+            };
+        }
+    }
+    expect: {
+        function f(r) {
+            return function() {
+                function n(n) {
+                    return n * n;
+                }
+                return r(n);
+            };
+        }
+    }
+}
+
+level_two: {
+    options = {
+        keep_fnames: true
+    }
+    mangle = {
+        keep_fnames: true
+    }
+    input: {
+        function f(x) {
+            return function() {
+                function r(a) {
+                    return a * a;
+                }
+                return function() {
+                    function n(a) {
+                        return a * a;
+                    }
+                    return x(n);
+                };
+            };
+        }
+    }
+    expect: {
+        function f(t) {
+            return function() {
+                function r(n) {
+                    return n * n;
+                }
+                return function() {
+                    function n(n) {
+                        return n * n;
+                    }
+                    return t(n);
+                };
+            };
+        }
+    }
+}
+
+level_three: {
+    options = {
+        keep_fnames: true
+    }
+    mangle = {
+        keep_fnames: true
+    }
+    input: {
+        function f(x) {
+            return function() {
+                function r(a) {
+                    return a * a;
+                }
+                return [
+                    function() {
+                        function t(a) {
+                            return a * a;
+                        }
+                        return t;
+                    },
+                    function() {
+                        function n(a) {
+                            return a * a;
+                        }
+                        return x(n);
+                    }
+                ];
+            };
+        }
+    }
+    expect: {
+        function f(t) {
+            return function() {
+                function r(n) {
+                    return n * n;
+                }
+                return [
+                    function() {
+                        function t(n) {
+                            return n * n;
+                        }
+                        return t;
+                    },
+                    function() {
+                        function n(n) {
+                            return n * n;
+                        }
+                        return t(n);
+                    }
+                ];
+            };
+        }
+    }
+}


### PR DESCRIPTION
- produces better mangled names without unnecessary collisions as with #1431
- extra logic gated by `options.keep_fnames` to preserve performance in the general case
- fixes more corner cases than #1431