### PR TITLE
invert `reduce_vars` tracking flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ function uglify(ast, options, mangle) {
 
   // Compression
   uAST.figure_out_scope();
-  uAST = uAST.transform(UglifyJS.Compressor(options));
+  uAST = UglifyJS.Compressor(options).compress(uAST);
 
   // Mangling (optional)
   if (mangle) {
@@ -865,7 +865,7 @@ toplevel.figure_out_scope()
 Like this:
 ```javascript
 var compressor = UglifyJS.Compressor(options);
-var compressed_ast = toplevel.transform(compressor);
+var compressed_ast = compressor.compress(toplevel);
 ```
 
 The `options` can be missing.  Available options are discussed above in

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -61,7 +61,7 @@ function Compressor(options, false_by_default) {
         booleans      : !false_by_default,
         loops         : !false_by_default,
         unused        : !false_by_default,
-        toplevel      : !!options["top_retain"],
+        toplevel      : !!(options && options["top_retain"]),
         top_retain    : null,
         hoist_funs    : !false_by_default,
         keep_fargs    : true,
@@ -70,7 +70,7 @@ function Compressor(options, false_by_default) {
         if_return     : !false_by_default,
         join_vars     : !false_by_default,
         collapse_vars : !false_by_default,
-        reduce_vars   : false,
+        reduce_vars   : !false_by_default,
         cascade       : !false_by_default,
         side_effects  : !false_by_default,
         pure_getters  : false,
@@ -187,8 +187,8 @@ merge(Compressor.prototype, {
                 if (node instanceof AST_SymbolRef) {
                     var d = node.definition();
                     d.references.push(node);
-                    if (!d.modified && (d.orig.length > 1 || isModified(node, 0))) {
-                        d.modified = true;
+                    if (d.fixed && (d.orig.length > 1 || isModified(node, 0))) {
+                        d.fixed = false;
                     }
                 }
                 if (node instanceof AST_Call && node.expression instanceof AST_Function) {
@@ -205,7 +205,7 @@ merge(Compressor.prototype, {
         this.walk(tw);
 
         function reset_def(def) {
-            def.modified = false;
+            def.fixed = true;
             def.references = [];
             def.should_replace = undefined;
             if (unsafe && def.init) {
@@ -1258,7 +1258,7 @@ merge(Compressor.prototype, {
             this._evaluating = true;
             try {
                 var d = this.definition();
-                if (compressor.option("reduce_vars") && !d.modified && d.init) {
+                if (compressor.option("reduce_vars") && d.fixed && d.init) {
                     if (compressor.option("unsafe")) {
                         if (d.init._evaluated === undefined) {
                             d.init._evaluated = ev(d.init, compressor);
@@ -3041,7 +3041,7 @@ merge(Compressor.prototype, {
         }
         if (compressor.option("evaluate") && compressor.option("reduce_vars")) {
             var d = self.definition();
-            if (!d.modified && d.init) {
+            if (d.fixed && d.init) {
                 if (d.should_replace === undefined) {
                     var init = d.init.evaluate(compressor);
                     if (init.length > 1) {

--- a/test/mocha/minify.js
+++ b/test/mocha/minify.js
@@ -182,4 +182,13 @@ describe("minify", function() {
         });
     });
 
+    describe("Compressor", function() {
+        it("should be backward compatible with ast.transform(compressor)", function() {
+            var ast = Uglify.parse("function f(a){for(var i=0;i<a;i++)console.log(i)}");
+            ast.figure_out_scope();
+            ast = ast.transform(Uglify.Compressor());
+            assert.strictEqual(ast.print_to_string(), "function f(a){for(var i=0;i<a;i++)console.log(i)}");
+        });
+    })
+
 });


### PR DESCRIPTION
Modules like webpack and grunt-contrib-uglify still uses `ast.transform(compressor)` before `Compressor.compress(ast)` was introduced.

Workaround this compatibility issue by deactivating `reduce_vars` in such case.

fixes #1516