### PR TITLE
clean up `negate_iife`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -261,6 +261,15 @@ merge(Compressor.prototype, {
         return x;
     };
 
+    var readOnlyPrefix = makePredicate("! ~ + - void typeof");
+    function statement_to_expression(stat) {
+        if (stat.body instanceof AST_UnaryPrefix && readOnlyPrefix(stat.body.operator)) {
+            return stat.body.expression;
+        } else {
+            return stat.body;
+        }
+    }
+
     function tighten_body(statements, compressor) {
         var CHANGED, max_iter = 10;
         do {
@@ -285,10 +294,6 @@ merge(Compressor.prototype, {
                 statements = collapse_single_use_vars(statements, compressor);
             }
         } while (CHANGED && max_iter-- > 0);
-
-        if (compressor.option("negate_iife")) {
-            negate_iifes(statements, compressor);
-        }
 
         return statements;
 
@@ -731,7 +736,7 @@ merge(Compressor.prototype, {
             };
             statements.forEach(function(stat){
                 if (stat instanceof AST_SimpleStatement && seqLength(seq) < compressor.sequences_limit) {
-                    seq.push(stat.body);
+                    seq.push(seq.length > 0 ? statement_to_expression(stat) : stat.body);
                 } else {
                     push_seq();
                     ret.push(stat);
@@ -780,7 +785,7 @@ merge(Compressor.prototype, {
                                 stat.init = cons_seq(stat.init);
                             }
                             else if (!stat.init) {
-                                stat.init = prev.body;
+                                stat.init = statement_to_expression(prev);
                                 ret.pop();
                             }
                         } catch(ex) {
@@ -835,50 +840,6 @@ merge(Compressor.prototype, {
                 }
                 return a;
             }, []);
-        };
-
-        function negate_iifes(statements, compressor) {
-            function is_iife_call(node) {
-                if (node instanceof AST_Call) {
-                    return node.expression instanceof AST_Function || is_iife_call(node.expression);
-                }
-                return false;
-            }
-
-            statements.forEach(function(stat){
-                if (stat instanceof AST_SimpleStatement) {
-                    stat.body = (function transform(thing) {
-                        return thing.transform(new TreeTransformer(function(node){
-                            if (node instanceof AST_New) {
-                                return node;
-                            }
-                            if (is_iife_call(node)) {
-                                return make_node(AST_UnaryPrefix, node, {
-                                    operator: "!",
-                                    expression: node
-                                });
-                            }
-                            else if (node instanceof AST_Call) {
-                                node.expression = transform(node.expression);
-                            }
-                            else if (node instanceof AST_Seq) {
-                                node.car = transform(node.car);
-                            }
-                            else if (node instanceof AST_Conditional) {
-                                var expr = transform(node.condition);
-                                if (expr !== node.condition) {
-                                    // it has been negated, reverse
-                                    node.condition = expr;
-                                    var tmp = node.consequent;
-                                    node.consequent = node.alternative;
-                                    node.alternative = tmp;
-                                }
-                            }
-                            return node;
-                        }));
-                    })(stat.body);
-                }
-            });
         };
 
     };
@@ -985,7 +946,15 @@ merge(Compressor.prototype, {
         return ast1.print_to_string().length >
             ast2.print_to_string().length
             ? ast2 : ast1;
-    };
+    }
+
+    function best_of_statement(ast1, ast2) {
+        return best_of(make_node(AST_SimpleStatement, ast1, {
+            body: ast1
+        }), make_node(AST_SimpleStatement, ast2, {
+            body: ast2
+        })).body;
+    }
 
     // methods to evaluate a constant expression
     (function (def){
@@ -1205,7 +1174,17 @@ merge(Compressor.prototype, {
                 operator: "!",
                 expression: exp
             });
-        };
+        }
+        function best(orig, alt, first_in_statement) {
+            var negated = basic_negation(orig);
+            if (first_in_statement) {
+                var stat = make_node(AST_SimpleStatement, alt, {
+                    body: alt
+                });
+                return best_of(negated, stat) === stat ? alt : negated;
+            }
+            return best_of(negated, alt);
+        }
         def(AST_Node, function(){
             return basic_negation(this);
         });
@@ -1225,13 +1204,13 @@ merge(Compressor.prototype, {
             self.cdr = self.cdr.negate(compressor);
             return self;
         });
-        def(AST_Conditional, function(compressor){
+        def(AST_Conditional, function(compressor, first_in_statement){
             var self = this.clone();
             self.consequent = self.consequent.negate(compressor);
             self.alternative = self.alternative.negate(compressor);
-            return best_of(basic_negation(this), self);
+            return best(this, self, first_in_statement);
         });
-        def(AST_Binary, function(compressor){
+        def(AST_Binary, function(compressor, first_in_statement){
             var self = this.clone(), op = this.operator;
             if (compressor.option("unsafe_comps")) {
                 switch (op) {
@@ -1248,20 +1227,20 @@ merge(Compressor.prototype, {
               case "!==": self.operator = "==="; return self;
               case "&&":
                 self.operator = "||";
-                self.left = self.left.negate(compressor);
+                self.left = self.left.negate(compressor, first_in_statement);
                 self.right = self.right.negate(compressor);
-                return best_of(basic_negation(this), self);
+                return best(this, self, first_in_statement);
               case "||":
                 self.operator = "&&";
-                self.left = self.left.negate(compressor);
+                self.left = self.left.negate(compressor, first_in_statement);
                 self.right = self.right.negate(compressor);
-                return best_of(basic_negation(this), self);
+                return best(this, self, first_in_statement);
             }
             return basic_negation(this);
         });
     })(function(node, func){
-        node.DEFMETHOD("negate", function(compressor){
-            return func.call(this, compressor);
+        node.DEFMETHOD("negate", function(compressor, first_in_statement){
+            return func.call(this, compressor, first_in_statement);
         });
     });
 
@@ -1890,8 +1869,8 @@ merge(Compressor.prototype, {
             return make_node(AST_SimpleStatement, self, {
                 body: make_node(AST_Conditional, self, {
                     condition   : self.condition,
-                    consequent  : self.body.body,
-                    alternative : self.alternative.body
+                    consequent  : statement_to_expression(self.body),
+                    alternative : statement_to_expression(self.alternative)
                 })
             }).transform(compressor);
         }
@@ -1907,14 +1886,14 @@ merge(Compressor.prototype, {
                 body: make_node(AST_Binary, self, {
                     operator : "||",
                     left     : negated,
-                    right    : self.body.body
+                    right    : statement_to_expression(self.body)
                 })
             }).transform(compressor);
             return make_node(AST_SimpleStatement, self, {
                 body: make_node(AST_Binary, self, {
                     operator : "&&",
                     left     : self.condition,
-                    right    : self.body.body
+                    right    : statement_to_expression(self.body)
                 })
             }).transform(compressor);
         }
@@ -1925,7 +1904,7 @@ merge(Compressor.prototype, {
                 body: make_node(AST_Binary, self, {
                     operator : "||",
                     left     : self.condition,
-                    right    : self.alternative.body
+                    right    : statement_to_expression(self.alternative)
                 })
             }).transform(compressor);
         }
@@ -2292,7 +2271,19 @@ merge(Compressor.prototype, {
                 }
             }
         }
-        return self.evaluate(compressor)[0];
+        if (compressor.option("negate_iife")
+            && compressor.parent() instanceof AST_SimpleStatement
+            && is_iife_call(self)) {
+            return self.negate(compressor, true);
+        }
+        return self;
+
+        function is_iife_call(node) {
+            if (node instanceof AST_Call && !(node instanceof AST_New)) {
+                return node.expression instanceof AST_Function || is_iife_call(node.expression);
+            }
+            return false;
+        }
     });
 
     OPT(AST_New, function(self, compressor){
@@ -2379,6 +2370,10 @@ merge(Compressor.prototype, {
                     // !!foo ==> foo, if we're in boolean context
                     return e.expression;
                 }
+                if (e instanceof AST_Binary) {
+                    var statement = first_in_statement(compressor);
+                    self = (statement ? best_of_statement : best_of)(self, e.negate(compressor, statement));
+                }
                 break;
               case "typeof":
                 // typeof always returns a non-empty string, thus it's
@@ -2391,9 +2386,6 @@ merge(Compressor.prototype, {
                     });
                 }
                 return make_node(AST_True, self);
-            }
-            if (e instanceof AST_Binary && self.operator == "!") {
-                self = best_of(self, e.negate(compressor));
             }
         }
         return self.evaluate(compressor)[0];
@@ -2570,11 +2562,12 @@ merge(Compressor.prototype, {
         if (compressor.option("comparisons") && self.is_boolean()) {
             if (!(compressor.parent() instanceof AST_Binary)
                 || compressor.parent() instanceof AST_Assign) {
+                var statement = first_in_statement(compressor);
                 var negated = make_node(AST_UnaryPrefix, self, {
                     operator: "!",
-                    expression: self.negate(compressor)
+                    expression: self.negate(compressor, statement)
                 });
-                self = best_of(self, negated);
+                self = (statement ? best_of_statement : best_of)(self, negated);
             }
             if (compressor.option("unsafe_comps")) {
                 switch (self.operator) {
@@ -2773,8 +2766,9 @@ merge(Compressor.prototype, {
                 return maintain_this_binding(compressor.parent(), self, self.alternative);
             }
         }
-        var negated = cond[0].negate(compressor);
-        if (best_of(cond[0], negated) === negated) {
+        var statement = first_in_statement(compressor);
+        var negated = cond[0].negate(compressor, statement);
+        if ((statement ? best_of_statement : best_of)(cond[0], negated) === negated) {
             self = make_node(AST_Conditional, self, {
                 condition: negated,
                 consequent: self.alternative,

--- a/lib/output.js
+++ b/lib/output.js
@@ -425,7 +425,6 @@ function OutputStream(options) {
         pos             : function() { return current_pos },
         push_node       : function(node) { stack.push(node) },
         pop_node        : function() { return stack.pop() },
-        stack           : function() { return stack },
         parent          : function(n) {
             return stack[stack.length - 2 - (n || 0)];
         }
@@ -1331,30 +1330,6 @@ function OutputStream(options) {
                 output.force_semicolon();
             else
                 stat.print(output);
-        }
-    };
-
-    // return true if the node at the top of the stack (that means the
-    // innermost node in the current output) is lexically the first in
-    // a statement.
-    function first_in_statement(output) {
-        var a = output.stack(), i = a.length, node = a[--i], p = a[--i];
-        while (i > 0) {
-            if (p instanceof AST_Statement && p.body === node)
-                return true;
-            if ((p instanceof AST_Seq           && p.car === node        ) ||
-                (p instanceof AST_Call          && p.expression === node && !(p instanceof AST_New) ) ||
-                (p instanceof AST_Dot           && p.expression === node ) ||
-                (p instanceof AST_Sub           && p.expression === node ) ||
-                (p instanceof AST_Conditional   && p.condition === node  ) ||
-                (p instanceof AST_Binary        && p.left === node       ) ||
-                (p instanceof AST_UnaryPostfix  && p.expression === node ))
-            {
-                node = p;
-                p = a[--i];
-            } else {
-                return false;
-            }
         }
     };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -320,3 +320,26 @@ Dictionary.fromObject = function(obj) {
 function HOP(obj, prop) {
     return Object.prototype.hasOwnProperty.call(obj, prop);
 }
+
+// return true if the node at the top of the stack (that means the
+// innermost node in the current output) is lexically the first in
+// a statement.
+function first_in_statement(stack) {
+    var node = stack.parent(-1);
+    for (var i = 0, p; p = stack.parent(i); i++) {
+        if (p instanceof AST_Statement && p.body === node)
+            return true;
+        if ((p instanceof AST_Seq           && p.car === node        ) ||
+            (p instanceof AST_Call          && p.expression === node && !(p instanceof AST_New) ) ||
+            (p instanceof AST_Dot           && p.expression === node ) ||
+            (p instanceof AST_Sub           && p.expression === node ) ||
+            (p instanceof AST_Conditional   && p.condition === node  ) ||
+            (p instanceof AST_Binary        && p.left === node       ) ||
+            (p instanceof AST_UnaryPostfix  && p.expression === node ))
+        {
+            node = p;
+        } else {
+            return false;
+        }
+    }
+}

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -169,3 +169,41 @@ for_sequences: {
         for (y = 5; false;);
     }
 }
+
+negate_iife_for: {
+    options = {
+        sequences: true,
+        negate_iife: true,
+    };
+    input: {
+        (function() {})();
+        for (i = 0; i < 5; i++) console.log(i);
+
+        (function() {})();
+        for (; i < 5; i++) console.log(i);
+    }
+    expect: {
+        for (!function() {}(), i = 0; i < 5; i++) console.log(i);
+        for (function() {}(); i < 5; i++) console.log(i);
+    }
+}
+
+iife: {
+    options = {
+        sequences: true,
+    };
+    input: {
+        x = 42;
+        (function a() {})();
+        !function b() {}();
+        ~function c() {}();
+        +function d() {}();
+        -function e() {}();
+        void function f() {}();
+        typeof function g() {}();
+    }
+    expect: {
+        x = 42, function a() {}(), function b() {}(), function c() {}(),
+        function d() {}(), function e() {}(), function f() {}(), function g() {}()
+    }
+}


### PR DESCRIPTION
- remove extra tree scanning phase for `negate_iife`
- `negate_iife` now only deals with the narrowest form, i.e. IIFE sitting directly under `AST_SimpleStatement`
- `booleans`, `conditionals` etc. will now take care the rest via more accurate accounting

IIRC there was a previous issue raised about some corner cases of `negate_iife` which the only workaround was to turn the flag off. If anybody remembers what it is I'd like to add it to test cases, since my aim is to improve the correctness of this feature.

Reading material: #640, #1288, #1293