### PR TITLE
fix chained evaluation

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3461,7 +3461,7 @@ merge(Compressor.prototype, {
                     }
                 }
                 if (d.should_replace) {
-                    return d.should_replace;
+                    return d.should_replace.clone(true);
                 }
             }
         }

--- a/test/compress/issue-1609.js
+++ b/test/compress/issue-1609.js
@@ -1,0 +1,56 @@
+chained_evaluation_1: {
+    options = {
+        collapse_vars: true,
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        (function() {
+            var a = 1;
+            (function() {
+                var b = a, c;
+                c = f(b);
+                c.bar = b;
+            })();
+        })();
+    }
+    expect: {
+        (function() {
+            (function() {
+                var c;
+                c = f(1);
+                c.bar = 1;
+            })();
+        })();
+    }
+}
+
+chained_evaluation_2: {
+    options = {
+        collapse_vars: true,
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        (function() {
+            var a = "long piece of string";
+            (function() {
+                var b = a, c;
+                c = f(b);
+                c.bar = b;
+            })();
+        })();
+    }
+    expect: {
+        (function() {
+            var a = "long piece of string";
+            (function() {
+                var c;
+                c = f(a);
+                c.bar = a;
+            })();
+        })();
+    }
+}


### PR DESCRIPTION
`reduce_vars` enables substitution of variables but did not clone the value's `AST_Node`.

This confuses `collapse_vars` and result in invalid AST and subsequent crash.

fixes #1609