### PR TITLE
fix a corner case in #1530

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2760,10 +2760,12 @@ merge(Compressor.prototype, {
             }
         }
         if (exp instanceof AST_Function) {
-            if (exp.body[0] instanceof AST_Return
-                && exp.body[0].value.is_constant()) {
-                var args = self.args.concat(exp.body[0].value);
-                return AST_Seq.from_array(args).transform(compressor);
+            if (exp.body[0] instanceof AST_Return) {
+                var value = exp.body[0].value;
+                if (!value || value.is_constant()) {
+                    var args = self.args.concat(value || make_node(AST_Undefined, self));
+                    return AST_Seq.from_array(args).transform(compressor);
+                }
             }
             if (compressor.option("side_effects")) {
                 if (!AST_Block.prototype.has_side_effects.call(exp, compressor)) {

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -74,3 +74,20 @@ iifes_returning_constants_keep_fargs_false: {
         console.log((a(), b(), 6));
     }
 }
+
+issue_485_crashing_1530: {
+    options = {
+        conditionals: true,
+        dead_code: true,
+        evaluate: true,
+    }
+    input: {
+        (function(a) {
+            if (true) return;
+            var b = 42;
+        })(this);
+    }
+    expect: {
+        this, void 0;
+    }
+}


### PR DESCRIPTION
@kzc looks like both of us forget `AST_Return.value` can be `null`, which has the same meaning as `AST_Undefined` (technically, `return;` vs. `return void 0;`)

Test case is simplified version of #485