### PR TITLE
handle variable declaration within catch blocks

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -812,9 +812,6 @@ var AST_SymbolAccessor = DEFNODE("SymbolAccessor", null, {
 
 var AST_SymbolDeclaration = DEFNODE("SymbolDeclaration", "init", {
     $documentation: "A declaration symbol (symbol in var/const, function name or argument, symbol in catch)",
-    $propdoc: {
-        init: "[AST_Node*/S] array of initializers for this declaration."
-    }
 }, AST_Symbol);
 
 var AST_SymbolVar = DEFNODE("SymbolVar", null, {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -223,6 +223,7 @@ merge(Compressor.prototype, {
 
     AST_Node.DEFMETHOD("reset_opt_flags", function(compressor, rescan){
         var reduce_vars = rescan && compressor.option("reduce_vars");
+        var ie8 = !compressor.option("screw_ie8");
         var safe_ids = [];
         push();
         var suppressor = new TreeWalker(function(node) {
@@ -232,7 +233,7 @@ merge(Compressor.prototype, {
                 d.fixed = false;
             }
         });
-        var tw = new TreeWalker(function(node){
+        var tw = new TreeWalker(function(node, descend){
             if (!(node instanceof AST_Directive || node instanceof AST_Constant)) {
                 node._squeezed = false;
                 node._optimized = false;
@@ -246,6 +247,9 @@ merge(Compressor.prototype, {
                     if (!d.fixed || isModified(node, 0) || !is_safe(d)) {
                         d.fixed = false;
                     }
+                }
+                if (ie8 && node instanceof AST_SymbolCatch) {
+                    node.definition().fixed = false;
                 }
                 if (node instanceof AST_VarDef) {
                     var d = node.name.definition();
@@ -298,6 +302,12 @@ merge(Compressor.prototype, {
                     node.object.walk(tw);
                     push();
                     node.body.walk(tw);
+                    pop();
+                    return true;
+                }
+                if (node instanceof AST_Catch) {
+                    push();
+                    descend();
                     pop();
                     return true;
                 }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -154,8 +154,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
         }
         else if (node instanceof AST_SymbolVar
                  || node instanceof AST_SymbolConst) {
-            var def = defun.def_variable(node);
-            def.init = tw.parent().value;
+            defun.def_variable(node);
         }
         else if (node instanceof AST_SymbolCatch) {
             (options.screw_ie8 ? scope : defun)

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -605,6 +605,29 @@ inner_var_for_in_2: {
     }
 }
 
+inner_var_catch: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        try {
+            a();
+        } catch (e) {
+            var b = 1;
+        }
+        console.log(b);
+    }
+    expect: {
+        try {
+            a();
+        } catch (e) {
+            var b = 1;
+        }
+        console.log(b);
+    }
+}
+
 issue_1533_1: {
     options = {
         collapse_vars: true,

--- a/test/compress/screw-ie8.js
+++ b/test/compress/screw-ie8.js
@@ -132,3 +132,37 @@ dont_screw_try_catch_undefined: {
         }
     }
 }
+
+reduce_vars: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        screw_ie8: false,
+        unused: true,
+    }
+    mangle = {
+        screw_ie8: false,
+    }
+    input: {
+        function f() {
+            var a;
+            try {
+                x();
+            } catch (a) {
+                y();
+            }
+            alert(a);
+        }
+    }
+    expect: {
+        function f() {
+            var t;
+            try {
+                x();
+            } catch (t) {
+                y();
+            }
+            alert(t);
+        }
+    }
+}


### PR DESCRIPTION
For IE8 and below, `AST_SymbolCatch` is essentially an assignment rather than a definition.