### PR TITLE
optimize try-catch-finally

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2606,6 +2606,16 @@ merge(Compressor.prototype, {
 
     OPT(AST_Try, function(self, compressor){
         self.body = tighten_body(self.body, compressor);
+        if (self.bcatch && all(self.bcatch.body, is_empty)) self.bcatch = null;
+        if (self.bfinally && all(self.bfinally.body, is_empty)) self.bfinally = null;
+        if (all(self.body, is_empty)) {
+            var body = [];
+            if (self.bcatch) extract_declarations_from_unreachable_code(compressor, self.bcatch, body);
+            if (self.bfinally) body = body.concat(self.bfinally.body);
+            return body.length > 0 ? make_node(AST_BlockStatement, self, {
+                body: body
+            }) : make_node(AST_EmptyStatement, self);
+        }
         return self;
     });
 

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2606,15 +2606,14 @@ merge(Compressor.prototype, {
 
     OPT(AST_Try, function(self, compressor){
         self.body = tighten_body(self.body, compressor);
-        if (self.bcatch && all(self.bcatch.body, is_empty)) self.bcatch = null;
-        if (self.bfinally && all(self.bfinally.body, is_empty)) self.bfinally = null;
+        if (self.bcatch && self.bfinally && all(self.bfinally.body, is_empty)) self.bfinally = null;
         if (all(self.body, is_empty)) {
             var body = [];
             if (self.bcatch) extract_declarations_from_unreachable_code(compressor, self.bcatch, body);
             if (self.bfinally) body = body.concat(self.bfinally.body);
             return body.length > 0 ? make_node(AST_BlockStatement, self, {
                 body: body
-            }) : make_node(AST_EmptyStatement, self);
+            }).optimize(compressor) : make_node(AST_EmptyStatement, self);
         }
         return self;
     });

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -234,7 +234,10 @@ try_catch_finally: {
                 console.log("PASS");
             }
         }();
-        console.log(a);
+        try {
+            console.log(a);
+        } finally {
+        }
     }
     expect: {
         var a = 1;
@@ -243,7 +246,10 @@ try_catch_finally: {
             a = 3;
             console.log("PASS");
         }();
-        console.log(a);
+        try {
+            console.log(a);
+        } finally {
+        }
     }
     expect_stdout: [
         "PASS",

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -214,3 +214,39 @@ dead_code_const_annotation_complex_scope: {
     }
     expect_stdout: true
 }
+
+try_catch_finally: {
+    options = {
+        conditionals: true,
+        dead_code: true,
+        evaluate: true,
+    }
+    input: {
+        var a = 1;
+        !function() {
+            try {
+                if (false) throw x;
+            } catch (a) {
+                var a = 2;
+                console.log("FAIL");
+            } finally {
+                a = 3;
+                console.log("PASS");
+            }
+        }();
+        console.log(a);
+    }
+    expect: {
+        var a = 1;
+        !function() {
+            var a;
+            a = 3;
+            console.log("PASS");
+        }();
+        console.log(a);
+    }
+    expect_stdout: [
+        "PASS",
+        "1",
+    ]
+}

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -853,7 +853,9 @@ issue_1715_1: {
         var a = 1;
         function f() {
             a++;
-            try {} catch (a) {
+            try {
+                x();
+            } catch (a) {
                 var a;
             }
         }
@@ -864,7 +866,9 @@ issue_1715_1: {
         var a = 1;
         function f() {
             a++;
-            try {} catch (a) {
+            try {
+                x();
+            } catch (a) {
                 var a;
             }
         }
@@ -882,7 +886,9 @@ issue_1715_2: {
         var a = 1;
         function f() {
             a++;
-            try {} catch (a) {
+            try {
+                x();
+            } catch (a) {
                 var a = 2;
             }
         }
@@ -893,7 +899,9 @@ issue_1715_2: {
         var a = 1;
         function f() {
             a++;
-            try {} catch (a) {
+            try {
+                x();
+            } catch (a) {
                 var a;
             }
         }
@@ -911,7 +919,9 @@ issue_1715_3: {
         var a = 1;
         function f() {
             a++;
-            try {} catch (a) {
+            try {
+                console;
+            } catch (a) {
                 var a = 2 + x();
             }
         }
@@ -922,7 +932,9 @@ issue_1715_3: {
         var a = 1;
         function f() {
             a++;
-            try {} catch (a) {
+            try {
+                console;
+            } catch (a) {
                 var a = x();
             }
         }
@@ -940,7 +952,9 @@ issue_1715_4: {
         var a = 1;
         !function a() {
             a++;
-            try {} catch (a) {
+            try {
+                x();
+            } catch (a) {
                 var a;
             }
         }();
@@ -950,7 +964,9 @@ issue_1715_4: {
         var a = 1;
         !function() {
             a++;
-            try {} catch (a) {
+            try {
+                x();
+            } catch (a) {
                 var a;
             }
         }();

--- a/test/compress/issue-1673.js
+++ b/test/compress/issue-1673.js
@@ -70,6 +70,7 @@ side_effects_finally: {
         function f() {
             function g() {
                 try {
+                    if (f);
                 } catch (e) {
                 } finally {
                     console.log("PASS");
@@ -83,7 +84,7 @@ side_effects_finally: {
         function f() {
             (function() {
                 try {
-                } catch (e) {
+                    if (f);
                 } finally {
                     console.log("PASS");
                 }

--- a/test/compress/issue-1673.js
+++ b/test/compress/issue-1673.js
@@ -70,7 +70,7 @@ side_effects_finally: {
         function f() {
             function g() {
                 try {
-                    if (f);
+                    x();
                 } catch (e) {
                 } finally {
                     console.log("PASS");
@@ -84,7 +84,8 @@ side_effects_finally: {
         function f() {
             (function() {
                 try {
-                    if (f);
+                    x();
+                } catch (e) {
                 } finally {
                     console.log("PASS");
                 }

--- a/test/compress/screw-ie8.js
+++ b/test/compress/screw-ie8.js
@@ -204,13 +204,13 @@ issue_1586_1: {
     input: {
         function f() {
             try {
+                x();
             } catch (err) {
                 console.log(err.message);
             }
         }
     }
-    expect_exact: "function f(){try{}catch(c){console.log(c.message)}}"
-    expect_stdout: true
+    expect_exact: "function f(){try{x()}catch(c){console.log(c.message)}}"
 }
 
 issue_1586_2: {
@@ -223,11 +223,11 @@ issue_1586_2: {
     input: {
         function f() {
             try {
+                x();
             } catch (err) {
                 console.log(err.message);
             }
         }
     }
-    expect_exact: "function f(){try{}catch(c){console.log(c.message)}}"
-    expect_stdout: true
+    expect_exact: "function f(){try{x()}catch(c){console.log(c.message)}}"
 }


### PR DESCRIPTION
- eliminate empty blocks
- flatten out if try-block does not throw

So before this PR `OPT(AST_Try)` is identical to `OPT(AST_Block)` - I think we can do better than that.

Fix up existing tests by introducing non-empty try-blocks so they remain effective in testing their respective conditions.