### PR TITLE
fix mangleProperties of `undefined` & `Infinity`

### DIFF
--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -44,7 +44,11 @@
 "use strict";
 
 function find_builtins() {
-    var a = [];
+    // NaN will be included due to Number.NaN
+    var a = [
+        "Infinity",
+        "undefined",
+    ];
     [ Object, Array, Function, Number,
       String, Boolean, Error, Math,
       Date, RegExp

--- a/test/compress/issue-1770.js
+++ b/test/compress/issue-1770.js
@@ -1,0 +1,48 @@
+mangle_props: {
+    mangle_props = {}
+    input: {
+        var obj = {
+            undefined: 1,
+            NaN: 2,
+            Infinity: 3,
+            "-Infinity": 4,
+        };
+        console.log(
+            obj[void 0],
+            obj[undefined],
+            obj["undefined"],
+            obj[0/0],
+            obj[NaN],
+            obj["NaN"],
+            obj[1/0],
+            obj[Infinity],
+            obj["Infinity"],
+            obj[-1/0],
+            obj[-Infinity],
+            obj["-Infinity"]
+        );
+    }
+    expect: {
+        var obj = {
+            undefined: 1,
+            NaN: 2,
+            Infinity: 3,
+            "-Infinity": 4,
+        };
+        console.log(
+            obj[void 0],
+            obj[void 0],
+            obj["undefined"],
+            obj[0/0],
+            obj[NaN],
+            obj["NaN"],
+            obj[1/0],
+            obj[1/0],
+            obj["Infinity"],
+            obj[-1/0],
+            obj[-1/0],
+            obj["-Infinity"]
+        );
+    }
+    expect_stdout: true
+}


### PR DESCRIPTION
`NaN` already works by the happy accident of `Number.NaN`

fixes #1770

@kzc I added those terms to the `reserved` list and a comment to explain the `NaN` magic.