### PR TITLE
improve keep_fargs & keep_fnames

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1413,7 +1413,7 @@ merge(Compressor.prototype, {
             && !self.uses_with
            ) {
             var in_use = [];
-            var in_use_ids = {}; // avoid expensive linear scans of in_use
+            var in_use_ids = Object.create(null); // avoid expensive linear scans of in_use
             var initializations = new Dictionary();
             // pass 1: find out which symbols are directly used in
             // this scope (not in nested scopes).
@@ -1477,11 +1477,17 @@ merge(Compressor.prototype, {
             // pass 3: we should drop declarations not in_use
             var tt = new TreeTransformer(
                 function before(node, descend, in_list) {
+                    if (node instanceof AST_Function
+                        && node.name
+                        && !compressor.option("keep_fnames")
+                        && !(node.name.definition().id in in_use_ids)) {
+                        node.name = null;
+                    }
                     if (node instanceof AST_Lambda && !(node instanceof AST_Accessor)) {
                         if (!compressor.option("keep_fargs")) {
                             for (var a = node.argnames, i = a.length; --i >= 0;) {
                                 var sym = a[i];
-                                if (sym.unreferenced()) {
+                                if (!(sym.definition().id in in_use_ids)) {
                                     a.pop();
                                     compressor.warn("Dropping unused function argument {name} [{file}:{line},{col}]", {
                                         name : sym.name,
@@ -2099,16 +2105,6 @@ merge(Compressor.prototype, {
     OPT(AST_Definitions, function(self, compressor){
         if (self.definitions.length == 0)
             return make_node(AST_EmptyStatement, self);
-        return self;
-    });
-
-    OPT(AST_Function, function(self, compressor){
-        self = AST_Lambda.prototype.optimize.call(self, compressor);
-        if (compressor.option("unused") && !compressor.option("keep_fnames")) {
-            if (self.name && self.name.unreferenced()) {
-                self.name = null;
-            }
-        }
         return self;
     });
 

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -177,3 +177,37 @@ keep_fnames: {
         }
     }
 }
+
+drop_fargs: {
+    options = {
+        keep_fargs: false,
+        unused: true,
+    }
+    input: {
+        function f(a) {
+            var b = a;
+        }
+    }
+    expect: {
+        function f() {}
+    }
+}
+
+drop_fnames: {
+    options = {
+        keep_fnames: false,
+        unused: true,
+    }
+    input: {
+        function f() {
+            return function g() {
+                var a = g;
+            };
+        }
+    }
+    expect: {
+        function f() {
+            return function() {};
+        }
+    }
+}


### PR DESCRIPTION
[`AST_Symbol.unreferenced()`](https://github.com/mishoo/UglifyJS2/blob/1eaa211e0932105439d98d4f03a981f157f0a77c/lib/scope.js#L360-L363) is based on `SymbolDef.references` array which is [populated](https://github.com/mishoo/UglifyJS2/blob/1eaa211e0932105439d98d4f03a981f157f0a77c/lib/scope.js#L269) during [`AST_Toplevel.figure_out_scope()`](https://github.com/mishoo/UglifyJS2/blob/1eaa211e0932105439d98d4f03a981f157f0a77c/lib/scope.js#L236) before `Compressor` is used.

As a result, there are corner cases which `!keep_fnames` and `!keep_fargs` won't be able to give the best solution. As we already do a [thorough usage scan](https://github.com/mishoo/UglifyJS2/blob/1eaa211e0932105439d98d4f03a981f157f0a77c/lib/compress.js#L1407-L1476) in `AST_Scope.drop_unused()`, we might as well perform the optimisation steps over there instead.