### PR TITLE
disallow collapse_vars constant replacement in for-in statements

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -481,11 +481,9 @@ merge(Compressor.prototype, {
                     // Constant single use vars can be replaced in any scope.
                     if (var_decl.value.is_constant()) {
                         var ctt = new TreeTransformer(function(node) {
-                            if (node === ref) {
-                                var parent = ctt.parent();
-                                if (!(parent instanceof AST_ForIn && parent.init === node)) {
-                                    return replace_var(node, parent, true);
-                                }
+                            if (node === ref
+                                && !ctt.find_parent(AST_ForIn)) {
+                                return replace_var(node, ctt.parent(), true);
                             }
                         });
                         stat.transform(ctt);


### PR DESCRIPTION
A more comprehensive fix for: #1537