### PR TITLE
fixup for #1585

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -787,8 +787,6 @@ function parse($TEXT, options) {
         return function() {
             var start = S.token;
             var expr = parser();
-            if (!expr) croak("Expected expression");
-
             var end = prev();
             expr.start = start;
             expr.end = end;
@@ -930,11 +928,9 @@ function parse($TEXT, options) {
                     expression : parenthesised(),
                     body       : statement()
                 });
-
-              default:
-                unexpected();
             }
         }
+        unexpected();
     });
 
     function labeled_statement() {

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -247,7 +247,7 @@ describe("bin/uglifyjs", function () {
             assert.strictEqual(lines[0], "Parse error at test/input/invalid/loop-no-body.js:2,0");
             assert.strictEqual(lines[1], "for (var i = 0; i < 1; i++) ");
             assert.strictEqual(lines[2], "                            ^");
-            assert.strictEqual(lines[3], "SyntaxError: Expected expression");
+            assert.strictEqual(lines[3], "SyntaxError: Unexpected token: eof (undefined)");
             done();
         });
     });


### PR DESCRIPTION
As patched on `harmony`, `statement()` is the only user of `embed_tokens()` with a missing error branch.

Updated test case and match up with `harmony` to facilitate future merging.