### PR TITLE
improve error marker placement

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1457,7 +1457,7 @@ function parse($TEXT, options) {
 
     function make_unary(ctor, op, expr) {
         if ((op == "++" || op == "--") && !is_assignable(expr))
-            croak("Invalid use of " + op + " operator");
+            croak("Invalid use of " + op + " operator", null, ctor === AST_UnaryPrefix ? expr.start.col - 1 : null);
         return new ctor({ operator: op, expression: expr });
     };
 

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -298,9 +298,9 @@ describe("bin/uglifyjs", function () {
            assert.ok(err);
            assert.strictEqual(stdout, "");
            assert.strictEqual(stderr.split(/\n/).slice(0, 4).join("\n"), [
-               "Parse error at test/input/invalid/assign_3.js:1,23",
+               "Parse error at test/input/invalid/assign_3.js:1,18",
                "console.log(3 || ++this);",
-               "                       ^",
+               "                  ^",
                "SyntaxError: Invalid use of ++ operator"
            ].join("\n"));
            done();


### PR DESCRIPTION
For AST_UnaryPrefix, points to the operator rather than end of expression.

https://github.com/mishoo/UglifyJS2/pull/1642#issuecomment-288935313