### PR TITLE
metadata cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
     - "0.12"
     - "4"
     - "6"
-    - "7"
 env:
     - UGLIFYJS_TEST_ALL=1
 matrix:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ There's also an
 [in-browser online demo](http://lisperator.net/uglifyjs/#demo) (for Firefox,
 Chrome and probably Safari).
 
-Note: release versions of `uglify-js` only support ECMAScript 5 (ES5). If you wish to minify
+#### Note:
+- release versions of `uglify-js` only support ECMAScript 5 (ES5). If you wish to minify
 ES2015+ (ES6+) code then please use the [harmony](#harmony) development branch.
+- Node 7 has a known performance regression and runs `uglify-js` twice as slow.
 
 Install
 -------

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   ],
   "dependencies": {
     "source-map": "~0.5.1",
-    "uglify-to-browserify": "~1.0.0",
     "yargs": "~3.10.0"
   },
   "devDependencies": {
@@ -40,13 +39,15 @@
     "estraverse": "~1.5.1",
     "mocha": "~2.3.4"
   },
+  "optionalDependencies": {
+    "uglify-to-browserify": "~1.0.0"
+  },
   "browserify": {
     "transform": [
       "uglify-to-browserify"
     ]
   },
   "scripts": {
-    "shrinkwrap": "rm ./npm-shrinkwrap.json; rm -rf ./node_modules; npm i && npm shrinkwrap && npm outdated",
     "test": "node test/run-tests.js"
   },
   "keywords": ["uglify", "uglify-js", "minify", "minifier"]

--- a/test/mozilla-ast.js
+++ b/test/mozilla-ast.js
@@ -5,7 +5,7 @@ var UglifyJS = require(".."),
     escodegen = require("escodegen"),
     esfuzz = require("esfuzz"),
     estraverse = require("estraverse"),
-    prefix = Array(20).join("\b") + "    ";
+    prefix = "\r    ";
 
 // Normalizes input AST for UglifyJS in order to get correct comparison.
 
@@ -62,7 +62,7 @@ module.exports = function(options) {
         var ast1 = normalizeInput(esfuzz.generate({
             maxDepth: options.maxDepth
         }));
-        
+
         var ast2 =
             UglifyJS
             .AST_Node


### PR DESCRIPTION
- drop Node.js 7 from CI due to performance anomaly
- remove unused npm "scripts"
- mark browserify dependency as optional
- stop `test/mozilla-ast.js` from spamming console output in later versions of Node.js