### PR TITLE
improve `unsafe` on undefined

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -765,7 +765,7 @@ merge(Compressor.prototype, {
                             CHANGED = true;
                             stat = stat.clone();
                             stat.alternative = ret[0] || make_node(AST_Return, stat, {
-                                value: make_node(AST_Undefined, stat)
+                                value: null
                             });
                             ret[0] = stat.transform(compressor);
                             continue loop;
@@ -798,7 +798,7 @@ merge(Compressor.prototype, {
                             && !stat.alternative) {
                             CHANGED = true;
                             ret.push(make_node(AST_Return, ret[0], {
-                                value: make_node(AST_Undefined, ret[0])
+                                value: null
                             }).transform(compressor));
                             ret.unshift(stat);
                             continue loop;
@@ -1054,6 +1054,10 @@ merge(Compressor.prototype, {
             }
         }));
     };
+
+    function is_undefined(node) {
+        return node instanceof AST_Undefined || node.is_undefined;
+    }
 
     /* -----[ boolean/negation helpers ]----- */
 
@@ -2402,8 +2406,8 @@ merge(Compressor.prototype, {
             return make_node(self.body.CTOR, self, {
                 value: make_node(AST_Conditional, self, {
                     condition   : self.condition,
-                    consequent  : self.body.value || make_node(AST_Undefined, self.body).optimize(compressor),
-                    alternative : self.alternative.value || make_node(AST_Undefined, self.alternative).optimize(compressor)
+                    consequent  : self.body.value || make_node(AST_Undefined, self.body),
+                    alternative : self.alternative.value || make_node(AST_Undefined, self.alternative)
                 })
             }).transform(compressor);
         }
@@ -2832,7 +2836,7 @@ merge(Compressor.prototype, {
                 return self.car;
             }
         }
-        if (self.cdr instanceof AST_Undefined) {
+        if (is_undefined(self.cdr)) {
             return make_node(AST_UnaryPrefix, self, {
                 operator   : "void",
                 expression : self.car
@@ -2871,7 +2875,7 @@ merge(Compressor.prototype, {
                 self.expression = e;
                 return self;
             } else {
-                return make_node(AST_Undefined, self);
+                return make_node(AST_Undefined, self).transform(compressor);
             }
         }
         if (compressor.option("booleans") && compressor.in_boolean_context()) {
@@ -3350,7 +3354,7 @@ merge(Compressor.prototype, {
             && (!self.scope.uses_with || !compressor.find_parent(AST_With))) {
             switch (self.name) {
               case "undefined":
-                return make_node(AST_Undefined, self);
+                return make_node(AST_Undefined, self).transform(compressor);
               case "NaN":
                 return make_node(AST_NaN, self).transform(compressor);
               case "Infinity":
@@ -3393,11 +3397,13 @@ merge(Compressor.prototype, {
             var scope = compressor.find_parent(AST_Scope);
             var undef = scope.find_variable("undefined");
             if (undef) {
-                return make_node(AST_SymbolRef, self, {
+                var ref = make_node(AST_SymbolRef, self, {
                     name   : "undefined",
                     scope  : scope,
                     thedef : undef
                 });
+                ref.is_undefined = true;
+                return ref;
             }
         }
         return self;
@@ -3684,7 +3690,7 @@ merge(Compressor.prototype, {
     OPT(AST_RegExp, literals_in_boolean_context);
 
     OPT(AST_Return, function(self, compressor){
-        if (self.value instanceof AST_Undefined) {
+        if (self.value && is_undefined(self.value)) {
             self.value = null;
         }
         return self;

--- a/test/compress/issue-1443.js
+++ b/test/compress/issue-1443.js
@@ -2,6 +2,7 @@
 
 unsafe_undefined: {
     options = {
+        conditionals: true,
         if_return: true,
         unsafe: true
     }
@@ -19,12 +20,7 @@ unsafe_undefined: {
     expect: {
         function f(n) {
             return function() {
-                if (a)
-                    return b;
-                if (c)
-                    return d;
-                else
-                    return n;
+                return a ? b : c ? d : n;
             };
         }
     }
@@ -32,6 +28,7 @@ unsafe_undefined: {
 
 keep_fnames: {
     options = {
+        conditionals: true,
         if_return: true,
         unsafe: true
     }
@@ -57,12 +54,7 @@ keep_fnames: {
                 function n(n) {
                     return n * n;
                 }
-                if (a)
-                    return b;
-                if (c)
-                    return d;
-                else
-                    return r;
+                return a ? b : c ? d : r;
             };
         }
     }

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -251,3 +251,36 @@ iife: {
         function d() {}(), function e() {}(), function f() {}(), function g() {}();
     }
 }
+
+unsafe_undefined: {
+    options = {
+        conditionals: true,
+        if_return: true,
+        sequences: true,
+        side_effects: true,
+        unsafe: true,
+    }
+    input: {
+        function f(undefined) {
+            if (a)
+                return b;
+            if (c)
+                return d;
+        }
+        function g(undefined) {
+            if (a)
+                return b;
+            if (c)
+                return d;
+            e();
+        }
+    }
+    expect: {
+        function f(undefined) {
+            return a ? b : c ? d : undefined;
+        }
+        function g(undefined) {
+            return a ? b : c ? d : void e();
+        }
+    }
+}


### PR DESCRIPTION
`unsafe` turns undefined keyword into a variable of the same name if found, but that interferes with other related optimisations.

Keep track of such transformations to ensure zero information loss in the process.