### PR TITLE
make `expect_stdout` work on Node.js 0.12

### DIFF
--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -823,6 +823,7 @@ collapse_vars_repeated: {
             console.log(e + "!");
         })("!");
     }
+    expect_stdout: true
 }
 
 collapse_vars_closures: {
@@ -1109,6 +1110,7 @@ collapse_vars_eval_and_with: {
             return function() { with (o) console.log(a) };
         })()();
     }
+    expect_stdout: true
 }
 
 collapse_vars_constants: {
@@ -1168,6 +1170,7 @@ collapse_vars_arguments: {
             (function(){console.log(arguments);})(7, 1);
         })();
     }
+    expect_stdout: true
 }
 
 collapse_vars_short_circuit: {
@@ -1317,6 +1320,7 @@ collapse_vars_regexp: {
                 console.log(result[0]);
         })();
     }
+    expect_stdout: true
 }
 
 issue_1537: {

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -43,6 +43,7 @@ collapse_vars_side_effects_1: {
                 z = i += 4;
             log(x, z, y, i);
         }
+        f1(), f2(), f3(), f4();
     }
     expect: {
         function f1() {
@@ -73,7 +74,9 @@ collapse_vars_side_effects_1: {
                 y = i += 3;
             log(x, i += 4, y, i);
         }
+        f1(), f2(), f3(), f4();
     }
+    expect_stdout: true
 }
 
 collapse_vars_side_effects_2: {

--- a/test/compress/concat-strings.js
+++ b/test/compress/concat-strings.js
@@ -51,6 +51,7 @@ concat_2: {
             "1" + "2" + "3"
         );
     }
+    expect_stdout: true
 }
 
 concat_3: {
@@ -79,6 +80,7 @@ concat_3: {
             1 + 2 + "3" + "4" + "5"
         );
     }
+    expect_stdout: true
 }
 
 concat_4: {
@@ -107,6 +109,7 @@ concat_4: {
             1 + "2" + "3" + "4" + "5"
         );
     }
+    expect_stdout: true
 }
 
 concat_5: {
@@ -135,6 +138,7 @@ concat_5: {
             "1" + 2 + "3" + "4" + "5"
         );
     }
+    expect_stdout: true
 }
 
 concat_6: {
@@ -163,6 +167,7 @@ concat_6: {
             "1" + "2" + "3" + "4" + "5"
         );
     }
+    expect_stdout: true
 }
 
 concat_7: {
@@ -188,6 +193,7 @@ concat_7: {
             x += "foo"
         );
     }
+    expect_stdout: true
 }
 
 concat_8: {
@@ -213,4 +219,5 @@ concat_8: {
             x += "foo"
         );
     }
+    expect_stdout: true
 }

--- a/test/compress/const.js
+++ b/test/compress/const.js
@@ -162,4 +162,5 @@ regexp_literal_not_const: {
             while (result = REGEXP_LITERAL.exec("acdabcdeabbb")) console.log(result[0]);
         })();
     }
+    expect_stdout: true
 }

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -87,6 +87,7 @@ dead_code_constant_boolean_should_warn_more: {
         var x = 10, y;
         var moo;
     }
+    expect_stdout: true
 }
 
 dead_code_const_declaration: {
@@ -113,6 +114,7 @@ dead_code_const_declaration: {
         var moo;
         function bar() {}
     }
+    expect_stdout: true
 }
 
 dead_code_const_annotation: {
@@ -140,6 +142,7 @@ dead_code_const_annotation: {
         var moo;
         function bar() {}
     }
+    expect_stdout: true
 }
 
 dead_code_const_annotation_regex: {
@@ -163,6 +166,7 @@ dead_code_const_annotation_regex: {
         var CONST_FOO_ANN = !1;
         CONST_FOO_ANN && console.log('reachable');
     }
+    expect_stdout: true
 }
 
 dead_code_const_annotation_complex_scope: {
@@ -208,4 +212,5 @@ dead_code_const_annotation_complex_scope: {
         var meat = 'beef';
         var pork = 'bad';
     }
+    expect_stdout: true
 }

--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -245,6 +245,7 @@ unsafe_constant: {
             (void 0).a
         );
     }
+    expect_stdout: true
 }
 
 unsafe_object: {
@@ -268,6 +269,7 @@ unsafe_object: {
             1..b + 1
         );
     }
+    expect_stdout: true
 }
 
 unsafe_object_nested: {
@@ -291,6 +293,7 @@ unsafe_object_nested: {
             2
         );
     }
