### PR TITLE
fix `cascade` on `delete` operator

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2542,7 +2542,6 @@ merge(Compressor.prototype, {
                         continue;
                     }
                 }
-                var case_side_effects = branch instanceof AST_Case && branch.expression.has_side_effects(compressor);
                 if (aborts(branch)) {
                     var block = make_node(AST_BlockStatement, branch, branch).print_to_string();
                     if (!fallthrough && prev_block === block) body[body.length - 1].body = [];
@@ -2946,7 +2945,10 @@ merge(Compressor.prototype, {
                             field = "left";
                         }
                     } else if (cdr instanceof AST_Call
-                        || cdr instanceof AST_Unary && cdr.operator != "++" && cdr.operator != "--") {
+                        || cdr instanceof AST_Unary
+                            && cdr.operator != "delete"
+                            && cdr.operator != "++"
+                            && cdr.operator != "--") {
                         field = "expression";
                     } else break;
                     parent = cdr;

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -306,3 +306,27 @@ unsafe_undefined: {
         }
     }
 }
+
+issue_1685: {
+    options = {
+        cascade: true,
+        side_effects: true,
+    }
+    input: {
+        var a = 100, b = 10;
+        function f() {
+            var a = (a--, delete a && --b);
+        }
+        f();
+        console.log(a, b);
+    }
+    expect: {
+        var a = 100, b = 10;
+        function f() {
+            var a = (a--, delete a && --b);
+        }
+        f();
+        console.log(a, b);
+    }
+    expect_stdout: true
+}


### PR DESCRIPTION
Conditions including strict mode would make `delete` return `true` or `false`, and are too complex to be evaluated by the compressor.

Suppress assignment folding into said operator.

fixes #1685