### PR TITLE
speed up IIFE elimination

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -200,7 +200,7 @@ merge(Compressor.prototype, {
         return this.print_to_string() == node.print_to_string();
     });
 
-    AST_Node.DEFMETHOD("process_expression", function(insert) {
+    AST_Node.DEFMETHOD("process_expression", function(insert, compressor) {
         var self = this;
         var tt = new TreeTransformer(function(node) {
             if (insert && node instanceof AST_SimpleStatement) {
@@ -209,6 +209,12 @@ merge(Compressor.prototype, {
                 });
             }
             if (!insert && node instanceof AST_Return) {
+                if (compressor) {
+                    var value = node.value && node.value.drop_side_effect_free(compressor, true);
+                    return value ? make_node(AST_SimpleStatement, node, {
+                        body: value
+                    }) : make_node(AST_EmptyStatement, node);
+                }
                 return make_node(AST_SimpleStatement, node, {
                     body: node.value || make_node(AST_Undefined, node)
                 });
@@ -2154,7 +2160,7 @@ merge(Compressor.prototype, {
                 if (this.expression instanceof AST_Function
                     && (!this.expression.name || !this.expression.name.definition().references.length)) {
                     var node = this.clone();
-                    node.expression = node.expression.process_expression(false);
+                    node.expression = node.expression.process_expression(false, compressor);
                     return node;
                 }
                 return this;
@@ -2866,11 +2872,9 @@ merge(Compressor.prototype, {
                     return AST_Seq.from_array(args).transform(compressor);
                 }
             }
-            if (compressor.option("side_effects")) {
-                if (!AST_Block.prototype.has_side_effects.call(exp, compressor)) {
-                    var args = self.args.concat(make_node(AST_Undefined, self));
-                    return AST_Seq.from_array(args).transform(compressor);
-                }
+            if (compressor.option("side_effects") && all(exp.body, is_empty)) {
+                var args = self.args.concat(make_node(AST_Undefined, self));
+                return AST_Seq.from_array(args).transform(compressor);
             }
         }
         if (compressor.option("drop_console")) {


### PR DESCRIPTION
- `side_effects` will clean up inner statements, so checking for an empty function body should suffice
- drop side effects when dropping `return` from statement

The only difference from `test/benchmark.js` is `ember.prod.js`, which has two `return` statement trimming due to unused `REDEFINE_SUPPORTED` and `LinkedListRemover`.