### PR TITLE
fix invalid `AST_For.init`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1961,6 +1961,9 @@ merge(Compressor.prototype, {
                             return in_list ? MAP.splice(body) : make_node(AST_BlockStatement, node, {
                                 body: body
                             });
+                        } else if (is_empty(node.init)) {
+                            node.init = null;
+                            return node;
                         }
                     }
                     if (node instanceof AST_Scope && node !== self)
@@ -2327,7 +2330,6 @@ merge(Compressor.prototype, {
     };
 
     OPT(AST_For, function(self, compressor){
-        if (is_empty(self.init)) self.init = null;
         if (!compressor.option("loops")) return self;
         if (self.condition) {
             var cond = self.condition.evaluate(compressor);

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -791,3 +791,17 @@ issue_1583: {
         }
     }
 }
+
+issue_1656: {
+    options = {
+        toplevel: true,
+        unused: true,
+    }
+    beautify = {
+        beautify: true,
+    }
+    input: {
+        for(var a=0;;);
+    }
+    expect_exact: "for (;;) ;"
+}

--- a/test/compress/issue-1656.js
+++ b/test/compress/issue-1656.js
@@ -1,0 +1,45 @@
+f7: {
+    options = {
+        booleans: true,
+        cascade: true,
+        collapse_vars: true,
+        comparisons: true,
+        conditionals: true,
+        dead_code: true,
+        drop_debugger: true,
+        evaluate: true,
+        hoist_funs: true,
+        if_return: true,
+        join_vars: true,
+        loops: true,
+        negate_iife: true,
+        passes: 3,
+        properties: true,
+        reduce_vars: true,
+        sequences: true,
+        side_effects: true,
+        toplevel: true,
+        unused: true,
+    }
+    beautify = {
+        beautify: true,
+    }
+    input: {
+        var a = 100, b = 10;
+        function f22464() {
+            var brake146670 = 5;
+            while (((b = a) ? !a : ~a ? null : b += a) && --brake146670 > 0) {
+            }
+        }
+        f22464();
+        console.log(a, b);
+    }
+    expect_exact: [
+        "var a = 100, b = 10;",
+        "",
+        "!function() {",
+        "    for (;b = a, !1; ) ;",
+        "}(), console.log(a, b);",
+    ]
+    expect_stdout: true
+}


### PR DESCRIPTION
Turns out the only place in `Compressor` which can generate invalid `AST_For.init` is within `drop_unused()`, so focus the fix-up efforts.

supercedes #1652
fixes #1656