### PR TITLE
speed up fuzzer code generation

### DIFF
--- a/test/ufuzz.js
+++ b/test/ufuzz.js
@@ -288,7 +288,7 @@ var loops = 0;
 var funcs = 0;
 
 function rng(max) {
-    var r = randomBytes(2).readUInt16LE(0) / 0xFFFF;
+    var r = randomBytes(2).readUInt16LE(0) / 65536;
     return Math.floor(max * r);
 }
 
@@ -563,7 +563,7 @@ function _createSimpleBinaryExpr(recurmax, noComma) {
     // intentionally generate more hardcore ops
     if (--recurmax < 0) return createValue();
     var r = rng(30);
-    if (r === 0) return '(c = c + 1, ' + _createSimpleBinaryExpr(recurmax, noComma) + ')'
+    if (r === 0) return '(c = c + 1, ' + _createSimpleBinaryExpr(recurmax, noComma) + ')';
     var s = _createSimpleBinaryExpr(recurmax, noComma) + createBinaryOp(noComma) + _createSimpleBinaryExpr(recurmax, noComma);
     if (r === 1) {
         // try to get a generated name reachable from current scope. default to just `a`

--- a/test/ufuzz.js
+++ b/test/ufuzz.js
@@ -514,7 +514,7 @@ function _createExpression(recurmax, noComma, stmtDepth, canThrow) {
         VAR_NAMES.length = nameLenBefore;
         return s;
       case 9:
-        return createTypeofExpr();
+        return createTypeofExpr(recurmax, stmtDepth, canThrow);
       case 10:
         // you could statically infer that this is just `Math`, regardless of the other expression
         // I don't think Uglify does this at this time...
@@ -573,7 +573,7 @@ function _createSimpleBinaryExpr(recurmax, noComma) {
     return s;
 }
 
-function createTypeofExpr() {
+function createTypeofExpr(recurmax, stmtDepth, canThrow) {
     switch (rng(8)) {
       case 0:
         return 'typeof ' + createVarName(MANDATORY, DONT_STORE) + ' === "' + TYPEOF_OUTCOMES[rng(TYPEOF_OUTCOMES.length)] + '"';
@@ -585,10 +585,8 @@ function createTypeofExpr() {
         return 'typeof ' + createVarName(MANDATORY, DONT_STORE) + ' != "' + TYPEOF_OUTCOMES[rng(TYPEOF_OUTCOMES.length)] + '"';
       case 4:
         return 'typeof ' + createVarName(MANDATORY, DONT_STORE);
-      case 5:
-      case 6:
-      case 7:
-        return '(typeof ' + createExpression(3, COMMA_OK, 2, true) + ')';
+      default:
+        return '(typeof ' + createExpression(recurmax, COMMA_OK, stmtDepth, canThrow) + ')';
     }
 }
 


### PR DESCRIPTION
- only output one top-level function or statement block
- reduce `rng()` granularity from 2^32 to 65536