### PR TITLE
Walk even body for harmony classes

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1070,6 +1070,9 @@ var AST_Class = DEFNODE("Class", "name extends properties", {
             if (this.extends) {
                 this.extends._walk(visitor);
             }
+            if (this.body) {
+                walk_body(this, visitor)
+            }
             this.properties.forEach(function(prop){
                 prop._walk(visitor);
             });


### PR DESCRIPTION
Walk in `AST_Class` walks `name`, `extends` and `properties`, bot not `body` (inherited from a `AST_Scope`). This does no harm for normal JS usage, as class body is undefined anyway. In my utility it would be handy if walk would visit even the class `body`, as I am placing some artificial variable declarations there so that I can provide type inference in the class scope. 

This PR should do no harm to normal Uglify operation, as such walk would never be executed. On the other hand, it could be confusing why it is even there.

If this PR is not acceptable, I will try to search for some other structure (using properties instead of body variables might be acceptable, even if more difficult) or I can develop this in my fork only.