+    expect_stdout: true
 }
 
 unsafe_object_complex: {
@@ -314,6 +317,7 @@ unsafe_object_complex: {
             2
         );
     }
+    expect_stdout: true
 }
 
 unsafe_object_repeated: {
@@ -337,6 +341,7 @@ unsafe_object_repeated: {
             1..b + 1
         );
     }
+    expect_stdout: true
 }
 
 unsafe_object_accessor: {
@@ -386,6 +391,7 @@ unsafe_function: {
             ({a:{b:1},b:function(){}}).a.b + 1
         );
     }
+    expect_stdout: true
 }
 
 unsafe_integer_key: {
@@ -533,6 +539,7 @@ unsafe_array: {
             (void 0)[1] + 1
         );
     }
+    expect_stdout: true
 }
 
 unsafe_string: {
@@ -651,6 +658,7 @@ call_args: {
         console.log(1);
         +(1, 1);
     }
+    expect_stdout: true
 }
 
 call_args_drop_param: {
@@ -672,6 +680,7 @@ call_args_drop_param: {
         console.log(1);
         +(b, 1);
     }
+    expect_stdout: true
 }
 
 in_boolean_context: {
@@ -709,6 +718,7 @@ in_boolean_context: {
             (foo(), !1)
         );
     }
+    expect_stdout: true
 }
 
 unsafe_charAt: {

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -39,6 +39,7 @@ iifes_returning_constants_keep_fargs_true: {
         console.log(6);
         console.log((a(), b(), 6));
     }
+    expect_stdout: true
 }
 
 iifes_returning_constants_keep_fargs_false: {
@@ -73,6 +74,7 @@ iifes_returning_constants_keep_fargs_false: {
         console.log(6);
         console.log((a(), b(), 6));
     }
+    expect_stdout: true
 }
 
 issue_485_crashing_1530: {

--- a/test/compress/issue-1275.js
+++ b/test/compress/issue-1275.js
@@ -46,4 +46,5 @@ string_plus_optimization: {
         }
         foo();
     }
+    expect_stdout: true
 }

--- a/test/compress/issue-1321.js
+++ b/test/compress/issue-1321.js
@@ -14,6 +14,7 @@ issue_1321_no_debug: {
         x["a"] = 2 * x.b;
         console.log(x.b, x["a"]);
     }
+    expect_stdout: true
 }
 
 issue_1321_debug: {
@@ -33,6 +34,7 @@ issue_1321_debug: {
         x["_$foo$_"] = 2 * x.a;
         console.log(x.a, x["_$foo$_"]);
     }
+    expect_stdout: true
 }
 
 issue_1321_with_quoted: {
@@ -51,4 +53,5 @@ issue_1321_with_quoted: {
         x["b"] = 2 * x.a;
         console.log(x.a, x["b"]);
     }
+    expect_stdout: true
 }

--- a/test/compress/issue-1447.js
+++ b/test/compress/issue-1447.js
@@ -42,4 +42,5 @@ conditional_false_stray_else_in_loop: {
         }
     }
     expect_exact: "for(var i=1;i<=4;++i)if(!(i<=2))console.log(i);"
+    expect_stdout: true
 }

--- a/test/compress/issue-640.js
+++ b/test/compress/issue-640.js
@@ -48,6 +48,7 @@ dead_code_const_annotation_regex: {
         var CONST_FOO_ANN = !1;
         if (CONST_FOO_ANN) console.log('reachable');
     }
+    expect_stdout: true
 }
 
 drop_console_2: {
@@ -225,6 +226,7 @@ issue_1254_negate_iife_true: {
         })()();
     }
     expect_exact: '(function(){return function(){console.log("test")}})()();'
+    expect_stdout: true
 }
 
 issue_1254_negate_iife_nested: {
@@ -240,6 +242,7 @@ issue_1254_negate_iife_nested: {
         })()()()()();
     }
     expect_exact: '(function(){return function(){console.log("test")}})()()()()();'
+    expect_stdout: true
 }
 
 conditional: {

--- a/test/compress/issue-892.js
+++ b/test/compress/issue-892.js
@@ -29,4 +29,5 @@ dont_mangle_arguments: {
         })(5,6,7);
     }
     expect_exact: "(function(){var arguments=arguments,o=9;console.log(o,arguments)})(5,6,7);"
+    expect_stdout: true
 }

--- a/test/compress/issue-976.js
+++ b/test/compress/issue-976.js
@@ -42,6 +42,7 @@ eval_collapse_vars: {
             eval("console.log(a);");
         })(eval);
     }
