### PR TITLE
minor clean-ups

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -984,8 +984,8 @@ TreeWalker.prototype = {
     push: function (node) {
         if (node instanceof AST_Lambda) {
             this.directives = Object.create(this.directives);
-        } else if (node instanceof AST_Directive) {
-            this.directives[node.value] = this.directives[node.value] ? "up" : true;
+        } else if (node instanceof AST_Directive && !this.directives[node.value]) {
+            this.directives[node.value] = node;
         }
         this.stack.push(node);
     },
@@ -1013,7 +1013,7 @@ TreeWalker.prototype = {
             for (var i = 0; i < node.body.length; ++i) {
                 var st = node.body[i];
                 if (!(st instanceof AST_Directive)) break;
-                if (st.value == type) return true;
+                if (st.value == type) return st;
             }
         }
     },

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1664,7 +1664,7 @@ merge(Compressor.prototype, {
     /* -----[ optimizers ]----- */
 
     OPT(AST_Directive, function(self, compressor){
-        if (compressor.has_directive(self.value) === "up") {
+        if (compressor.has_directive(self.value) !== self) {
             return make_node(AST_EmptyStatement, self);
         }
         return self;
@@ -3018,16 +3018,6 @@ merge(Compressor.prototype, {
     var commutativeOperators = makePredicate("== === != !== * & | ^");
 
     OPT(AST_Binary, function(self, compressor){
-        var lhs = self.left.evaluate(compressor);
-        var rhs = self.right.evaluate(compressor);
-        if (lhs.length > 1 && lhs[0].is_constant() !== self.left.is_constant()
-            || rhs.length > 1 && rhs[0].is_constant() !== self.right.is_constant()) {
-            return make_node(AST_Binary, self, {
-                operator: self.operator,
-                left: lhs[0],
-                right: rhs[0]
-            }).optimize(compressor);
-        }
         function reversible() {
             return self.left instanceof AST_Constant
                 || self.right instanceof AST_Constant


### PR DESCRIPTION
- remove obsolete optimisation in `AST_Binary` after #1477
- improve `TreeWalker.has_directive()` readability and resilience against multiple visits

Just things that I've discovered whilst working on #1593 which should be minimal and safe. The first part is covered by existing tests that comes with #1427, while the latter is covered by https://github.com/mishoo/UglifyJS2/blob/872270b14986b2f24df406425eda5a3bf7a3b56a/test/mocha/directives.js#L348-L369