### PR TITLE
drop unused: toplevel, assign-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,15 @@ to set `true`; it's effectively a shortcut for `foo=true`).
 - `loops` -- optimizations for `do`, `while` and `for` loops when we can
   statically determine the condition
 
-- `unused` -- drop unreferenced functions and variables
+- `unused` -- drop unreferenced functions and variables (simple direct variable
+  assignments do not count as references unless set to `"keep_assign"`)
+
+- `toplevel` -- drop unreferenced functions (`"funcs"`) and/or variables (`"vars"`)
+  in the toplevel scope (`false` by default, `true` to drop both unreferenced
+  functions and variables)
+
+- `top_retain` -- prevent specific toplevel functions and variables from `unused`
+  removal (can be array, comma-separated, RegExp or function. Implies `toplevel`)
 
 - `hoist_funs` -- hoist function declarations
 

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -60,6 +60,8 @@ function Compressor(options, false_by_default) {
         booleans      : !false_by_default,
         loops         : !false_by_default,
         unused        : !false_by_default,
+        toplevel      : !!options["top_retain"],
+        top_retain    : null,
         hoist_funs    : !false_by_default,
         keep_fargs    : true,
         keep_fnames   : false,
@@ -80,6 +82,21 @@ function Compressor(options, false_by_default) {
         global_defs   : {},
         passes        : 1,
     }, true);
+    var top_retain = this.options["top_retain"];
+    if (top_retain instanceof RegExp) {
+        this.top_retain = function(def) {
+            return top_retain.test(def.name);
+        };
+    } else if (typeof top_retain === "function") {
+        this.top_retain = top_retain;
+    } else if (top_retain) {
+        if (typeof top_retain === "string") {
+            top_retain = top_retain.split(/,/);
+        }
+        this.top_retain = function(def) {
+            return top_retain.indexOf(def.name) >= 0;
+        };
+    }
     var sequences = this.options["sequences"];
     this.sequences_limit = sequences == 1 ? 200 : sequences | 0;
     this.warnings_produced = {};
