### PR TITLE
facilitate fix for #1531

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -181,6 +181,13 @@ merge(Compressor.prototype, {
         var reduce_vars = rescan && compressor.option("reduce_vars");
         var safe_ids = [];
         push();
+        var suppressor = new TreeWalker(function(node) {
+            if (node instanceof AST_Symbol) {
+                var d = node.definition();
+                if (node instanceof AST_SymbolRef) d.references.push(node);
+                d.fixed = false;
+            }
+        });
         var tw = new TreeWalker(function(node){
             if (!(node instanceof AST_Directive || node instanceof AST_Constant)) {
                 node._squeezed = false;
@@ -243,13 +250,7 @@ merge(Compressor.prototype, {
                     return true;
                 }
                 if (node instanceof AST_ForIn) {
-                    var sym = node.init;
-                    if (sym instanceof AST_Var) {
-                        sym = sym.definitions[0].name;
-                    }
-                    var d = sym.definition();
-                    d.references.push(sym);
-                    d.fixed = false;
+                    node.init.walk(suppressor);
                     node.object.walk(tw);
                     push();
                     node.body.walk(tw);


### PR DESCRIPTION
The change is somewhat less efficient as before, but will minimise the diff between `master` and `harmony` when we fix #1531