### PR TITLE
fix cascade of `evaluate` optimisation

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3291,6 +3291,7 @@ merge(Compressor.prototype, {
                         left: self.left,
                         right: self.right.expression
                     });
+                    break;
                 }
                 // -a + b => b - a
                 if (self.left instanceof AST_UnaryPrefix
@@ -3302,6 +3303,7 @@ merge(Compressor.prototype, {
                         left: self.right,
                         right: self.left.expression
                     });
+                    break;
                 }
               case "*":
                 associative = compressor.option("unsafe_math");

--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -789,3 +789,16 @@ unsafe_charAt_noop: {
         );
     }
 }
+
+issue_1649: {
+    options = {
+        evaluate: true,
+    }
+    input: {
+        console.log(-1 + -1);
+    }
+    expect: {
+        console.log(-2);
+    }
+    expect_stdout: "-2";
+}


### PR DESCRIPTION
Operator has changed, so break out from rest of the rules.

fixes #1649