### PR TITLE
disallow parameter substitution for named IIFEs

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -279,6 +279,7 @@ merge(Compressor.prototype, {
                 }
                 var iife;
                 if (node instanceof AST_Function
+                    && !node.name
                     && (iife = tw.parent()) instanceof AST_Call
                     && iife.expression === node) {
                     // Virtually turn IIFE parameters into variable definitions:

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -1252,3 +1252,78 @@ iife_func_side_effects: {
         })(x(), 0, z());
     }
 }
+
+issue_1595_1: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        (function f(a) {
+            return f(a + 1);
+        })(2);
+    }
+    expect: {
+        (function f(a) {
+            return f(a + 1);
+        })(2);
+    }
+}
+
+issue_1595_2: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        (function f(a) {
+            return g(a + 1);
+        })(2);
+    }
+    expect: {
+        (function(a) {
+            return g(a + 1);
+        })(2);
+    }
+}
+
+issue_1595_3: {
+    options = {
+        evaluate: true,
+        passes: 2,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        (function f(a) {
+            return g(a + 1);
+        })(2);
+    }
+    expect: {
+        (function(a) {
+            return g(3);
+        })();
+    }
+}
+
+issue_1595_4: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        (function iife(a, b, c) {
+            console.log(a, b, c);
+            if (a) iife(a - 1, b, c);
+        })(3, 4, 5);
+    }
+    expect: {
+        (function iife(a, b, c) {
+            console.log(a, b, c);
+            if (a) iife(a - 1, b, c);
+        })(3, 4, 5);
+    }
+}


### PR DESCRIPTION
Self-referenced function has non-fixed values assigned to its parameters.

Let `unused` & `!keep_fnames` do the scanning, then apply `reduce_vars` only to unnamed functions.

fixes #1595