### PR TITLE
fix corner case in `unused`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1896,8 +1896,7 @@ merge(Compressor.prototype, {
                             if (def.value) def.value = def.value.transform(tt);
                             var sym = def.name.definition();
                             if (sym.id in in_use_ids) return true;
-                            if (sym.orig[0] instanceof AST_SymbolCatch
-                                && sym.scope.parent_scope.find_variable(def.name).orig[0] === def.name) {
+                            if (sym.orig[0] instanceof AST_SymbolCatch) {
                                 def.value = def.value && def.value.drop_side_effect_free(compressor);
                                 return true;
                             }

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -931,3 +931,30 @@ issue_1715_3: {
     }
     expect_stdout: "1"
 }
+
+issue_1715_4: {
+    options = {
+        unused: true,
+    }
+    input: {
+        var a = 1;
+        !function a() {
+            a++;
+            try {} catch (a) {
+                var a;
+            }
+        }();
+        console.log(a);
+    }
+    expect: {
+        var a = 1;
+        !function() {
+            a++;
+            try {} catch (a) {
+                var a;
+            }
+        }();
+        console.log(a);
+    }
+    expect_stdout: "1"
+}


### PR DESCRIPTION
When fixing catch-related issue in #1715, it tries to optimise for duplicate definitions but did not take anonymous functions into account.

Remove such optimisation for now and we can cover this as a more general rule later.