### PR TITLE
optimize conditional when condition symbol matches consequent

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3563,8 +3563,19 @@ merge(Compressor.prototype, {
                 alternative: self.consequent
             });
         }
+        var condition = self.condition;
         var consequent = self.consequent;
         var alternative = self.alternative;
+        // x?x:y --> x||y
+        if (condition instanceof AST_SymbolRef
+            && consequent instanceof AST_SymbolRef
+            && condition.definition() === consequent.definition()) {
+            return make_node(AST_Binary, self, {
+                operator: "||",
+                left: condition,
+                right: alternative
+            });
+        }
         // if (foo) exp = something; else exp = something_else;
         //                   |
         //                   v

--- a/test/compress/conditionals.js
+++ b/test/compress/conditionals.js
@@ -933,3 +933,32 @@ issue_1645_2: {
     }
     expect_stdout: true
 }
+
+condition_symbol_matches_consequent: {
+    options = {
+        conditionals: true,
+    }
+    input: {
+        function foo(x, y) {
+            return x ? x : y;
+        }
+        function bar() {
+            return g ? g : h;
+        }
+        var g = 4;
+        var h = 5;
+        console.log(foo(3, null), foo(0, 7), foo(true, false), bar());
+    }
+    expect: {
+        function foo(x, y) {
+            return x || y;
+        }
+        function bar() {
+            return g || h;
+        }
+        var g = 4;
+        var h = 5;
+        console.log(foo(3, null), foo(0, 7), foo(true, false), bar());
+    }
+    expect_stdout: "3 7 true 4"
+}


### PR DESCRIPTION
Idea originated from a [recent commit](https://github.com/mishoo/UglifyJS2/blob/6a54de79b58c37da1b6f8bcff20aadfd1d0e2043/lib/compress.js#L3949). 

It shouldn't matter if the conditional condition is an undeclared global. It will error out in the same way:
```
$ echo 'console.log(x ? x : 5);' | bin/uglifyjs -c
console.log(x||5);
```