### PR TITLE
fix top-level directives in compress tests

### DIFF
--- a/test/compress/issue-1202.js
+++ b/test/compress/issue-1202.js
@@ -49,4 +49,3 @@ mangle_keep_fnames_true: {
         }
     }
 }
-

--- a/test/compress/screw-ie8.js
+++ b/test/compress/screw-ie8.js
@@ -1,20 +1,29 @@
 do_screw: {
-    options = { screw_ie8: true };
+    options = {
+        screw_ie8: true,
+    }
     beautify = {
         screw_ie8: true,
-        ascii_only: true
-    };
-
-    input: f("\v");
-    expect_exact: 'f("\\v");';
+        ascii_only: true,
+    }
+    input: {
+        f("\v");
+    }
+    expect_exact: 'f("\\v");'
 }
 
 dont_screw: {
-    options = { screw_ie8: false };
-    beautify = { screw_ie8: false, ascii_only: true };
-
-    input: f("\v");
-    expect_exact: 'f("\\x0B");';
+    options = {
+        screw_ie8: false,
+    }
+    beautify = {
+        screw_ie8: false,
+        ascii_only: true,
+    }
+    input: {
+        f("\v");
+    }
+    expect_exact: 'f("\\x0B");'
 }
 
 do_screw_constants: {


### PR DESCRIPTION
Since `input` and `expect` are parsed as `AST_BlockStatement`, there cannot be any top-level `AST_Directive`s.

Verify that they are not present so as to avoid confusion.