### PR TITLE
fix chained assignment with `unused`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1801,14 +1801,17 @@ merge(Compressor.prototype, {
                         }
                         return node;
                     }
-                    if (drop_vars && assign_as_unused
-                        && node instanceof AST_Assign
-                        && node.operator == "="
-                        && node.left instanceof AST_SymbolRef) {
-                        var def = node.left.definition();
-                        if (!(def.id in in_use_ids) && self.variables.get(def.name) === def) {
-                            return node.right;
+                    if (drop_vars && assign_as_unused) {
+                        var n = node;
+                        while (n instanceof AST_Assign
+                            && n.operator == "="
+                            && n.left instanceof AST_SymbolRef) {
+                            var def = n.left.definition();
+                            if (def.id in in_use_ids
+                                || self.variables.get(def.name) !== def) break;
+                            n = n.right;
                         }
+                        if (n !== node) return n;
                     }
                     if (node instanceof AST_For) {
                         descend(node, this);

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -679,3 +679,24 @@ const_assign: {
         }
     }
 }
+
+issue_1539: {
+    options = {
+        cascade: true,
+        sequences: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        function f() {
+            var a, b;
+            a = b = 42;
+            return a;
+        }
+    }
+    expect: {
+        function f() {
+            return 42;
+        }
+    }
+}


### PR DESCRIPTION
When #1450 optimises `a=b=42`, it stops after the first variable even if both are unused.