### PR TITLE
verify that property names after mangle are legal

### DIFF
--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -149,6 +149,7 @@ function mangle_properties(ast, options) {
     // only function declarations after this line
 
     function can_mangle(name) {
+        if (!is_identifier(name)) return false;
         if (unmangleable.indexOf(name) >= 0) return false;
         if (reserved.indexOf(name) >= 0) return false;
         if (options.only_cache) {


### PR DESCRIPTION
same as in mangle_names (for variables/functions)