### PR TITLE
fix `dead_code` on `AST_Switch`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2529,14 +2529,14 @@ merge(Compressor.prototype, {
                     // no need to descend these node types
                     return node;
                 }
-                else if (node instanceof AST_Switch && node === self) {
+                else if (node === self) {
                     node = node.clone();
                     descend(node, this);
                     return ruined ? node : make_node(AST_BlockStatement, node, {
-                        body: node.body.reduce(function(a, branch){
-                            return a.concat(branch.body);
-                        }, [])
-                    }).transform(compressor);
+                        body: node.body.map(function(stat) {
+                            return stat instanceof AST_SwitchBranch ? make_node(AST_BlockStatement, stat, stat) : stat;
+                        })
+                    }).optimize(compressor);
                 }
                 else if (node instanceof AST_If || node instanceof AST_Try) {
                     var save = in_if;
@@ -2559,10 +2559,10 @@ merge(Compressor.prototype, {
                     }
                     if (in_block) return node;
                     stopped = true;
-                    return in_list ? MAP.skip : make_node(AST_EmptyStatement, node);
+                    return skip(node);
                 }
                 else if (node instanceof AST_SwitchBranch && this.parent() === self) {
-                    if (stopped) return MAP.skip;
+                    if (stopped) return skip(node);
                     if (node instanceof AST_Case) {
                         var exp = node.expression.evaluate(compressor);
                         if (exp === node.expression) {
@@ -2572,13 +2572,16 @@ merge(Compressor.prototype, {
                         if (exp === value || started) {
                             started = true;
                             if (aborts(node)) stopped = true;
-                            descend(node, this);
-                            return node;
-                        }
-                        return MAP.skip;
+                        } else return skip(node);
                     }
-                    descend(node, this);
-                    return node;
+                }
+
+                function skip(node) {
+                    var a = [];
+                    extract_declarations_from_unreachable_code(compressor, node, a);
+                    return in_list ? MAP.splice(a) : make_node(AST_BlockStatement, node, {
+                        body: a
+                    });
                 }
             });
             tt.stack = compressor.stack.slice(); // so that's able to see parent nodes

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2584,7 +2584,8 @@ merge(Compressor.prototype, {
                     });
                 }
             });
-            tt.stack = compressor.stack.slice(); // so that's able to see parent nodes
+            // allow transform() to view the whole AST
+            tt.stack = compressor.stack.slice(0, -1);
             self = self.transform(tt);
         } catch(ex) {
             if (ex !== self) throw ex;

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -258,3 +258,35 @@ keep_default: {
         }
     }
 }
+
+issue_1663: {
+    options = {
+        dead_code: true,
+        evaluate: true,
+    }
+    input: {
+        var a = 100, b = 10;
+        function f() {
+            switch (1) {
+              case 1:
+                b = a++;
+                return ++b;
+              default:
+                var b;
+            }
+        }
+        f();
+        console.log(a, b);
+    }
+    expect: {
+        var a = 100, b = 10;
+        function f() {
+            b = a++;
+            return ++b;
+            var b;
+        }
+        f();
+        console.log(a, b);
+    }
+    expect_stdout: true
+}


### PR DESCRIPTION
Need to call `extract_declarations_from_unreachable_code()`.

fixes #1663