### PR TITLE
handle runtime errors in `expect_stdout`

### DIFF
--- a/test/compress/issue-1588.js
+++ b/test/compress/issue-1588.js
@@ -85,3 +85,15 @@ unsafe_undefined: {
     }
     expect_stdout: true
 }
+
+runtime_error: {
+    input: {
+        const a = 1;
+        console.log(a++);
+    }
+    expect: {
+        const a = 1;
+        console.log(a++);
+    }
+    expect_stdout: true
+}


### PR DESCRIPTION
allow test to pass if both `input` and `expect` throws the same kind of error