### PR TITLE
collapse_vars should not replace constant in for-in init section

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -480,8 +480,12 @@ merge(Compressor.prototype, {
                     // Constant single use vars can be replaced in any scope.
                     if (var_decl.value.is_constant()) {
                         var ctt = new TreeTransformer(function(node) {
-                            if (node === ref)
-                                return replace_var(node, ctt.parent(), true);
+                            if (node === ref) {
+                                var parent = ctt.parent();
+                                if (!(parent instanceof AST_ForIn && parent.init === node)) {
+                                    return replace_var(node, parent, true);
+                                }
+                            }
                         });
                         stat.transform(ctt);
                         continue;
@@ -570,7 +574,7 @@ merge(Compressor.prototype, {
                 // Further optimize statement after substitution.
                 stat.reset_opt_flags(compressor);
 
-                compressor.warn("Replacing " + (is_constant ? "constant" : "variable") +
+                compressor.warn("Collapsing " + (is_constant ? "constant" : "variable") +
                     " " + var_name + " [{file}:{line},{col}]", node.start);
                 CHANGED = true;
                 return value;

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -1315,3 +1315,17 @@ collapse_vars_regexp: {
         })();
     }
 }
+
+issue_1537: {
+    options = {
+        collapse_vars: true,
+    }
+    input: {
+        var k = '';
+        for (k in {prop: 'val'}){}
+    }
+    expect: {
+        var k = '';
+        for (k in {prop: 'val'});
+    }
+}


### PR DESCRIPTION
Fixes #1537 for `for-in` loops on `master`.

`harmony` `for-of` loops will be fixed in another PR.