### PR TITLE
[ES6] Allow 'name' as object literal shorthand property (closes #1613)

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1998,7 +1998,6 @@ function parse($TEXT, options) {
                 // allow trailing comma
                 break;
             start = S.token;
-            var type = start.type;
             var name = as_property_name();
             var value;
 
@@ -2008,9 +2007,6 @@ function parse($TEXT, options) {
                 if (concise) {
                     a.push(concise);
                     continue;
-                }
-                if (!(start.type !== name)) {
-                    unexpected(S.token);
                 }
 
                 value = new AST_SymbolRef({

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -320,3 +320,14 @@ expansion: {
         }
     }
 }
+
+issue_1613: {
+  mangle = { toplevel: true };
+  input: {
+    const name = 1;
+    const foo = {
+      name
+    };
+  }
+  expect_exact: "const n=1;const c={name:n};"
+}


### PR DESCRIPTION
The removed comparison would have thrown an error for shorthand objects using `name` as a property. @kzc recommended removing it entirely as it seems superfluous (all tests still pass).