### PR TITLE
[Harmony] - prefix for mangle property names

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -74,6 +74,7 @@ You need to pass an argument to this option to specify the name that your module
     .describe("reserve-domprops", "Make (most?) DOM properties reserved for --mangle-props")
     .describe("mangle-props", "Mangle property names (0 - disabled, 1 - mangle all properties, 2 - mangle unquoted properies)")
     .describe("mangle-regex", "Only mangle property names matching the regex")
+    .describe("mangle-prefix", "Prefix of the mangle properties")
     .describe("name-cache", "File to hold mangled names mappings")
     .describe("pure-funcs", "List of functions that can be safely removed if their return value is not used")
     .describe("dump-spidermonkey-ast", "Dump SpiderMonkey AST to stdout.")
@@ -110,6 +111,7 @@ You need to pass an argument to this option to specify the name that your module
     .string("p")
     .string("prefix")
     .string("name-cache")
+    .string("mangle-prefix")
 
     .array("reserved-file")
     .array("pure-funcs")
@@ -421,6 +423,7 @@ async.eachLimit(files, 1, function (file, cb) {
             only_cache    : !ARGS.mangle_props,
             regex         : regex,
             ignore_quoted : ARGS.mangle_props == 2,
+            prefix        : ARGS.mangle_prefix || "",
             debug         : typeof ARGS.mangle_props_debug === "undefined" ? false : ARGS.mangle_props_debug
         });
         writeNameCache("props", cache);

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -78,7 +78,6 @@ function find_builtins() {
 }
 
 function mangle_properties(ast, options) {
-    console.log(options);
     options = defaults(options, {
         reserved : null,
         cache : null,

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -78,6 +78,7 @@ function find_builtins() {
 }
 
 function mangle_properties(ast, options) {
+    console.log(options);
     options = defaults(options, {
         reserved : null,
         cache : null,
@@ -227,7 +228,7 @@ function mangle_properties(ast, options) {
                 // (filled with quoted properties when ignore_quoted set). Make sure we add this
                 // check so we don't collide with a quoted name.
                 do {
-                    mangled = base54(++cache.cname);
+                    mangled = options.prefix + base54(++cache.cname);
                 } while (!can_mangle(mangled) || (ignore_quoted && mangled in ignored));
             }
 


### PR DESCRIPTION
It could be very useful to set profix of mangle names.
It could permit to restrict access (at runtime) to "private" properties/methods on proxified objects.