### PR TITLE
[ES6] Another variant of import added - import * from "x.js"

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1233,7 +1233,7 @@ function OutputStream(options) {
             output.space();
         }
         if (self.imported_names) {
-            if (self.imported_names.length === 1 && self.imported_names[0].name.name === "*") {
+            if (self.imported_names.length === 1 && self.imported_names[0].foreign_name.name === "*") {
                 self.imported_names[0].print(output);
             } else {
                 output.print("{");

--- a/lib/output.js
+++ b/lib/output.js
@@ -1233,17 +1233,21 @@ function OutputStream(options) {
             output.space();
         }
         if (self.imported_names) {
-            output.print("{");
-            self.imported_names.forEach(function(name_import, i) {
-                output.space();
-                name_import.print(output);
-                if (i < self.imported_names.length - 1) {
-                    output.print(",");
+            if (self.imported_names.length === 1 && self.imported_names[0].name.name === "*") {
+                self.imported_names[0].print(output);
+            } else {
+                output.print("{");
+                self.imported_names.forEach(function (name_import, i) {
                     output.space();
-                }
-            });
-            output.space();
-            output.print("}");
+                    name_import.print(output);
+                    if (i < self.imported_names.length - 1) {
+                        output.print(",");
+                        output.space();
+                    }
+                });
+                output.space();
+                output.print("}");
+            }
         }
         if (self.imported_name || self.imported_names) {
             output.space();

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2176,7 +2176,7 @@ function parse($TEXT, options) {
             next();
         }
 
-        imported_names = import_names();
+        imported_names = import_names(true);
 
         if (imported_names || imported_name) {
             expect_token("name", "from");
@@ -2227,16 +2227,14 @@ function parse($TEXT, options) {
         })
     }
 
-    function import_nameAsterisk() {
+    function import_nameAsterisk(name) {
         var start = S.token;
         var foreign_name;
-        var name;
 
-        next();
 
         var end = prev();
 
-        name = new AST_SymbolImport({
+        name = name || new AST_SymbolImport({
             name: '*',
             start: start,
             end: end,
@@ -2256,7 +2254,7 @@ function parse($TEXT, options) {
         })
     }
 
-    function import_names() {
+    function import_names(allow_as) {
         var names;
         if (is("punc", "{")) {
             next();
@@ -2269,8 +2267,13 @@ function parse($TEXT, options) {
             }
             next();
         } else if (is("operator", "*")) {
-            var st = prev();
-            names = [import_nameAsterisk()];
+            var name;
+            next();
+            if (allow_as && is("name", "as")) {
+                next();  // The "as" word
+                name = as_symbol(AST_SymbolImportForeign);
+            }
+            names = [import_nameAsterisk(name)];
         }
         return names;
     }
@@ -2286,7 +2289,7 @@ function parse($TEXT, options) {
             next();
         }
 
-        exported_names = import_names();
+        exported_names = import_names(false);
 
         if (exported_names) {
             expect_token("name", "from");

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2277,6 +2277,7 @@ function parse($TEXT, options) {
         }
         return names;
     }
+
     function export_() {
         var start = S.token;
         var is_default;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2176,17 +2176,7 @@ function parse($TEXT, options) {
             next();
         }
 
-        if (is("punc", "{")) {
-            next();
-            imported_names = [];
-            while (!is("punc", "}")) {
-                imported_names.push(import_name());
-                if (is("punc", ",")) {
-                    next();
-                }
-            }
-            next();
-        }
+        imported_names = import_names();
 
         if (imported_names || imported_name) {
             expect_token("name", "from");
@@ -2266,6 +2256,24 @@ function parse($TEXT, options) {
         })
     }
 
+    function import_names() {
+        var names;
+        if (is("punc", "{")) {
+            next();
+            names = [];
+            while (!is("punc", "}")) {
+                names.push(import_name());
+                if (is("punc", ",")) {
+                    next();
+                }
+            }
+            next();
+        } else if (is("operator", "*")) {
+            var st = prev();
+            names = [import_nameAsterisk()];
+        }
+        return names;
+    }
     function export_() {
         var start = S.token;
         var is_default;
@@ -2278,20 +2286,7 @@ function parse($TEXT, options) {
             next();
         }
 
-        if (is("punc", "{")) {
-            next();
-            exported_names = [];
-            while (!is("punc", "}")) {
-                exported_names.push(import_name());
-                if (is("punc", ",")) {
-                    next();
-                }
-            }
-            next();
-        } else if (is("operator", "*")) {
-            var st = prev();
-            exported_names = [import_nameAsterisk()];
-        }
+        exported_names = import_names();
 
         if (exported_names) {
             expect_token("name", "from");

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -183,9 +183,16 @@ import_statement: {
         import { Bar, Baz } from 'lel';
         import Bar, { Foo } from 'lel';
         import { Bar as kex, Baz as food } from 'lel';
-        import * from 'lel';
     }
-    expect_exact: 'import"mod-name";import Foo from"bar";import{Bar,Baz}from"lel";import Bar,{Foo}from"lel";import{Bar as kex,Baz as food}from"lel";import*from"lel";'
+    expect_exact: 'import"mod-name";import Foo from"bar";import{Bar,Baz}from"lel";import Bar,{Foo}from"lel";import{Bar as kex,Baz as food}from"lel";'
+}
+
+import_all_statement: {
+    input: {
+    import * from 'lel';
+    import * as Lel from 'lel';
+    }
+    expect_exact: 'import*from"lel";import*as Lel from"lel";'
 }
 
 export_statement: {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -183,8 +183,9 @@ import_statement: {
         import { Bar, Baz } from 'lel';
         import Bar, { Foo } from 'lel';
         import { Bar as kex, Baz as food } from 'lel';
+        import * from 'lel';
     }
-    expect_exact: "import\"mod-name\";import Foo from\"bar\";import{Bar,Baz}from\"lel\";import Bar,{Foo}from\"lel\";import{Bar as kex,Baz as food}from\"lel\";"
+    expect_exact: "import\"mod-name\";import Foo from\"bar\";import{Bar,Baz}from\"lel\";import Bar,{Foo}from\"lel\";import{Bar as kex,Baz as food}from\"lel\";import*from\"lel\";"
 }
 
 export_statement: {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -189,8 +189,8 @@ import_statement: {
 
 import_all_statement: {
     input: {
-    import * from 'lel';
-    import * as Lel from 'lel';
+        import * from 'lel';
+        import * as Lel from 'lel';
     }
     expect_exact: 'import*from"lel";import*as Lel from"lel";'
 }

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -185,7 +185,7 @@ import_statement: {
         import { Bar as kex, Baz as food } from 'lel';
         import * from 'lel';
     }
-    expect_exact: "import\"mod-name\";import Foo from\"bar\";import{Bar,Baz}from\"lel\";import Bar,{Foo}from\"lel\";import{Bar as kex,Baz as food}from\"lel\";import*from\"lel\";"
+    expect_exact: 'import"mod-name";import Foo from"bar";import{Bar,Baz}from"lel";import Bar,{Foo}from"lel";import{Bar as kex,Baz as food}from"lel";import*from"lel";'
 }
 
 export_statement: {


### PR DESCRIPTION
Import also exists in a "import all" varient, written as `import * from 'a.js'`