### PR TITLE
fix corner case in keep_fnames

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -270,12 +270,12 @@ AST_SymbolRef.DEFMETHOD("reference", function(options) {
     var s = this.scope;
     while (s) {
         push_uniq(s.enclosed, def);
-        if (s === def.scope) break;
         if (options.keep_fnames) {
-            s.variables.each(function(d) {
+            s.functions.each(function(d) {
                 push_uniq(def.scope.enclosed, d);
             });
         }
+        if (s === def.scope) break;
         s = s.parent_scope;
     }
     this.frame = this.scope.nesting - def.scope.nesting;

--- a/test/compress/issue-1431.js
+++ b/test/compress/issue-1431.js
@@ -1,3 +1,32 @@
+level_zero: {
+    options = {
+        keep_fnames: true
+    }
+    mangle = {
+        keep_fnames: true
+    }
+    input: {
+        function f(x) {
+            function n(a) {
+                return a * a;
+            }
+            return function() {
+                return x;
+            };
+        }
+    }
+    expect: {
+        function f(r) {
+            function n(n) {
+                return n * n;
+            }
+            return function() {
+                return r;
+            };
+        }
+    }
+}
+
 level_one: {
     options = {
         keep_fnames: true


### PR DESCRIPTION
Happens when inner function:
- just below top level
- not referenced
- `unused` is disabled

Now also iterates over function definitions only when adding to `enclosed` during `keep_fnames=true`, so performance should improve as well.

Quick notes on why I think it's safe to iterate over `AST_Scope.functions` instead of `AST_Scope.variables`:
- only `AST_SymbolLambda` & `AST_SymbolDefun` can be [unmangleable](https://github.com/mishoo/UglifyJS2/blob/1eaa211e0932105439d98d4f03a981f157f0a77c/lib/scope.js#L68-L70) under `keep_fnames`
- both node types [call](https://github.com/mishoo/UglifyJS2/blob/1eaa211e0932105439d98d4f03a981f157f0a77c/lib/scope.js#L147-L157) `AST_Scope.def_function()` when processed by `figure_out_scope()`
- `def_function()` [sets `AST_Scope.functions` and calls `def_variable()`](https://github.com/mishoo/UglifyJS2/blob/1eaa211e0932105439d98d4f03a981f157f0a77c/lib/scope.js#L291), which in turn [sets `AST_Scope.variables`](https://github.com/mishoo/UglifyJS2/blob/1eaa211e0932105439d98d4f03a981f157f0a77c/lib/scope.js#L298)