### PR TITLE
fix function name eliminiation

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2611,7 +2611,8 @@ merge(Compressor.prototype, {
                 if (compressor.option("unused")
                     && def.references.length == 1
                     && compressor.find_parent(AST_Scope) === def.scope) {
-                    if (!compressor.option("keep_fnames")) {
+                    if (!compressor.option("keep_fnames")
+                        && exp.name && exp.name.definition() === def) {
                         exp.name = null;
                     }
                     self.expression = exp;

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -1122,3 +1122,25 @@ defun_label: {
         }();
     }
 }
+
+double_reference: {
+    options = {
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        function f() {
+            var g = function g() {
+                g();
+            };
+            g();
+        }
+    }
+    expect: {
+        function f() {
+            (function g() {
+                g();
+            })();
+        }
+    }
+}


### PR DESCRIPTION
Function expression can be assigned to a variable and be given a name. Ensure function name is the reduced variable before clearing it out.

fixes #1573
fixes #1575