### PR TITLE
Support marking a call as pure

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1273,21 +1273,26 @@ merge(Compressor.prototype, {
         def(AST_Constant, return_false);
         def(AST_This, return_false);
 
-        var pure_regex = /[@#]__PURE__/;
+        var pure_regex = /[@#]__PURE__/g;
         function has_pure_annotation(node) {
             if (node.pure !== undefined) return node.pure;
             var pure = false;
+            var comments, last_comment;
             if (node.start
-                && node.start.comments_before
-                && node.start.comments_before.length
-                && pure_regex.test(node.start.comments_before[node.start.comments_before.length - 1].value)) {
+                && (comments = node.start.comments_before)
+                && comments.length
+                && pure_regex.test((last_comment = comments[comments.length - 1]).value)) {
+                last_comment.value = last_comment.value.replace(pure_regex, ' ');
                 pure = true;
             }
             return node.pure = pure;
         }
 
         def(AST_Call, function(compressor){
-            if (has_pure_annotation(this)) return false;
+            if (has_pure_annotation(this)) {
+                compressor.warn("Dropping __PURE__ call [{file}:{line},{col}]", this.start);
+                return false;
+            }
             var pure = compressor.option("pure_funcs");
             if (!pure) return true;
             if (typeof pure == "function") return pure(this);

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1273,7 +1273,21 @@ merge(Compressor.prototype, {
         def(AST_Constant, return_false);
         def(AST_This, return_false);
 
+        var pure_regex = /[@#]__PURE__/;
+        function has_pure_annotation(node) {
+            if (node.pure !== undefined) return node.pure;
+            var pure = false;
+            if (node.start
+                && node.start.comments_before
+                && node.start.comments_before.length
+                && pure_regex.test(node.start.comments_before[node.start.comments_before.length - 1].value)) {
+                pure = true;
+            }
+            return node.pure = pure;
+        }
+
         def(AST_Call, function(compressor){
+            if (has_pure_annotation(this)) return false;
             var pure = compressor.option("pure_funcs");
             if (!pure) return true;
             if (typeof pure == "function") return pure(this);

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1288,7 +1288,7 @@ merge(Compressor.prototype, {
         }
 
         def(AST_Call, function(compressor){
-            if (has_pure_annotation(this)) {
+            if (compressor.option("side_effects") && has_pure_annotation(this)) {
                 compressor.warn("Dropping __PURE__ call [{file}:{line},{col}]", this.start);
                 return false;
             }

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1273,7 +1273,6 @@ merge(Compressor.prototype, {
         def(AST_Constant, return_false);
         def(AST_This, return_false);
 
-        var pure_regex = /[@#]__PURE__/g;
         function has_pure_annotation(node) {
             if (node.pure !== undefined) return node.pure;
             var pure = false;
@@ -1281,8 +1280,8 @@ merge(Compressor.prototype, {
             if (node.start
                 && (comments = node.start.comments_before)
                 && comments.length
-                && pure_regex.test((last_comment = comments[comments.length - 1]).value)) {
-                last_comment.value = last_comment.value.replace(pure_regex, ' ');
+                && /[@#]__PURE__/.test((last_comment = comments[comments.length - 1]).value)) {
+                last_comment.value = last_comment.value.replace(/[@#]__PURE__/g, ' ');
                 pure = true;
             }
             return node.pure = pure;

--- a/test/compress/issue-1261.js
+++ b/test/compress/issue-1261.js
@@ -1,0 +1,51 @@
+pure_function_calls: {
+    options = {
+        evaluate     : true,
+        conditionals : true,
+        comparisons  : true,
+        side_effects : true,
+        booleans     : true,
+        unused       : true,
+        if_return    : true,
+        join_vars    : true,
+        cascade      : true,
+        negate_iife  : true,
+    }
+    input: {
+        // pure top-level IIFE will be dropped
+        // @__PURE__ - comment
+        (function() {
+            console.log("iife0");
+        })();
+
+        // pure top-level IIFE assigned to unreferenced var will not be dropped
+        var iife1 = /*@__PURE__*/(function() {
+            console.log("iife1");
+            function iife1() {}
+            return iife1;
+        })();
+
+        (function(){
+            // pure IIFE in function scope assigned to unreferenced var will be dropped
+            var iife2 = /*#__PURE__*/(function() {
+                console.log("iife2");
+                function iife2() {}
+                return iife2;
+            })();
+        })();
+
+        // comment #__PURE__ comment
+        bar(), baz(), quux();
+        a.b(), /* @__PURE__ */ c.d.e(), f.g();
+    }
+    expect: {
+        var iife1 = function() {
+            console.log("iife1");
+            function iife1() {}
+            return iife1;
+        }();
+
+        baz(), quux();
+        a.b(), f.g();
+    }
+}

--- a/test/compress/issue-1261.js
+++ b/test/compress/issue-1261.js
@@ -48,4 +48,13 @@ pure_function_calls: {
         baz(), quux();
         a.b(), f.g();
     }
+    expect_warnings: [
+        "WARN: Dropping __PURE__ call [test/compress/issue-1261.js:17,8]",
+        "WARN: Dropping side-effect-free statement [test/compress/issue-1261.js:17,8]",
+        "WARN: Dropping __PURE__ call [test/compress/issue-1261.js:30,37]",
+        "WARN: Dropping unused variable iife2 [test/compress/issue-1261.js:30,16]",
+        "WARN: Dropping side-effect-free statement [test/compress/issue-1261.js:28,8]",
+        "WARN: Dropping __PURE__ call [test/compress/issue-1261.js:38,8]",
+        "WARN: Dropping __PURE__ call [test/compress/issue-1261.js:39,31]"
+    ]
 }

--- a/test/mocha/minify.js
+++ b/test/mocha/minify.js
@@ -95,4 +95,19 @@ describe("minify", function() {
             assert.strictEqual(code, "var a=function(n){return n};");
         });
     });
+
+    describe("#__PURE__", function() {
+        it("should drop #__PURE__ hint after use", function() {
+            var result = Uglify.minify('//@__PURE__ comment1 #__PURE__ comment2\n foo(), bar();', {
+                fromString: true,
+                output: {
+                    comments: "all",
+                    beautify: false,
+                }
+            });
+            var code = result.code;
+            assert.strictEqual(code, "//  comment1   comment2\nbar();");
+        });
+    });
+
 });


### PR DESCRIPTION
Fixes: #1261

A function call or IIFE with an immediately preceding comment containing `@__PURE__` or `#__PURE__` is deemed to be a side-effect-free pure function call and can potentially be dropped.

Related: https://github.com/Microsoft/TypeScript/issues/13721