### PR TITLE
fix typeof side-effects

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3013,10 +3013,10 @@ merge(Compressor.prototype, {
                 // typeof always returns a non-empty string, thus it's
                 // always true in booleans
                 compressor.warn("Boolean expression always true [{file}:{line},{col}]", self.start);
-                return make_node(AST_Seq, self, {
+                return (e instanceof AST_SymbolRef ? make_node(AST_True, self) : make_node(AST_Seq, self, {
                     car: e,
                     cdr: make_node(AST_True, self)
-                }).optimize(compressor);
+                })).optimize(compressor);
             }
         }
         // avoids infinite recursion of numerals

--- a/test/compress/typeof.js
+++ b/test/compress/typeof.js
@@ -48,3 +48,15 @@ typeof_in_boolean_context: {
         foo();
     }
 }
+
+issue_1668: {
+    options = {
+        booleans: true,
+    }
+    input: {
+        if (typeof bar);
+    }
+    expect: {
+        if (!0);
+    }
+}


### PR DESCRIPTION
`has_side_effects()` does not take `typeof`'s magical power of not tripping over undeclared variable into account.

fixes #1668