### PR TITLE
fix `hoist_vars` on `reduce_vars`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1986,7 +1986,7 @@ merge(Compressor.prototype, {
                                 vars.set(def.name.name, def);
                                 ++vars_found;
                             });
-                            var seq = node.to_assignments();
+                            var seq = node.to_assignments(compressor);
                             var p = tt.parent();
                             if (p instanceof AST_ForIn && p.init === node) {
                                 if (seq == null) {
@@ -2579,7 +2579,8 @@ merge(Compressor.prototype, {
         this.definitions.forEach(function(def){ def.value = null });
     });
 
-    AST_Definitions.DEFMETHOD("to_assignments", function(){
+    AST_Definitions.DEFMETHOD("to_assignments", function(compressor){
+        var reduce_vars = compressor.option("reduce_vars");
         var assignments = this.definitions.reduce(function(a, def){
             if (def.value) {
                 var name = make_node(AST_SymbolRef, def.name, def.name);
@@ -2588,6 +2589,7 @@ merge(Compressor.prototype, {
                     left     : name,
                     right    : def.value
                 }));
+                if (reduce_vars) name.definition().fixed = false;
             }
             return a;
         }, []);

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -1327,3 +1327,27 @@ issue_1595_4: {
         })(3, 4, 5);
     }
 }
+
+issue_1606: {
+    options = {
+        evaluate: true,
+        hoist_vars: true,
+        reduce_vars: true,
+    }
+    input: {
+        function f() {
+            var a;
+            function g(){};
+            var b = 2;
+            x(b);
+        }
+    }
+    expect: {
+        function f() {
+            var a, b;
+            function g(){};
+            b = 2;
+            x(b);
+        }
+    }
+}


### PR DESCRIPTION
`hoist_vars` converts variable declarations into plain assignments, which then confuses `reduce_vars`

fixes #1606