### PR TITLE
fix `unused` on var of the same name within catch

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1894,7 +1894,13 @@ merge(Compressor.prototype, {
                     if (drop_vars && node instanceof AST_Definitions && !(tt.parent() instanceof AST_ForIn)) {
                         var def = node.definitions.filter(function(def){
                             if (def.value) def.value = def.value.transform(tt);
-                            if (def.name.definition().id in in_use_ids) return true;
+                            var sym = def.name.definition();
+                            if (sym.id in in_use_ids) return true;
+                            if (sym.orig[0] instanceof AST_SymbolCatch
+                                && sym.scope.parent_scope.find_variable(def.name).orig[0] === def.name) {
+                                def.value = def.value && def.value.drop_side_effect_free(compressor);
+                                return true;
+                            }
                             var w = {
                                 name : def.name.name,
                                 file : def.name.start.file,

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -844,3 +844,90 @@ issue_1709: {
     }
     expect_stdout: true
 }
+
+issue_1715_1: {
+    options = {
+        unused: true,
+    }
+    input: {
+        var a = 1;
+        function f() {
+            a++;
+            try {} catch (a) {
+                var a;
+            }
+        }
+        f();
+        console.log(a);
+    }
+    expect: {
+        var a = 1;
+        function f() {
+            a++;
+            try {} catch (a) {
+                var a;
+            }
+        }
+        f();
+        console.log(a);
+    }
+    expect_stdout: "1"
+}
+
+issue_1715_2: {
+    options = {
+        unused: true,
+    }
+    input: {
+        var a = 1;
+        function f() {
+            a++;
+            try {} catch (a) {
+                var a = 2;
+            }
+        }
+        f();
+        console.log(a);
+    }
+    expect: {
+        var a = 1;
+        function f() {
+            a++;
+            try {} catch (a) {
+                var a;
+            }
+        }
+        f();
+        console.log(a);
+    }
+    expect_stdout: "1"
+}
+
+issue_1715_3: {
+    options = {
+        unused: true,
+    }
+    input: {
+        var a = 1;
+        function f() {
+            a++;
+            try {} catch (a) {
+                var a = 2 + x();
+            }
+        }
+        f();
+        console.log(a);
+    }
+    expect: {
+        var a = 1;
+        function f() {
+            a++;
+            try {} catch (a) {
+                var a = x();
+            }
+        }
+        f();
+        console.log(a);
+    }
+    expect_stdout: "1"
+}


### PR DESCRIPTION
fixes #1715