@@ -1407,13 +1424,27 @@ merge(Compressor.prototype, {
     AST_Scope.DEFMETHOD("drop_unused", function(compressor){
         var self = this;
         if (compressor.has_directive("use asm")) return self;
+        var toplevel = compressor.option("toplevel");
         if (compressor.option("unused")
-            && !(self instanceof AST_Toplevel)
+            && (!(self instanceof AST_Toplevel) || toplevel)
             && !self.uses_eval
-            && !self.uses_with
-           ) {
+            && !self.uses_with) {
+            var assign_as_unused = !/keep_assign/.test(compressor.option("unused"));
+            var drop_funcs = /funcs/.test(toplevel);
+            var drop_vars = /vars/.test(toplevel);
+            if (!(self instanceof AST_Toplevel) || toplevel == true) {
+                drop_funcs = drop_vars = true;
+            }
             var in_use = [];
             var in_use_ids = {}; // avoid expensive linear scans of in_use
+            if (self instanceof AST_Toplevel && compressor.top_retain) {
+                self.variables.each(function(def) {
+                    if (compressor.top_retain(def) && !(def.id in in_use_ids)) {
+                        in_use_ids[def.id] = true;
+                        in_use.push(def);
+                    }
+                });
+            }
             var initializations = new Dictionary();
             // pass 1: find out which symbols are directly used in
             // this scope (not in nested scopes).
@@ -1421,11 +1452,25 @@ merge(Compressor.prototype, {
             var tw = new TreeWalker(function(node, descend){
                 if (node !== self) {
                     if (node instanceof AST_Defun) {
+                        if (!drop_funcs && scope === self) {
+                            var node_def = node.name.definition();
+                            if (!(node_def.id in in_use_ids)) {
+                                in_use_ids[node_def.id] = true;
+                                in_use.push(node_def);
+                            }
+                        }
                         initializations.add(node.name.name, node);
                         return true; // don't go in nested scopes
                     }
                     if (node instanceof AST_Definitions && scope === self) {
                         node.definitions.forEach(function(def){
+                            if (!drop_vars) {
+                                var node_def = def.name.definition();
+                                if (!(node_def.id in in_use_ids)) {
+                                    in_use_ids[node_def.id] = true;
+                                    in_use.push(node_def);
+                                }
+                            }
                             if (def.value) {
                                 initializations.add(def.name.name, def.value);
                                 if (def.value.has_side_effects(compressor)) {
@@ -1433,6 +1478,14 @@ merge(Compressor.prototype, {
                                 }
                             }
                         });
+                        return true;
+                    }
+                    if (assign_as_unused
+                        && node instanceof AST_Assign
+                        && node.operator == "="
+                        && node.left instanceof AST_SymbolRef
+                        && scope === self) {
+                        node.right.walk(tw);
                         return true;
                     }
                     if (node instanceof AST_SymbolRef) {
@@ -1494,7 +1547,7 @@ merge(Compressor.prototype, {
                             }
                         }
                     }
-                    if (node instanceof AST_Defun && node !== self) {
+                    if (drop_funcs && node instanceof AST_Defun && node !== self) {
                         if (!(node.name.definition().id in in_use_ids)) {
                             compressor.warn("Dropping unused function {name} [{file}:{line},{col}]", {
                                 name : node.name.name,
@@ -1506,7 +1559,7 @@ merge(Compressor.prototype, {
                         }
                         return node;
                     }
-                    if (node instanceof AST_Definitions && !(tt.parent() instanceof AST_ForIn)) {
+                    if (drop_vars && node instanceof AST_Definitions && !(tt.parent() instanceof AST_ForIn)) {
                         var def = node.definitions.filter(function(def){
                             if (def.name.definition().id in in_use_ids) return true;
                             var w = {
@@ -1568,6 +1621,15 @@ merge(Compressor.prototype, {
                             return in_list ? MAP.splice(side_effects.body) : side_effects;
                         }
                         return node;
+                    }
+                    if (drop_vars && assign_as_unused
+                        && node instanceof AST_Assign
+                        && node.operator == "="
+                        && node.left instanceof AST_SymbolRef) {
+                        var def = node.left.definition();
+                        if (!(def.id in in_use_ids) && self.variables.get(def.name) === def) {
+                            return node.right;
+                        }
                     }
                     if (node instanceof AST_For) {
                         descend(node, this);

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -177,3 +177,382 @@ keep_fnames: {
         }
     }
 }
+
+drop_assign: {
+    options = { unused: true };
+    input: {
+        function f1() {
+            var a;
+            a = 1;
+        }
+        function f2() {
+            var a = 1;
+            a = 2;
+        }
+        function f3(a) {
+            a = 1;
+        }
+        function f4() {
+            var a;
+            return a = 1;
+        }
+        function f5() {
+            var a;
+            return function() {
+                a = 1;
+            }
+        }
+    }
+    expect: {
+        function f1() {
+            1;
+        }
+        function f2() {
+            2;
+        }
+        function f3(a) {
+            1;
+        }
+        function f4() {
+            return 1;
+        }
+        function f5() {
+            var a;
+            return function() {
+                a = 1;
+            }
+        }
+    }
+}
+
+keep_assign: {
+    options = { unused: "keep_assign" };
+    input: {
+        function f1() {
+            var a;
+            a = 1;
+        }
+        function f2() {
+            var a = 1;
+            a = 2;
+        }
+        function f3(a) {
+            a = 1;
+        }
+        function f4() {
+            var a;
+            return a = 1;
+        }
+        function f5() {
+            var a;
+            return function() {
+                a = 1;
+            }
+        }
+    }
+    expect: {
+        function f1() {
+            var a;
+            a = 1;
+        }
+        function f2() {
+            var a = 1;
+            a = 2;
+        }
+        function f3(a) {
+            a = 1;
+        }
+        function f4() {
+            var a;
+            return a = 1;
+        }
+        function f5() {
+            var a;
+            return function() {
+                a = 1;
+            }
+        }
+    }
+}
+
+drop_toplevel_funcs: {
+    options = { toplevel: "funcs", unused: true };
+    input: {
+        var a, b = 1, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        function h() {}
+        console.log(b = 3);
+    }
+    expect: {
+        var a, b = 1, c = g;
+        a = 2;
+        function g() {}
+        console.log(b = 3);
+    }
+}
+
+drop_toplevel_vars: {
+    options = { toplevel: "vars", unused: true };
+    input: {
+        var a, b = 1, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        function h() {}
+        console.log(b = 3);
+    }
+    expect: {
+        var c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        2;
+        function g() {}
+        function h() {}
+        console.log(3);
+    }
+}
+
+drop_toplevel_vars_fargs: {
+    options = { keep_fargs: false, toplevel: "vars", unused: true };
+    input: {
+        var a, b = 1, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        function h() {}
+        console.log(b = 3);
+    }
+    expect: {
+        var c = g;
+        function f() {
+            return function() {
+                c = 2;
+            }
+        }
+        2;
+        function g() {}
+        function h() {}
+        console.log(3);
+    }
+}
+
+drop_toplevel_all: {
+    options = { toplevel: true, unused: true };
+    input: {
+        var a, b = 1, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        function h() {}
+        console.log(b = 3);
+    }
+    expect: {
+        2;
+        console.log(3);
+    }
+}
+
+drop_toplevel_retain: {
+    options = { top_retain: "f,a,o", unused: true };
+    input: {
+        var a, b = 1, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        function h() {}
+        console.log(b = 3);
+    }
+    expect: {
+        var a, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        console.log(3);
+    }
+}
+
+drop_toplevel_retain_array: {
+    options = { top_retain: [ "f", "a", "o" ], unused: true };
+    input: {
+        var a, b = 1, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        function h() {}
+        console.log(b = 3);
+    }
+    expect: {
+        var a, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        console.log(3);
+    }
+}
+
+drop_toplevel_retain_regex: {
+    options = { top_retain: /^[fao]$/, unused: true };
+    input: {
+        var a, b = 1, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        function h() {}
+        console.log(b = 3);
+    }
+    expect: {
+        var a, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        console.log(3);
+    }
+}
+
+drop_toplevel_all_retain: {
+    options = { toplevel: true, top_retain: "f,a,o", unused: true };
+    input: {
+        var a, b = 1, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        function h() {}
+        console.log(b = 3);
+    }
+    expect: {
+        var a, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        console.log(3);
+    }
+}
+
+drop_toplevel_funcs_retain: {
+    options = { toplevel: "funcs", top_retain: "f,a,o", unused: true };
+    input: {
+        var a, b = 1, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        function h() {}
+        console.log(b = 3);
+    }
+    expect: {
+        var a, b = 1, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        console.log(b = 3);
+    }
+}
+
+drop_toplevel_vars_retain: {
+    options = { toplevel: "vars", top_retain: "f,a,o", unused: true };
+    input: {
+        var a, b = 1, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        function h() {}
+        console.log(b = 3);
+    }
+    expect: {
+        var a, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        function h() {}
+        console.log(3);
+    }
+}
+
+drop_toplevel_keep_assign: {
+    options = { toplevel: true, unused: "keep_assign" };
+    input: {
+        var a, b = 1, c = g;
+        function f(d) {
+            return function() {
+                c = 2;
+            }
+        }
+        a = 2;
+        function g() {}
+        function h() {}
+        console.log(b = 3);
+    }
+    expect: {
+        var a, b = 1;
+        a = 2;
+        console.log(b = 3);
+    }
+}


### PR DESCRIPTION
Only works when assignment is on the same scope level as declaration for now (see new tests in `drop-unused.js`).

Run against `angular.js` and managed to shave one extra variable off without any measureable change in performance.

This can obviously be extended in the future, but given how long I spent reading up `drop_unused()` let's take one step at a time. Putting it here as I run out of tests to throw at it (for now).