### PR TITLE
fix mangle for variable declared within catch block

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -154,6 +154,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
         else if (node instanceof AST_SymbolVar
                  || node instanceof AST_SymbolConst) {
             defun.def_variable(node);
+            if (defun !== scope) node.mark_enclosed(options);
         }
         else if (node instanceof AST_SymbolCatch) {
             scope.def_variable(node);
@@ -262,9 +263,8 @@ AST_Lambda.DEFMETHOD("init_scope_vars", function(){
     }));
 });
 
-AST_SymbolRef.DEFMETHOD("reference", function(options) {
+AST_Symbol.DEFMETHOD("mark_enclosed", function(options) {
     var def = this.definition();
-    def.references.push(this);
     var s = this.scope;
     while (s) {
         push_uniq(s.enclosed, def);
@@ -276,6 +276,11 @@ AST_SymbolRef.DEFMETHOD("reference", function(options) {
         if (s === def.scope) break;
         s = s.parent_scope;
     }
+});
+
+AST_SymbolRef.DEFMETHOD("reference", function(options) {
+    this.definition().references.push(this);
+    this.mark_enclosed(options);
 });
 
 AST_Scope.DEFMETHOD("find_variable", function(name){

--- a/test/compress/issue-1704.js
+++ b/test/compress/issue-1704.js
@@ -1,0 +1,175 @@
+mangle_catch: {
+    options = {
+        screw_ie8: true,
+        toplevel: false,
+    }
+    mangle = {
+        screw_ie8: true,
+        toplevel: false,
+    }
+    input: {
+        var a = "FAIL";
+        try {
+            throw 1;
+        } catch (args) {
+            a = "PASS";
+        }
+        console.log(a);
+    }
+    expect_exact: 'var a="FAIL";try{throw 1}catch(o){a="PASS"}console.log(a);'
+    expect_stdout: "PASS"
+}
+
+mangle_catch_ie8: {
+    options = {
+        screw_ie8: false,
+        toplevel: false,
+    }
+    mangle = {
+        screw_ie8: false,
+        toplevel: false,
+    }
+    input: {
+        var a = "FAIL";
+        try {
+            throw 1;
+        } catch (args) {
+            a = "PASS";
+        }
+        console.log(a);
+    }
+    expect_exact: 'var a="FAIL";try{throw 1}catch(args){a="PASS"}console.log(a);'
+    expect_stdout: "PASS"
+}
+
+mangle_catch_var: {
+    options = {
+        screw_ie8: true,
+        toplevel: false,
+    }
+    mangle = {
+        screw_ie8: true,
+        toplevel: false,
+    }
+    input: {
+        var a = "FAIL";
+        try {
+            throw 1;
+        } catch (args) {
+            var a = "PASS";
+        }
+        console.log(a);
+    }
+    expect_exact: 'var a="FAIL";try{throw 1}catch(o){var a="PASS"}console.log(a);'
+    expect_stdout: "PASS"
+}
+
+mangle_catch_var_ie8: {
+    options = {
+        screw_ie8: false,
+        toplevel: false,
+    }
+    mangle = {
+        screw_ie8: false,
+        toplevel: false,
+    }
+    input: {
+        var a = "FAIL";
+        try {
+            throw 1;
+        } catch (args) {
+            var a = "PASS";
+        }
+        console.log(a);
+    }
+    expect_exact: 'var a="FAIL";try{throw 1}catch(args){var a="PASS"}console.log(a);'
+    expect_stdout: "PASS"
+}
+
+mangle_catch_toplevel: {
+    options = {
+        screw_ie8: true,
+        toplevel: true,
+    }
+    mangle = {
+        screw_ie8: true,
+        toplevel: true,
+    }
+    input: {
+        var a = "FAIL";
+        try {
+            throw 1;
+        } catch (args) {
+            a = "PASS";
+        }
+        console.log(a);
+    }
+    expect_exact: 'var o="FAIL";try{throw 1}catch(c){o="PASS"}console.log(o);'
+    expect_stdout: "PASS"
+}
+
+mangle_catch_ie8_toplevel: {
+    options = {
+        screw_ie8: false,
+        toplevel: true,
+    }
+    mangle = {
+        screw_ie8: false,
+        toplevel: true,
+    }
+    input: {
+        var a = "FAIL";
+        try {
+            throw 1;
+        } catch (args) {
+            a = "PASS";
+        }
+        console.log(a);
+    }
+    expect_exact: 'var o="FAIL";try{throw 1}catch(c){o="PASS"}console.log(o);'
+    expect_stdout: "PASS"
+}
+
+mangle_catch_var_toplevel: {
+    options = {
+        screw_ie8: true,
+        toplevel: true,
+    }
+    mangle = {
+        screw_ie8: true,
+        toplevel: true,
+    }
+    input: {
+        var a = "FAIL";
+        try {
+            throw 1;
+        } catch (args) {
+            var a = "PASS";
+        }
+        console.log(a);
+    }
+    expect_exact: 'var o="FAIL";try{throw 1}catch(r){var o="PASS"}console.log(o);'
+    expect_stdout: "PASS"
+}
+
+mangle_catch_var_ie8_toplevel: {
+    options = {
+        screw_ie8: false,
+        toplevel: true,
+    }
+    mangle = {
+        screw_ie8: false,
+        toplevel: true,
+    }
+    input: {
+        var a = "FAIL";
+        try {
+            throw 1;
+        } catch (args) {
+            var a = "PASS";
+        }
+        console.log(a);
+    }
+    expect_exact: 'var o="FAIL";try{throw 1}catch(r){var o="PASS"}console.log(o);'
+    expect_stdout: "PASS"
+}


### PR DESCRIPTION
fixes #1704

This should play nice with `harmony` as well.