### PR TITLE
fix return from recursive IIFE

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2100,7 +2100,8 @@ merge(Compressor.prototype, {
         def(AST_This, return_null);
         def(AST_Call, function(compressor, first_in_statement){
             if (!this.has_pure_annotation(compressor) && compressor.pure_funcs(this)) {
-                if (this.expression instanceof AST_Function) {
+                if (this.expression instanceof AST_Function
+                    && (!this.expression.name || !this.expression.name.definition().references.length)) {
                     var node = this.clone();
                     node.expression = node.expression.process_expression(false);
                     return node;

--- a/test/compress/issue-1569.js
+++ b/test/compress/issue-1569.js
@@ -1,0 +1,19 @@
+inner_reference: {
+    options = {
+        side_effects: true,
+    }
+    input: {
+        !function f(a) {
+            return a && f(a - 1) + a;
+        }(42);
+        !function g(a) {
+            return a;
+        }(42);
+    }
+    expect: {
+        !function f(a) {
+            return a && f(a - 1) + a;
+        }(42);
+        !void 0;
+    }
+}


### PR DESCRIPTION
`side-effects` did not account for IIFEs being able to reference itself thus making its return value potentially significant

fixes #1569