### PR TITLE
fix crash on missing `props` to `string_template()`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2194,7 +2194,7 @@ merge(Compressor.prototype, {
             // here because they are only used in an equality comparison later on.
             self.condition = negated;
             var tmp = self.body;
-            self.body = self.alternative || make_node(AST_EmptyStatement);
+            self.body = self.alternative || make_node(AST_EmptyStatement, self);
             self.alternative = tmp;
         }
         if (is_empty(self.body) && is_empty(self.alternative)) {
@@ -2459,7 +2459,7 @@ merge(Compressor.prototype, {
                   case "Boolean":
                     if (self.args.length == 0) return make_node(AST_False, self);
                     if (self.args.length == 1) return make_node(AST_UnaryPrefix, self, {
-                        expression: make_node(AST_UnaryPrefix, null, {
+                        expression: make_node(AST_UnaryPrefix, self, {
                             expression: self.args[0],
                             operator: "!"
                         }),
@@ -2855,7 +2855,7 @@ merge(Compressor.prototype, {
                 compressor.warn("Boolean && always false [{file}:{line},{col}]", self.start);
                 return make_node(AST_Seq, self, {
                     car: self.left,
-                    cdr: make_node(AST_False)
+                    cdr: make_node(AST_False, self)
                 }).optimize(compressor);
             }
             if (ll.length > 1 && ll[1]) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -185,7 +185,7 @@ function push_uniq(array, el) {
 
 function string_template(text, props) {
     return text.replace(/\{(.+?)\}/g, function(str, p){
-        return props[p];
+        return props && props[p];
     });
 };
 


### PR DESCRIPTION
Ultimately we want to track down all the instantiation sites for AST_Node and make sure their `start` is populated, but patch this up for now as program crashes are undesirable.

fixes #1518