### PR TITLE
[ES6] Allow parsing regexp after arrow token

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -335,7 +335,8 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
     function token(type, value, is_comment) {
         S.regex_allowed = ((type == "operator" && !UNARY_POSTFIX(value)) ||
                            (type == "keyword" && KEYWORDS_BEFORE_EXPRESSION(value)) ||
-                           (type == "punc" && PUNC_BEFORE_EXPRESSION(value)));
+                           (type == "punc" && PUNC_BEFORE_EXPRESSION(value))) ||
+                           (type == "arrow");
         prev_was_dot = (type == "punc" && value == ".");
         var ret = {
             type    : type,

--- a/test/compress/arrow.js
+++ b/test/compress/arrow.js
@@ -126,3 +126,12 @@ arrow_binding_pattern_strict: {
     }
     expect_exact: 'var foo=([,])=>"foo";'
 }
+
+arrow_with_regexp: {
+    input: {
+        num => /\d{11,14}/.test( num )
+    }
+    expect: {
+        num => /\d{11,14}/.test( num )
+    }
+}


### PR DESCRIPTION
Fixes #1428