### PR TITLE
fix regression to allow CLI options with hyphens like -b ascii-only

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -561,7 +561,7 @@ function getOptions(flag, constants) {
 
         var ast;
         try {
-            ast = UglifyJS.parse(x, { expression: true });
+            ast = UglifyJS.parse(x, { cli: true, expression: true });
         } catch(ex) {
             if (ex instanceof UglifyJS.JS_Parse_Error) {
                 print_error("Error parsing arguments for flag `" + flag + "': " + x);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -695,6 +695,7 @@ function parse($TEXT, options) {
         html5_comments : true,
         bare_returns   : false,
         shebang        : true,
+        cli            : false,
     });
 
     var S = {
@@ -1501,6 +1502,7 @@ function parse($TEXT, options) {
     };
 
     function is_assignable(expr) {
+        if (options.cli) return true;
         return expr instanceof AST_PropAccess || expr instanceof AST_SymbolRef;
     };
 


### PR DESCRIPTION
Fixes #1637 

Regression was introduced in #1627

@alexlamsl Sorry about the lack of mocha tests. Feel free to take over this PR if you want.