### PR TITLE
Avoid using exports when they are not defined

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -81,7 +81,9 @@ function DEFNODE(type, props, methods, base) {
     ctor.DEFMETHOD = function(name, method) {
         this.prototype[name] = method;
     };
-    exports["AST_" + type] = ctor;
+    if (typeof exports !== "undefined") {
+        exports["AST_" + type] = ctor;
+    }
     return ctor;
 };
 


### PR DESCRIPTION
Avoid using exports when they are not defined (like running in a browser. Suggested fix for #1468 