+    expect_stdout: true
 }
 
 eval_unused: {

--- a/test/compress/labels.js
+++ b/test/compress/labels.js
@@ -9,6 +9,7 @@ labels_1: {
     expect: {
         foo || console.log("bar");
     }
+    expect_stdout: true
 }
 
 labels_2: {
@@ -40,6 +41,7 @@ labels_3: {
         for (var i = 0; i < 5; ++i)
             i < 3 || console.log(i);
     }
+    expect_stdout: true
 }
 
 labels_4: {
@@ -54,6 +56,7 @@ labels_4: {
         for (var i = 0; i < 5; ++i)
             i < 3 || console.log(i);
     }
+    expect_stdout: true
 }
 
 labels_5: {

--- a/test/compress/loops.js
+++ b/test/compress/loops.js
@@ -166,6 +166,7 @@ keep_collapse_const_in_own_block_scope: {
             console.log(i);
         console.log(c);
     }
+    expect_stdout: true
 }
 
 keep_collapse_const_in_own_block_scope_2: {
@@ -186,6 +187,7 @@ keep_collapse_const_in_own_block_scope_2: {
             console.log(i);
         console.log(c);
     }
+    expect_stdout: true
 }
 
 evaluate: {

--- a/test/compress/negate-iife.js
+++ b/test/compress/negate-iife.js
@@ -70,6 +70,7 @@ negate_iife_3_evaluate: {
     expect: {
         console.log(true);
     }
+    expect_stdout: true
 }
 
 negate_iife_3_side_effects: {
@@ -111,6 +112,7 @@ negate_iife_3_off_evaluate: {
     expect: {
         console.log(true);
     }
+    expect_stdout: true
 }
 
 negate_iife_4: {
@@ -243,6 +245,7 @@ negate_iife_nested: {
             }(7);
         }).f();
     }
+    expect_stdout: true
 }
 
 negate_iife_nested_off: {
@@ -275,6 +278,7 @@ negate_iife_nested_off: {
             })(7);
         }).f();
     }
+    expect_stdout: true
 }
 
 negate_iife_issue_1073: {
@@ -299,6 +303,7 @@ negate_iife_issue_1073: {
             };
         }(7))();
     }
+    expect_stdout: true
 }
 
 issue_1254_negate_iife_false: {
@@ -313,6 +318,7 @@ issue_1254_negate_iife_false: {
         })()();
     }
     expect_exact: '(function(){return function(){console.log("test")}})()();'
+    expect_stdout: true
 }
 
 issue_1254_negate_iife_true: {
@@ -327,6 +333,7 @@ issue_1254_negate_iife_true: {
         })()();
     }
     expect_exact: '!function(){return function(){console.log("test")}}()();'
+    expect_stdout: true
 }
 
 issue_1254_negate_iife_nested: {
@@ -341,6 +348,7 @@ issue_1254_negate_iife_nested: {
         })()()()()();
     }
     expect_exact: '!function(){return function(){console.log("test")}}()()()()();'
+    expect_stdout: true
 }
 
 issue_1288: {

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -58,6 +58,7 @@ reduce_vars: {
         })();
         console.log(2);
     }
+    expect_stdout: true
 }
 
 modified: {
@@ -166,7 +167,7 @@ modified: {
             console.log(A ? 'yes' : 'no');
             console.log(B ? 'yes' : 'no');
         }
-   }
+    }
 }
 
 unsafe_evaluate: {
@@ -401,6 +402,7 @@ iife: {
             console.log(0, 1 * b, 5);
         }(1, 2, 3);
     }
+    expect_stdout: true
 }
 
 iife_new: {
@@ -420,6 +422,7 @@ iife_new: {
             console.log(0, 1 * b, 5);
         }(1, 2, 3);
     }
+    expect_stdout: true
 }
 
 multi_def: {
@@ -707,6 +710,7 @@ toplevel_on: {
     expect: {
         console.log(3);
     }
+    expect_stdout: true
 }
 
 toplevel_off: {
@@ -724,6 +728,7 @@ toplevel_off: {
         var x = 3;
         console.log(x);
     }
+    expect_stdout: true
 }
 
 toplevel_on_loops_1: {
@@ -751,6 +756,7 @@ toplevel_on_loops_1: {
             })();
         while (x);
     }
+    expect_stdout: true
 }
 
 toplevel_off_loops_1: {
@@ -779,6 +785,7 @@ toplevel_off_loops_1: {
             bar();
         while (x);
     }
+    expect_stdout: true
 }
 
 toplevel_on_loops_2: {
@@ -1121,6 +1128,7 @@ defun_label: {
             }(2));
         }();
     }
