### PR TITLE
fix crash in unsafe replacement of undefined

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2719,13 +2719,11 @@ merge(Compressor.prototype, {
             var scope = compressor.find_parent(AST_Scope);
             var undef = scope.find_variable("undefined");
             if (undef) {
-                var ref = make_node(AST_SymbolRef, self, {
+                return make_node(AST_SymbolRef, self, {
                     name   : "undefined",
                     scope  : scope,
                     thedef : undef
                 });
-                ref.reference();
-                return ref;
             }
         }
         return self;

--- a/test/compress/issue-1443.js
+++ b/test/compress/issue-1443.js
@@ -1,0 +1,69 @@
+// tests assume that variable `undefined` not redefined and has `void 0` as value
+
+unsafe_undefined: {
+    options = {
+        if_return: true,
+        unsafe: true
+    }
+    mangle = {}
+    input: {
+        function f(undefined) {
+            return function() {
+                if (a)
+                    return b;
+                if (c)
+                    return d;
+            };
+        }
+    }
+    expect: {
+        function f(n) {
+            return function() {
+                if (a)
+                    return b;
+                if (c)
+                    return d;
+                else
+                    return n;
+            };
+        }
+    }
+}
+
+keep_fnames: {
+    options = {
+        if_return: true,
+        unsafe: true
+    }
+    mangle = {
+        keep_fnames: true
+    }
+    input: {
+        function f(undefined) {
+            return function() {
+                function n(a) {
+                    return a * a;
+                }
+                if (a)
+                    return b;
+                if (c)
+                    return d;
+            };
+        }
+    }
+    expect: {
+        function f(r) {
+            return function() {
+                function n(n) {
+                    return n * n;
+                }
+                if (a)
+                    return b;
+                if (c)
+                    return d;
+                else
+                    return r;
+            };
+        }
+    }
+}


### PR DESCRIPTION
There is [a call to](https://github.com/mishoo/UglifyJS2/blob/0610c020b1544820be9898a285ab6c9066490552/lib/compress.js#L2727) `AST_SymbolRef.reference()` within `compress.js`, which is the optimisation rule of mapping `undefined` to variable of the same name, guarded under `unsafe` flag. As it does not pass in any mangle `options` object, this results in `TypeError: Unable to get property 'keep_fnames' of undefined or null reference`.

`AST_SymbolRef.reference()` [is used to populate](https://github.com/mishoo/UglifyJS2/blob/1eaa211e0932105439d98d4f03a981f157f0a77c/lib/scope.js#L267-L282) `AST_Scope.enclosed` array (also `AST_SymbolRef.frame` integer, but seems unused), which [is only used by mangler](https://github.com/mishoo/UglifyJS2/blob/1eaa211e0932105439d98d4f03a981f157f0a77c/lib/scope.js#L308).

Now in both [command-line](https://github.com/mishoo/UglifyJS2/blob/1eaa211e0932105439d98d4f03a981f157f0a77c/bin/uglifyjs#L450) and [API](https://github.com/mishoo/UglifyJS2/blob/ec2e5fa3a2e5cf421aebd94b93c668b18e540c69/tools/node.js#L111) use cases, call to `mangle_names()` is preceded by a call to `figure_out_scope(<mangle options>)`, so there is no need for code within `compress.js` to call `AST_SymbolRef.reference()` at all.