### PR TITLE
fix catch variable reference in IE8

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -212,9 +212,10 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
         self.walk(new TreeWalker(function(node, descend) {
             if (node instanceof AST_SymbolCatch) {
                 var name = node.name;
+                var refs = node.thedef.references;
                 var scope = node.thedef.scope.parent_scope;
                 var def = scope.find_variable(name) || self.globals.get(name) || scope.def_variable(node);
-                node.thedef.references.forEach(function(ref) {
+                refs.forEach(function(ref) {
                     ref.thedef = def;
                     ref.reference(options);
                 });

--- a/test/compress/screw-ie8.js
+++ b/test/compress/screw-ie8.js
@@ -182,3 +182,39 @@ reduce_vars: {
         }
     }
 }
+
+issue_1586_1: {
+    options = {
+        screw_ie8: false,
+    }
+    mangle = {
+        screw_ie8: false,
+    }
+    input: {
+        function f() {
+            try {
+            } catch (err) {
+                console.log(err.message);
+            }
+        }
+    }
+    expect_exact: "function f(){try{}catch(c){console.log(c.message)}}"
+}
+
+issue_1586_2: {
+    options = {
+        screw_ie8: true,
+    }
+    mangle = {
+        screw_ie8: true,
+    }
+    input: {
+        function f() {
+            try {
+            } catch (err) {
+                console.log(err.message);
+            }
+        }
+    }
+    expect_exact: "function f(){try{}catch(c){console.log(c.message)}}"
+}


### PR DESCRIPTION
`AST_Scope.def_variable()` will overwrite `AST_Symbol.thedef`, so save a copy before calling.

fixes #1586