### PR TITLE
Improve if/return optimisation without a trailing return after if block (with return statement)

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -546,7 +546,7 @@ merge(Compressor.prototype, {
             var self = compressor.self();
             var multiple_if_returns = has_multiple_if_returns(statements);
             var in_lambda = self instanceof AST_Lambda;
-            var ret = [];
+            var ret = []; // Optimized statements, build from tail to front
             loop: for (var i = statements.length; --i >= 0;) {
                 var stat = statements[i];
                 switch (true) {
@@ -607,19 +607,21 @@ merge(Compressor.prototype, {
                             ret = funs.concat([ stat.transform(compressor) ]);
                             continue loop;
                         }
+
                         //---
-                        // XXX: what was the intention of this case?
+                        // if (a) return b; if (c) return d; e; ==> return a ? b : c ? d : void e;
+                        //
                         // if sequences is not enabled, this can lead to an endless loop (issue #866).
                         // however, with sequences on this helps producing slightly better output for
                         // the example code.
                         if (compressor.option("sequences")
+                            && i > 0 && statements[i - 1] instanceof AST_If && statements[i - 1].body instanceof AST_Return
                             && ret.length == 1 && in_lambda && ret[0] instanceof AST_SimpleStatement
-                            && (!stat.alternative || stat.alternative instanceof AST_SimpleStatement)) {
+                            && !stat.alternative) {
                             CHANGED = true;
                             ret.push(make_node(AST_Return, ret[0], {
                                 value: make_node(AST_Undefined, ret[0])
                             }).transform(compressor));
-                            ret = as_statement_array(stat.alternative).concat(ret);
                             ret.unshift(stat);
                             continue loop;
                         }

--- a/test/compress/if_return.js
+++ b/test/compress/if_return.js
@@ -170,8 +170,51 @@ if_return_7: {
         }
     }
     expect: {
-        // suboptimal
-        function f(x){return!!x||(foo(),void bar())}
+        function f(x){if(x)return!0;foo(),bar()}
+    }
+}
+
+if_return_8: {
+    options = {
+        if_return:     true,
+        sequences:     true,
+        conditionals:  true,
+        side_effects : true,
+    }
+    input: {
+        function f(e) {
+            if (2 == e) return foo();
+            if (3 == e) return bar();
+            if (4 == e) return baz();
+            fail(e);
+        }
+
+        function g(e) {
+            if (a(e)) return foo();
+            if (b(e)) return bar();
+            if (c(e)) return baz();
+            fail(e);
+        }
+
+        function h(e) {
+            if (a(e)) return foo();
+            else if (b(e)) return bar();
+            else if (c(e)) return baz();
+            else fail(e);
+        }
+
+        function i(e) {
+            if (a(e)) return foo();
+            else if (b(e)) return bar();
+            else if (c(e)) return baz();
+            fail(e);
+        }
+    }
+    expect: {
+        function f(e){return 2==e?foo():3==e?bar():4==e?baz():void fail(e)}
+        function g(e){return a(e)?foo():b(e)?bar():c(e)?baz():void fail(e)}
+        function h(e){return a(e)?foo():b(e)?bar():c(e)?baz():void fail(e)}
+        function i(e){return a(e)?foo():b(e)?bar():c(e)?baz():void fail(e)}
     }
 }
 
@@ -202,6 +245,60 @@ issue_1089: {
             var f = document.getElementById("fname");
             if (f.files[0].size > 12345)
                 return alert("alert"), f.focus(), !1;
+        }
+    }
+}
+
+issue_1437: {
+    options = {
+        if_return    : true,
+        sequences    : true,
+        conditionals : false
+    }
+    input: {
+        function x() {
+            if (a())
+                return b();
+            if (c())
+                return d();
+            else
+                e();
+            f();
+        }
+    }
+    expect: {
+        function x() {
+            if (a())
+                return b();
+            if (c())
+                return d();
+            else
+                e()
+            f();
+        }
+    }
+}
+
+issue_1437_conditionals: {
+    options = {
+        conditionals : true,
+        if_return    : true,
+        sequences    : true
+    }
+    input: {
+        function x() {
+            if (a())
+                return b();
+            if (c())
+                return d();
+            else
+                e();
+            f();
+        }
+    }
+    expect: {
+        function x() {
+            return a() ? b() : c() ? d() : (e(), f(), void 0);
         }
     }
 }

--- a/test/compress/issue-979.js
+++ b/test/compress/issue-979.js
@@ -82,7 +82,7 @@ issue979_test_negated_is_best: {
             1!=a||2!=b||foo();
         }
         function f7() {
-            return 1!=a&&2!=b?bar():void foo();
+            if(1!=a&&2!=b)return bar();foo()
         }
     }
 }

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -4,7 +4,7 @@ var exec = require("child_process").exec;
 describe("bin/uglifyjs", function () {
     var uglifyjscmd = '"' + process.argv[0] + '" bin/uglifyjs';
     it("should produce a functional build when using --self", function (done) {
-        this.timeout(5000);
+        this.timeout(15000);
 
         var command = uglifyjscmd + ' --self -cm --wrap WrappedUglifyJS';
 


### PR DESCRIPTION
Only apply the optimization in question when a return keyword can be removed.

\<old intro>
Still need to consider if this optimization is totally useless.

Pro case:
- Joins multiple statements into 1 statement, which could be useful for `return cond ? if_body : (alternative_or_tail)`

Contra case:
- Adding undefined to the last statement makes it produce longer code.
- Current transformer typically creates longer code with given code cases
- Other transformers can join multiple statements into 1 as well, I'm not sure if there are cases where it isn't

</old intro>