### PR TITLE
Allow AST_DefaultAssign as parameter

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -468,6 +468,9 @@ var AST_ArrowParametersOrSeq = DEFNODE("ArrowParametersOrSeq", "expressions", {
                 }), default_seen_above);
             } else if (ex instanceof AST_Assign) {
                 return insert_default(to_fun_args(ex.left, undefined, undefined, ex.right), default_seen_above);
+            } else if (ex instanceof AST_DefaultAssign) {
+                ex.left = to_fun_args(ex.left, 0, [ex.left]);
+                return ex;
             } else {
                 croak("Invalid function parameter", ex.start.line, ex.start.col);
             }

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -314,13 +314,25 @@ default_assign: {
         function f(a, b = 3) {
             console.log(a);
         }
+
         g = ([[] = 123]) => {};
+        h = ([[x, y, z] = [4, 5, 6]] = []) => {};
+
+        function i([[x, y, z] = [4, 5, 6]] = []) {
+            console.log(b);
+        };
     }
     expect: {
         function f(a) {
             console.log(a);
         }
+
         g = ([[] = 123]) => {};
+        h = ([[x, y, z] = [4, 5, 6]] = []) => {};
+
+        function i([[x, y, z] = [4, 5, 6]] = []) {
+            console.log(b);
+        };
     }
 }
 


### PR DESCRIPTION
This may be the case for parsing arrow functions, as left side expressions are converted to destructuring patterns before being converted to parameters.