### PR TITLE
fix `evaluate` on object getter & setter

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1148,11 +1148,14 @@ merge(Compressor.prototype, {
         def(AST_Statement, function(){
             throw new Error(string_template("Cannot evaluate a statement [{file}:{line},{col}]", this.start));
         });
+        // XXX: AST_Accessor and AST_Function both inherit from AST_Scope,
+        // which itself inherits from AST_Statement; however, they aren't
+        // really statements.  This could bite in other places too. :-(
+        // Wish JS had multiple inheritance.
+        def(AST_Accessor, function(){
+            throw def;
+        });
         def(AST_Function, function(){
-            // XXX: AST_Function inherits from AST_Scope, which itself
-            // inherits from AST_Statement; however, an AST_Function
-            // isn't really a statement.  This could byte in other
-            // places too. :-( Wish JS had multiple inheritance.
             throw def;
         });
         function ev(node, compressor) {
@@ -1180,7 +1183,9 @@ merge(Compressor.prototype, {
                 for (var i = 0, len = this.properties.length; i < len; i++) {
                     var prop = this.properties[i];
                     var key = prop.key;
-                    if (key instanceof AST_Node) {
+                    if (key instanceof AST_Symbol) {
+                        key = key.name;
+                    } else if (key instanceof AST_Node) {
                         key = ev(key, compressor);
                     }
                     if (typeof Object.prototype[key] === 'function') {

--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -337,6 +337,32 @@ unsafe_object_repeated: {
     }
 }
 
+unsafe_object_accessor: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unsafe: true,
+    }
+    input: {
+        function f() {
+            var a = {
+                get b() {},
+                set b() {}
+            };
+            return {a:a};
+        }
+    }
+    expect: {
+        function f() {
+            var a = {
+                get b() {},
+                set b() {}
+            };
+            return {a:a};
+        }
+    }
+}
+
 unsafe_function: {
     options = {
         evaluate  : true,


### PR DESCRIPTION
#1505 exposes a bug in #1425 whereby object getters and setters have `AST_SymbolRef` (`AST_SymbolMethod` on `harmony`) without any definitions as property `key`. So instead of trying to evaluate them, we should just grab its `name` and move on.

Also `.evaluate()` need to handle `AST_Accessor` gracefully like it does with `AST_Function`.