### PR TITLE
[ES6] Allow empty destructuring as function parameter

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -448,8 +448,6 @@ var AST_ArrowParametersOrSeq = DEFNODE("ArrowParametersOrSeq", "expressions", {
             } else if (ex instanceof AST_Hole) {
                 return ex;
             } else if (ex instanceof AST_Destructuring) {
-                if (ex.names.length == 0)
-                    croak("Invalid destructuring function parameter", ex.start.line, ex.start.col);
                 ex.names = ex.names.map(to_fun_args);
                 return insert_default(ex, default_seen_above);
             } else if (ex instanceof AST_SymbolRef) {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -314,11 +314,13 @@ default_assign: {
         function f(a, b = 3) {
             console.log(a);
         }
+        g = ([[] = 123]) => {};
     }
     expect: {
         function f(a) {
             console.log(a);
         }
+        g = ([[] = 123]) => {};
     }
 }
 


### PR DESCRIPTION
This should fix some failing test262 tests like https://github.com/tc39/test262/blob/master/test/language/expressions/arrow-function/dstr-ary-ptrn-elem-ary-empty-init.js.

There is no reason to have this restriction even though the use case would be weird on it's own.