### PR TITLE
upgrade fuzzer

### DIFF
--- a/test/ufuzz.json
+++ b/test/ufuzz.json
@@ -1,0 +1,34 @@
+[
+    {
+        "compress": {
+            "warnings": false
+        }
+    },
+    {
+        "compress": {
+            "warnings": false
+        },
+        "mangle": false
+    },
+    {
+        "compress": false,
+        "mangle": true
+    },
+    {
+        "compress": false,
+        "mangle": false,
+        "output": {
+            "beautify": true,
+            "bracketize": true
+        }
+    },
+    {
+        "compress": {
+            "keep_fargs": false,
+            "passes": 3,
+            "pure_getters": true,
+            "unsafe": true,
+            "warnings": false
+        }
+    }
+]


### PR DESCRIPTION
- configurable set of `minify()` options
- test and report suspects upon failure
- continue after failure if infinite iterations is specified

Inject the following:
```js
    original_code = "+function(){};console.log(function(){})";
```
Then run `node test/ufuzz.js 1` gives:
```sh
$ node test/ufuzz.js 1
0 of 1





!!!!!!!!!!



//=============================================================
// !!!!!! Failed... round 0
// original code
// (beautified)
+function() {};

console.log(function() {});


//-------------------------------------------------------------
// uglified code
// (beautified)
console.log(function() {});


original result:
[Function: __func_1__]

uglified result:
[Function: __func_0__]

minify(options):
{ compress: { warnings: false }, fromString: true }

Suspicious compress options:
  side_effects

!!!!!! Failed... round 0
```
