### PR TITLE
fix `cascade` on anonymous function reference

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2915,7 +2915,9 @@ merge(Compressor.prototype, {
                 && (self.car.operator == "++" || self.car.operator == "--")) {
                 left = self.car.expression;
             }
-            if (left) {
+            if (left
+                && !(left instanceof AST_SymbolRef
+                    && left.definition().orig[0] instanceof AST_SymbolLambda)) {
                 var parent, field;
                 var cdr = self.cdr;
                 while (true) {

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -330,3 +330,113 @@ issue_1685: {
     }
     expect_stdout: true
 }
+
+func_def_1: {
+    options = {
+        cascade: true,
+        side_effects: true,
+    }
+    input: {
+        function f() {
+            return f = 0, !!f;
+        }
+        console.log(f());
+    }
+    expect: {
+        function f() {
+            return !!(f = 0);
+        }
+        console.log(f());
+    }
+    expect_stdout: "false"
+}
+
+func_def_2: {
+    options = {
+        cascade: true,
+        side_effects: true,
+    }
+    input: {
+        console.log(function f() {
+            return f = 0, !!f;
+        }());
+    }
+    expect: {
+        console.log(function f() {
+            return f = 0, !!f;
+        }());
+    }
+    expect_stdout: "true"
+}
+
+func_def_3: {
+    options = {
+        cascade: true,
+        side_effects: true,
+    }
+    input: {
+        function f() {
+            function g() {}
+            return g = 0, !!g;
+        }
+        console.log(f());
+    }
+    expect: {
+        function f() {
+            function g() {}
+            return !!(g = 0);
+        }
+        console.log(f());
+    }
+    expect_stdout: "false"
+}
+
+func_def_4: {
+    options = {
+        cascade: true,
+        side_effects: true,
+    }
+    input: {
+        function f() {
+            function g() {
+                return g = 0, !!g;
+            }
+            return g();
+        }
+        console.log(f());
+    }
+    expect: {
+        function f() {
+            function g() {
+                return !!(g = 0);
+            }
+            return g();
+        }
+        console.log(f());
+    }
+    expect_stdout: "false"
+}
+
+func_def_5: {
+    options = {
+        cascade: true,
+        side_effects: true,
+    }
+    input: {
+        function f() {
+            return function g(){
+                return g = 0, !!g;
+            }();
+        }
+        console.log(f());
+    }
+    expect: {
+        function f() {
+            return function g(){
+                return g = 0, !!g;
+            }();
+        }
+        console.log(f());
+    }
+    expect_stdout: "true"
+}


### PR DESCRIPTION
Unlike normal variables and even function definitions, these cannot be reassigned, even though assignment expressions would "leak" the assigned value as normal.