### PR TITLE
improve beautified output of switch blocks

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -960,24 +960,24 @@ function OutputStream(options) {
             self.expression.print(output);
         });
         output.space();
-        if (self.body.length > 0) output.with_block(function(){
-            self.body.forEach(function(stmt, i){
-                if (i) output.newline();
+        var last = self.body.length - 1;
+        if (last < 0) output.print("{}");
+        else output.with_block(function(){
+            self.body.forEach(function(branch, i){
                 output.indent(true);
-                stmt.print(output);
+                branch.print(output);
+                if (i < last && branch.body.length > 0)
+                    output.newline();
             });
         });
-        else output.print("{}");
     });
     AST_SwitchBranch.DEFMETHOD("_do_print_body", function(output){
-        if (this.body.length > 0) {
+        output.newline();
+        this.body.forEach(function(stmt){
+            output.indent();
+            stmt.print(output);
             output.newline();
-            this.body.forEach(function(stmt){
-                output.indent();
-                stmt.print(output);
-                output.newline();
-            });
-        }
+        });
     });
     DEFPRINT(AST_Default, function(self, output){
         output.print("default:");

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -680,3 +680,44 @@ issue_1705_3: {
     }
     expect_stdout: true
 }
+
+beautify: {
+    beautify = {
+        beautify: true,
+    }
+    input: {
+        switch (a) {
+          case 0:
+          case 1:
+            break;
+          case 2:
+          default:
+        }
+        switch (b) {
+          case 3:
+            foo();
+            bar();
+          default:
+            break;
+        }
+    }
+    expect_exact: [
+        "switch (a) {",
+        "  case 0:",
+        "  case 1:",
+        "    break;",
+        "",
+        "  case 2:",
+        "  default:",
+        "}",
+        "",
+        "switch (b) {",
+        "  case 3:",
+        "    foo();",
+        "    bar();",
+        "",
+        "  default:",
+        "    break;",
+        "}",
+    ]
+}


### PR DESCRIPTION
Not that I care for `--beautify` too much myself, but after seeing a bunch of:
```js
    switch (x) {
        case ...:
            ...
        default:    }
```
From the fuzzer output, I guess it's time to tweak this a little.