### PR TITLE
remove `--mangle-props` from fuzzing

### DIFF
--- a/test/ufuzz.json
+++ b/test/ufuzz.json
@@ -17,12 +17,6 @@
         "compress": {
             "warnings": false
         },
-        "mangleProperties": {}
-    },
-    {
-        "compress": {
-            "warnings": false
-        },
         "mangle": false
     },
     {
@@ -35,23 +29,6 @@
         "output": {
             "beautify": true,
             "bracketize": true
-        }
-    },
-    {
-        "compress": {
-            "passes": 3,
-            "properties": false,
-            "toplevel": true,
-            "warnings": false
-        },
-        "mangle": {
-            "toplevel": true
-        },
-        "mangleProperties": {
-            "ignore_quoted": true
-        },
-        "output": {
-            "keep_quoted_props": true
         }
     },
     {


### PR DESCRIPTION
Employ `--mangle-props-debug` then filter the mangled property names in `console.log()`.

fixes #1774

@kzc if you prefer your solution from https://github.com/mishoo/UglifyJS2/issues/1774#issuecomment-291181678, please hoiler.