+    expect_stdout: true
 }
 
 double_reference: {
@@ -1164,6 +1172,7 @@ iife_arguments_1: {
             return f;
         });
     }
+    expect_stdout: true
 }
 
 iife_arguments_2: {
@@ -1186,6 +1195,7 @@ iife_arguments_2: {
             }() === arguments[0]);
         })();
     }
+    expect_stdout: true
 }
 
 iife_eval_1: {
@@ -1207,6 +1217,7 @@ iife_eval_1: {
             return f;
         });
     }
+    expect_stdout: true
 }
 
 iife_eval_2: {
@@ -1230,6 +1241,7 @@ iife_eval_2: {
             console.log(x() === eval("x"));
         })();
     }
+    expect_stdout: true
 }
 
 iife_func_side_effects: {
@@ -1326,6 +1338,7 @@ issue_1595_4: {
             if (a) iife(a - 1, b, c);
         })(3, 4, 5);
     }
+    expect_stdout: true
 }
 
 issue_1606: {

--- a/test/compress/screw-ie8.js
+++ b/test/compress/screw-ie8.js
@@ -128,6 +128,7 @@ do_screw_try_catch_undefined: {
             return void 0===o
         }
     }
+    expect_stdout: true
 }
 
 dont_screw_try_catch_undefined: {
@@ -156,6 +157,7 @@ dont_screw_try_catch_undefined: {
             return n === undefined
         }
     }
+    expect_stdout: true
 }
 
 reduce_vars: {
@@ -208,6 +210,7 @@ issue_1586_1: {
         }
     }
     expect_exact: "function f(){try{}catch(c){console.log(c.message)}}"
+    expect_stdout: true
 }
 
 issue_1586_2: {
@@ -226,4 +229,5 @@ issue_1586_2: {
         }
     }
     expect_exact: "function f(){try{}catch(c){console.log(c.message)}}"
+    expect_stdout: true
 }

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -86,6 +86,7 @@ make_sequences_4: {
         switch (x = 5, y) {}
         with (x = 5, obj);
     }
+    expect_stdout: true
 }
 
 lift_sequences_1: {
@@ -250,6 +251,7 @@ negate_iife_for: {
         for (!function() {}(), i = 0; i < 5; i++) console.log(i);
         for (function() {}(); i < 5; i++) console.log(i);
     }
+    expect_stdout: true
 }
 
 iife: {

--- a/test/compress/transform.js
+++ b/test/compress/transform.js
@@ -13,6 +13,7 @@ booleans_evaluate: {
         console.log(!0, !0);
         console.log(!1, !1);
     }
+    expect_stdout: true
 }
 
 booleans_global_defs: {
@@ -29,6 +30,7 @@ booleans_global_defs: {
     expect: {
         console.log(!0);
     }
+    expect_stdout: true
 }
 
 condition_evaluate: {

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -11,6 +11,17 @@ var vm = require("vm");
 var tests_dir = path.dirname(module.filename);
 var failures = 0;
 var failed_files = {};
+var same_stdout = ~process.version.lastIndexOf("v0.12.", 0) ? function(expected, actual) {
+    if (typeof expected != typeof actual) return false;
+    if (typeof expected != "string") {
+        if (expected.name != actual.name) return false;
+        expected = expected.message.slice(expected.message.lastIndexOf("\n") + 1);
+        actual = actual.message.slice(actual.message.lastIndexOf("\n") + 1);
+    }
+    return expected == actual;
+} : function(expected, actual) {
+    return typeof expected == typeof actual && expected.toString() == actual.toString();
+};
 
 run_compress_tests();
 if (failures) {
@@ -172,7 +183,7 @@ function run_compress_tests() {
                     }
                 }
                 if (test.expect_stdout) {
-                    var stdout = run_code(input_code);
+                    var stdout = run_code(make_code(input, output_options));
                     if (test.expect_stdout === true) {
                         test.expect_stdout = stdout;
                     }
@@ -335,8 +346,4 @@ function run_code(code) {
     } finally {
         process.stdout.write = original_write;
     }
-}
-
-function same_stdout(expected, actual) {
-    return typeof expected == typeof actual && expected.toString() == actual.toString();
 }


### PR DESCRIPTION
That particular version of Node.js has messed up error messages, so provide a version-specific workaround.

Also fixed an formatting issue which would cause `expect_stdout` to fail if error message contains excerpts of input.

Apply `expect_stdout` to more applicable tests.