### PR TITLE
fix `reduce_vars` on catch variable

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -251,7 +251,6 @@ merge(Compressor.prototype, {
     AST_Node.DEFMETHOD("reset_opt_flags", function(compressor, rescan){
         var reduce_vars = rescan && compressor.option("reduce_vars");
         var toplevel = compressor.option("toplevel");
-        var ie8 = !compressor.option("screw_ie8");
         var safe_ids = [];
         push();
         var suppressor = new TreeWalker(function(node) {
@@ -277,7 +276,7 @@ merge(Compressor.prototype, {
                         d.fixed = false;
                     }
                 }
-                if (ie8 && node instanceof AST_SymbolCatch) {
+                if (node instanceof AST_SymbolCatch) {
                     node.definition().fixed = false;
                 }
                 if (node instanceof AST_VarDef) {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -251,8 +251,7 @@ merge(Compressor.prototype, {
     AST_Node.DEFMETHOD("reset_opt_flags", function(compressor, rescan){
         var reduce_vars = rescan && compressor.option("reduce_vars");
         var toplevel = compressor.option("toplevel");
-        var safe_ids = [];
-        push();
+        var safe_ids = Object.create(null);
         var suppressor = new TreeWalker(function(node) {
             if (node instanceof AST_Symbol) {
                 var d = node.definition();
@@ -286,11 +285,12 @@ merge(Compressor.prototype, {
                             d.fixed = function() {
                                 return node.value;
                             };
+                            mark(d, false);
                             descend();
                         } else {
                             d.fixed = null;
                         }
-                        mark_as_safe(d);
+                        mark(d, true);
                         return true;
                     } else if (node.value) {
                         d.fixed = false;
@@ -302,11 +302,10 @@ merge(Compressor.prototype, {
                         d.fixed = false;
                     } else {
                         d.fixed = node;
-                        mark_as_safe(d);
+                        mark(d, true);
                     }
                     var save_ids = safe_ids;
-                    safe_ids = [];
-                    push();
+                    safe_ids = Object.create(null);
                     descend();
                     safe_ids = save_ids;
                     return true;
@@ -324,7 +323,7 @@ merge(Compressor.prototype, {
                         d.fixed = function() {
                             return iife.args[i] || make_node(AST_Undefined, iife);
                         };
-                        mark_as_safe(d);
+                        mark(d, true);
                     });
                 }
                 if (node instanceof AST_If || node instanceof AST_DWLoop) {
@@ -372,29 +371,27 @@ merge(Compressor.prototype, {
         });
         this.walk(tw);
 
-        function mark_as_safe(def) {
-            safe_ids[safe_ids.length - 1][def.id] = true;
+        function mark(def, safe) {
+            safe_ids[def.id] = safe;
         }
 
         function is_safe(def) {
-            for (var i = safe_ids.length, id = def.id; --i >= 0;) {
-                if (safe_ids[i][id]) {
-                    if (def.fixed == null) {
-                        var orig = def.orig[0];
-                        if (orig instanceof AST_SymbolFunarg || orig.name == "arguments") return false;
-                        def.fixed = make_node(AST_Undefined, orig);
-                    }
-                    return true;
+            if (safe_ids[def.id]) {
+                if (def.fixed == null) {
+                    var orig = def.orig[0];
+                    if (orig instanceof AST_SymbolFunarg || orig.name == "arguments") return false;
+                    def.fixed = make_node(AST_Undefined, orig);
                 }
+                return true;
             }
         }
 
         function push() {
-            safe_ids.push(Object.create(null));
+            safe_ids = Object.create(safe_ids);
         }
 
         function pop() {
-            safe_ids.pop();
+            safe_ids = Object.getPrototypeOf(safe_ids);
         }
 
         function reset_def(def) {

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -1938,3 +1938,28 @@ pure_getters: {
     }
     expect_stdout: "undefined"
 }
+
+catch_var: {
+    options = {
+        booleans: true,
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        try {
+            throw {};
+        } catch (e) {
+            var e;
+            console.log(!!e);
+        }
+    }
+    expect: {
+        try {
+            throw {};
+        } catch (e) {
+            var e;
+            console.log(!!e);
+        }
+    }
+    expect_stdout: "true"
+}

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -1917,7 +1917,7 @@ side_effects_assign: {
     expect_stdout: "undefined"
 }
 
-pure_getters: {
+pure_getters_1: {
     options = {
         pure_getters: true,
         reduce_vars: true,
@@ -1937,6 +1937,23 @@ pure_getters: {
         console.log(a);
     }
     expect_stdout: "undefined"
+}
+
+pure_getters_2: {
+    options = {
+        pure_getters: true,
+        reduce_vars: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        var a;
+        var a = a && a.b;
+    }
+    expect: {
+        var a;
+        var a = a && a.b;
+    }
 }
 
 catch_var: {


### PR DESCRIPTION
Improved catch handling in `figure_out_scope()` means special case treatment of IE8 is no longer valid in `reset_opt_flags()`.