### PR TITLE
plan B for IE8 do-while semi-colon fix

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -777,16 +777,14 @@ function OutputStream(options) {
     DEFPRINT(AST_Do, function(self, output){
         output.print("do");
         output.space();
-        self._do_print_body(output);
+        make_block(self.body, output);
         output.space();
         output.print("while");
         output.space();
         output.with_parens(function(){
             self.condition.print(output);
         });
-        if (output.option("beautify") && output.option("screw_ie8")) {
-            output.semicolon();
-        }
+        output.semicolon();
     });
     DEFPRINT(AST_While, function(self, output){
         output.print("while");
@@ -906,10 +904,10 @@ function OutputStream(options) {
 
     /* -----[ if ]----- */
     function make_then(self, output) {
-        if (output.option("bracketize")) {
-            make_block(self.body, output);
-            return;
-        }
+        var b = self.body;
+        if (output.option("bracketize")
+            || !output.option("screw_ie8") && b instanceof AST_Do)
+            return make_block(b, output);
         // The squeezer replaces "block"-s that contain only a single
         // statement with the statement itself; technically, the AST
         // is correct, but this can create problems when we output an
@@ -917,9 +915,7 @@ function OutputStream(options) {
         // IF *without* an ELSE block (then the outer ELSE would refer
         // to the inner IF).  This function checks for this case and
         // adds the block brackets if needed.
-        if (!self.body)
-            return output.force_semicolon();
-        var b = self.body;
+        if (!b) return output.force_semicolon();
         while (true) {
             if (b instanceof AST_If) {
                 if (!b.alternative) {
@@ -1328,15 +1324,7 @@ function OutputStream(options) {
 
     function force_statement(stat, output) {
         if (output.option("bracketize")) {
-            if (!stat || stat instanceof AST_EmptyStatement)
-                output.print("{}");
-            else if (stat instanceof AST_BlockStatement)
-                stat.print(output);
-            else output.with_block(function(){
-                output.indent();
-                stat.print(output);
-                output.newline();
-            });
+            make_block(stat, output);
         } else {
             if (!stat || stat instanceof AST_EmptyStatement)
                 output.force_semicolon();
@@ -1385,11 +1373,11 @@ function OutputStream(options) {
     };
 
     function make_block(stmt, output) {
-        if (stmt instanceof AST_BlockStatement) {
+        if (!stmt || stmt instanceof AST_EmptyStatement)
+            output.print("{}");
+        else if (stmt instanceof AST_BlockStatement)
             stmt.print(output);
-            return;
-        }
-        output.with_block(function(){
+        else output.with_block(function(){
             output.indent();
             stmt.print(output);
             output.newline();

--- a/test/compress/loops.js
+++ b/test/compress/loops.js
@@ -257,7 +257,7 @@ issue_186: {
         else
             bar();
     }
-    expect_exact: 'var x=3;if(foo())do do alert(x);while(--x)while(x)else bar();'
+    expect_exact: 'var x=3;if(foo())do{do{alert(x)}while(--x)}while(x);else bar();'
 }
 
 issue_186_ie8: {
@@ -276,7 +276,7 @@ issue_186_ie8: {
         else
             bar();
     }
-    expect_exact: 'var x=3;if(foo())do do alert(x);while(--x)while(x)else bar();'
+    expect_exact: 'var x=3;if(foo()){do{do{alert(x)}while(--x)}while(x)}else bar();'
 }
 
 issue_186_beautify: {
@@ -295,7 +295,7 @@ issue_186_beautify: {
         else
             bar();
     }
-    expect_exact: 'var x = 3;\n\nif (foo()) do do alert(x); while (--x); while (x); else bar();'
+    expect_exact: 'var x = 3;\n\nif (foo()) do {\n    do {\n        alert(x);\n    } while (--x);\n} while (x); else bar();'
 }
 
 issue_186_beautify_ie8: {
@@ -314,7 +314,7 @@ issue_186_beautify_ie8: {
         else
             bar();
     }
-    expect_exact: 'var x = 3;\n\nif (foo()) do do alert(x); while (--x) while (x) else bar();'
+    expect_exact: 'var x = 3;\n\nif (foo()) {\n    do {\n        do {\n            alert(x);\n        } while (--x);\n    } while (x);\n} else bar();'
 }
 
 issue_186_bracketize: {
@@ -394,5 +394,5 @@ issue_186_beautify_bracketize_ie8: {
         else
             bar();
     }
-    expect_exact: 'var x = 3;\n\nif (foo()) {\n    do {\n        do {\n            alert(x);\n        } while (--x)\n    } while (x)\n} else {\n    bar();\n}'
+    expect_exact: 'var x = 3;\n\nif (foo()) {\n    do {\n        do {\n            alert(x);\n        } while (--x);\n    } while (x);\n} else {\n    bar();\n}'
 }


### PR DESCRIPTION
@kzc as agreed before, this is the alternative for #1556 using mandatory braces for do-while body.

I've quickly checked `do ... while();return;` and `do ... while();for(...);` and they seem to work fine on IE8.

fixes #1568