### PR TITLE
fix corner case in `AST_For.init`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2327,6 +2327,7 @@ merge(Compressor.prototype, {
     };
 
     OPT(AST_For, function(self, compressor){
+        if (is_empty(self.init)) self.init = null;
         if (!compressor.option("loops")) return self;
         if (self.condition) {
             var cond = self.condition.evaluate(compressor);

--- a/lib/output.js
+++ b/lib/output.js
@@ -799,7 +799,7 @@ function OutputStream(options) {
         output.print("for");
         output.space();
         output.with_parens(function(){
-            if (self.init && !(self.init instanceof AST_EmptyStatement)) {
+            if (self.init) {
                 if (self.init instanceof AST_Definitions) {
                     self.init.print(output);
                 } else {

--- a/test/compress/loops.js
+++ b/test/compress/loops.js
@@ -440,3 +440,21 @@ issue_186_beautify_bracketize_ie8: {
         '}',
     ]
 }
+
+issue_1648: {
+    options = {
+        join_vars: true,
+        loops: true,
+        passes: 2,
+        sequences: true,
+        unused: true,
+    }
+    input: {
+        function f() {
+            x();
+            var b = 1;
+            while (1);
+        }
+    }
+    expect_exact: "function f(){for(x();1;);}"
+}


### PR DESCRIPTION
Enforce `null` as value for empty initialisation blocks.

fixes #1648