### PR TITLE
fix catch symbol mangling

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -81,7 +81,7 @@ SymbolDef.prototype = {
             var def;
             if (options.screw_ie8
                 && sym instanceof AST_SymbolCatch
-                && (def = s.parent_scope.find_variable(sym))) {
+                && (def = s.parent_scope.variables.get(this.name))) {
                 this.mangled_name = def.mangled_name || def.name;
             } else
                 this.mangled_name = s.next_mangled(options, this);

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -79,9 +79,7 @@ SymbolDef.prototype = {
             if (!options.screw_ie8 && sym instanceof AST_SymbolLambda)
                 s = s.parent_scope;
             var def;
-            if (options.screw_ie8
-                && sym instanceof AST_SymbolCatch
-                && (def = this.defun.variables.get(this.name))) {
+            if (this.defun && (def = this.defun.variables.get(this.name))) {
                 this.mangled_name = def.mangled_name || def.name;
             } else
                 this.mangled_name = s.next_mangled(options, this);

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -81,7 +81,7 @@ SymbolDef.prototype = {
             var def;
             if (options.screw_ie8
                 && sym instanceof AST_SymbolCatch
-                && (def = s.parent_scope.variables.get(this.name))) {
+                && (def = this.defun.variables.get(this.name))) {
                 this.mangled_name = def.mangled_name || def.name;
             } else
                 this.mangled_name = s.next_mangled(options, this);
@@ -171,7 +171,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
             }
         }
         else if (node instanceof AST_SymbolCatch) {
-            scope.def_variable(node);
+            scope.def_variable(node).defun = defun;
         }
         else if (node instanceof AST_LabelRef) {
             var sym = labels.get(node.name);
@@ -227,7 +227,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
             if (node instanceof AST_SymbolCatch) {
                 var name = node.name;
                 var refs = node.thedef.references;
-                var scope = node.thedef.scope.parent_scope;
+                var scope = node.thedef.defun;
                 var def = scope.find_variable(name) || self.globals.get(name) || scope.def_variable(node);
                 refs.forEach(function(ref) {
                     ref.thedef = def;

--- a/test/compress/issue-1733.js
+++ b/test/compress/issue-1733.js
@@ -39,3 +39,59 @@ function_iife_catch_ie8: {
     expect_exact: "function f(o){!function(){try{throw 0}catch(o){var c=1;console.log(o,c)}}()}f();"
     expect_stdout: "0 1"
 }
+
+function_catch_catch: {
+    mangle = {
+        screw_ie8: true,
+    }
+    input: {
+        var o = 0;
+        function f() {
+            try {
+                throw 1;
+            } catch (c) {
+                try {
+                    throw 2;
+                } catch (o) {
+                    var o = 3;
+                    console.log(o);
+                }
+            }
+            console.log(o);
+        }
+        f();
+    }
+    expect_exact: "var o=0;function f(){try{throw 1}catch(c){try{throw 2}catch(o){var o=3;console.log(o)}}console.log(o)}f();"
+    expect_stdout: [
+        "3",
+        "undefined",
+    ]
+}
+
+function_catch_catch_ie8: {
+    mangle = {
+        screw_ie8: false,
+    }
+    input: {
+        var o = 0;
+        function f() {
+            try {
+                throw 1;
+            } catch (c) {
+                try {
+                    throw 2;
+                } catch (o) {
+                    var o = 3;
+                    console.log(o);
+                }
+            }
+            console.log(o);
+        }
+        f();
+    }
+    expect_exact: "var o=0;function f(){try{throw 1}catch(c){try{throw 2}catch(o){var o=3;console.log(o)}}console.log(o)}f();"
+    expect_stdout: [
+        "3",
+        "undefined",
+    ]
+}

--- a/test/compress/issue-1733.js
+++ b/test/compress/issue-1733.js
@@ -1,0 +1,41 @@
+function_iife_catch: {
+    mangle = {
+        screw_ie8: true,
+    }
+    input: {
+        function f(n) {
+            !function() {
+                try {
+                    throw 0;
+                } catch (n) {
+                    var a = 1;
+                    console.log(n, a);
+                }
+            }();
+        }
+        f();
+    }
+    expect_exact: "function f(o){!function(){try{throw 0}catch(c){var o=1;console.log(c,o)}}()}f();"
+    expect_stdout: "0 1"
+}
+
+function_iife_catch_ie8: {
+    mangle = {
+        screw_ie8: false,
+    }
+    input: {
+        function f(n) {
+            !function() {
+                try {
+                    throw 0;
+                } catch (n) {
+                    var a = 1;
+                    console.log(n, a);
+                }
+            }();
+        }
+        f();
+    }
+    expect_exact: "function f(o){!function(){try{throw 0}catch(o){var c=1;console.log(o,c)}}()}f();"
+    expect_stdout: "0 1"
+}


### PR DESCRIPTION
Only need to look up the immediate ~parent~ non-block/catch scope for the same-name special case.

fixes #1733