### PR TITLE
extend `test/run-tests.js` to optionally execute uglified output

### DIFF
--- a/test/compress/issue-1588.js
+++ b/test/compress/issue-1588.js
@@ -1,0 +1,29 @@
+screw_ie8: {
+    options = {
+        screw_ie8: true,
+    }
+    mangle = {
+        screw_ie8: true,
+    }
+    input: {
+        try { throw "foo"; } catch (x) { console.log(x); }
+    }
+    expect_exact: 'try{throw"foo"}catch(o){console.log(o)}'
+    expect_stdout: [
+        "foo"
+    ]
+}
+
+support_ie8: {
+    options = {
+        screw_ie8: false,
+    }
+    mangle = {
+        screw_ie8: false,
+    }
+    input: {
+        try { throw "foo"; } catch (x) { console.log(x); }
+    }
+    expect_exact: 'try{throw"foo"}catch(x){console.log(x)}'
+    expect_stdout: "foo"
+}


### PR DESCRIPTION
fixes #1588 

@kzc please throw stuff at this, especially existing/new tests which utilise `expect_stdout`