### PR TITLE
scan assignment value in drop_unused()

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,11 +391,11 @@ to set `true`; it's effectively a shortcut for `foo=true`).
 - `cascade` -- small optimization for sequences, transform `x, x` into `x`
   and `x = something(), x` into `x = something()`
 
-- `collapse_vars` -- default `false`. Collapse single-use `var` and `const`
-  definitions when possible.
+- `collapse_vars` -- Collapse single-use `var` and `const` definitions
+  when possible.
 
-- `reduce_vars` -- default `false`. Improve optimization on variables assigned
-  with and used as constant values.
+- `reduce_vars` -- Improve optimization on variables assigned with and
+  used as constant values.
 
 - `warnings` -- display warnings when dropping unreachable code or unused
   declarations etc.

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1840,6 +1840,7 @@ merge(Compressor.prototype, {
                     }
                     if (drop_vars && node instanceof AST_Definitions && !(tt.parent() instanceof AST_ForIn)) {
                         var def = node.definitions.filter(function(def){
+                            if (def.value) def.value = def.value.transform(tt);
                             if (def.name.definition().id in in_use_ids) return true;
                             var w = {
                                 name : def.name.name,
@@ -2611,10 +2612,6 @@ merge(Compressor.prototype, {
                 if (compressor.option("unused")
                     && def.references.length == 1
                     && compressor.find_parent(AST_Scope) === def.scope) {
-                    if (!compressor.option("keep_fnames")
-                        && exp.name && exp.name.definition() === def) {
-                        exp.name = null;
-                    }
                     self.expression = exp;
                 }
             }

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -700,3 +700,28 @@ issue_1539: {
         }
     }
 }
+
+vardef_value: {
+    options = {
+        keep_fnames: false,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        function f() {
+            function g(){
+                return x();
+            }
+            var a = g();
+            return a(42);
+        }
+    }
+    expect: {
+        function f() {
+            var a = function(){
+                return x();
+            }();
+            return a(42);
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/mishoo/UglifyJS2/pull/1576#discussion_r104839146

So this covers more than just missed opportunity for `!keep_fnames` in named functions as assigned values, and it's also less lines than before.

@kzc included your doc changes from #1577, and thanks for pointing out the inefficiency in the previous PR 😉 