### PR TITLE
Fix undefined symbols in compression

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1804,6 +1804,7 @@ merge(Compressor.prototype, {
                         if (!compressor.option("keep_fargs")) {
                             for (var a = node.argnames, i = a.length; --i >= 0;) {
                                 var sym = a[i];
+                                if (!sym) break;
                                 if (!(sym.definition().id in in_use_ids)) {
                                     a.pop();
                                     compressor.warn("Dropping unused function argument {name} [{file}:{line},{col}]", {


### PR DESCRIPTION
Dropping unused declarations while compressing sometimes crash.
This is due to the symbols being undefined where the source code
tries to access `sym.definition().id`.