### PR TITLE
[ES6] Fix walker not able to handle destr pattern in spread when compressing

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1922,6 +1922,8 @@ merge(Compressor.prototype, {
                             else if (node.names[i] instanceof AST_Expansion) {
                                 if (node.names[i].expression instanceof AST_Symbol) {
                                     initializations.add(node.names[i].expression.name, destructuring_value);
+                                } else if (node.names[i].expression instanceof AST_Destructuring) {
+                                    node.names[i].expression.walk(tw);
                                 } else {
                                     throw new Error(string_template("Can't handle expansion of type: {type}", {
                                         type: Object.getPrototypeOf(node.names[i].expression).TYPE

--- a/test/compress/destructuring.js
+++ b/test/compress/destructuring.js
@@ -151,8 +151,12 @@ destructuring_remove_unused_1: {
         function e() {
             var unused = "foo";
             var a = [1, 2, 3, 4, 5];
+            var x = [[1, 2, 3]];
+            var y = {h: 1};
             var [b, ...c] = a;
-            f(b, c);
+            var [...[e, f]] = x;
+            var [...{g: h}] = y;
+            f(b, c, e, f, g);
         }
     }
     expect: {
@@ -178,8 +182,12 @@ destructuring_remove_unused_1: {
         }
         function e() {
             var a = [1, 2, 3, 4, 5];
+            var x = [[1, 2, 3]];
+            var y = {h: 1};
             var [b, ...c] = a;
-            f(b, c);
+            var [...[e, f]] = x;
+            var [...{g: h}] = y;
+            f(b, c, e, f, g);
         }
     }
 }


### PR DESCRIPTION
Currently still failing

```
language\statements\variable\dstr-ary-ptrn-rest-obj-prop-id
language\statements\variable\dstr-obj-ptrn-prop-eval-err
```

These are probably dependent on changes in #1417