### PR TITLE
[ES6] optimize trivial arrow functions with a return statement in braces

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3943,6 +3943,14 @@ merge(Compressor.prototype, {
         return self;
     });
 
+    OPT(AST_Arrow, function(self, compressor){
+        if (self.body.length === 1 && self.body[0] instanceof AST_Return) {
+            var value = self.body[0].value;
+            self.body = value ? value : [];
+        }
+        return self;
+    });
+
     OPT(AST_Class, function(self, compressor){
         // HACK to avoid compress failure.
         // AST_Class is not really an AST_Scope/AST_Block as it lacks a body.

--- a/test/compress/parameters.js
+++ b/test/compress/parameters.js
@@ -9,7 +9,19 @@ arrow_functions: {
         a=>{return b;}
         a => 'lel';  // Dropping the parens
     }
-    expect_exact: "a=>b;(a,b)=>c;()=>b;a=>b=>c;a=>b=>c;()=>(b,c)=>d;a=>{return b};a=>\"lel\";"
+    expect_exact: "a=>b;(a,b)=>c;()=>b;a=>b=>c;a=>b=>c;()=>(b,c)=>d;a=>b;a=>\"lel\";"
+}
+
+arrow_return: {
+    input: {
+        () => {};
+        () => { return; };
+        a => { return 1; }
+        a => { return -b }
+        a => { return b; var b; }
+        (x, y) => { return x - y; }
+    }
+    expect_exact: "()=>{};()=>{};a=>1;a=>-b;a=>{return b;var b};(x,y)=>x-y;"
 }
 
 regression_arrow_functions_and_hoist: {


### PR DESCRIPTION
Fixes #1676 