### PR TITLE
support multi-line string in tests

### DIFF
--- a/test/compress/loops.js
+++ b/test/compress/loops.js
@@ -295,7 +295,15 @@ issue_186_beautify: {
         else
             bar();
     }
-    expect_exact: 'var x = 3;\n\nif (foo()) do {\n    do {\n        alert(x);\n    } while (--x);\n} while (x); else bar();'
+    expect_exact: [
+        'var x = 3;',
+        '',
+        'if (foo()) do {',
+        '    do {',
+        '        alert(x);',
+        '    } while (--x);',
+        '} while (x); else bar();',
+    ]
 }
 
 issue_186_beautify_ie8: {
@@ -314,7 +322,17 @@ issue_186_beautify_ie8: {
         else
             bar();
     }
-    expect_exact: 'var x = 3;\n\nif (foo()) {\n    do {\n        do {\n            alert(x);\n        } while (--x);\n    } while (x);\n} else bar();'
+    expect_exact: [
+        'var x = 3;',
+        '',
+        'if (foo()) {',
+        '    do {',
+        '        do {',
+        '            alert(x);',
+        '        } while (--x);',
+        '    } while (x);',
+        '} else bar();',
+    ]
 }
 
 issue_186_bracketize: {
@@ -374,7 +392,19 @@ issue_186_beautify_bracketize: {
         else
             bar();
     }
-    expect_exact: 'var x = 3;\n\nif (foo()) {\n    do {\n        do {\n            alert(x);\n        } while (--x);\n    } while (x);\n} else {\n    bar();\n}'
+    expect_exact: [
+        'var x = 3;',
+        '',
+        'if (foo()) {',
+        '    do {',
+        '        do {',
+        '            alert(x);',
+        '        } while (--x);',
+        '    } while (x);',
+        '} else {',
+        '    bar();',
+        '}',
+    ]
 }
 
 issue_186_beautify_bracketize_ie8: {
@@ -394,5 +424,17 @@ issue_186_beautify_bracketize_ie8: {
         else
             bar();
     }
-    expect_exact: 'var x = 3;\n\nif (foo()) {\n    do {\n        do {\n            alert(x);\n        } while (--x);\n    } while (x);\n} else {\n    bar();\n}'
+    expect_exact: [
+        'var x = 3;',
+        '',
+        'if (foo()) {',
+        '    do {',
+        '        do {',
+        '            alert(x);',
+        '        } while (--x);',
+        '    } while (x);',
+        '} else {',
+        '    bar();',
+        '}',
+    ]
 }

--- a/test/compress/max_line_len.js
+++ b/test/compress/max_line_len.js
@@ -7,7 +7,13 @@ too_short: {
             return { c: 42, d: a(), e: "foo"};
         }
     }
-    expect_exact: 'function f(a){\nreturn{\nc:42,\nd:a(),\ne:"foo"}}'
+    expect_exact: [
+        'function f(a){',
+        'return{',
+        'c:42,',
+        'd:a(),',
+        'e:"foo"}}',
+    ]
     expect_warnings: [
         "WARN: Output exceeds 10 characters"
     ]
@@ -22,7 +28,12 @@ just_enough: {
             return { c: 42, d: a(), e: "foo"};
         }
     }
-    expect_exact: 'function f(a){\nreturn{c:42,\nd:a(),e:"foo"}\n}'
+    expect_exact: [
+        'function f(a){',
+        'return{c:42,',
+        'd:a(),e:"foo"}',
+        '}',
+    ]
     expect_warnings: [
     ]
 }


### PR DESCRIPTION
`expect_exact` sometimes have multiple lines and `\n` are hard to read.

Use array of strings to emulate line breaks and improve readability.

From https://github.com/mishoo/UglifyJS2/issues/1588#issuecomment-285454735