### PR TITLE
scan RHS of dropped assignments

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1901,17 +1901,15 @@ merge(Compressor.prototype, {
                         }
                         return node;
                     }
-                    if (drop_vars && assign_as_unused) {
-                        var n = node;
-                        while (n instanceof AST_Assign
-                            && n.operator == "="
-                            && n.left instanceof AST_SymbolRef) {
-                            var def = n.left.definition();
-                            if (def.id in in_use_ids
-                                || self.variables.get(def.name) !== def) break;
-                            n = n.right;
+                    if (drop_vars && assign_as_unused
+                        && node instanceof AST_Assign
+                        && node.operator == "="
+                        && node.left instanceof AST_SymbolRef) {
+                        var def = node.left.definition();
+                        if (!(def.id in in_use_ids)
+                            && self.variables.get(def.name) === def) {
+                            return maintain_this_binding(tt.parent(), node, node.right.transform(tt));
                         }
-                        if (n !== node) return n;
                     }
                     if (node instanceof AST_For) {
                         descend(node, this);

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -725,3 +725,39 @@ vardef_value: {
         }
     }
 }
+
+assign_binding: {
+    options = {
+        cascade: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        function f() {
+            var a;
+            a = f.g, a();
+        }
+    }
+    expect: {
+        function f() {
+            (0, f.g)();
+        }
+    }
+}
+
+assign_chain: {
+    options = {
+        unused: true,
+    }
+    input: {
+        function f() {
+            var a, b;
+            x = a = y = b = 42;
+        }
+    }
+    expect: {
+        function f() {
+            x = y = 42;
+        }
+    }
+}


### PR DESCRIPTION
Similar case as #1578 but against the missing branch of #1450 instead.

Also fixed `this` binding issue when dropping assignments.