### PR TITLE
fix `reduce_vars` within try-block

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -382,7 +382,19 @@ merge(Compressor.prototype, {
                     pop();
                     return true;
                 }
-                if (node instanceof AST_Catch || node instanceof AST_SwitchBranch) {
+                if (node instanceof AST_Try) {
+                    push();
+                    walk_body(node, tw);
+                    pop();
+                    if (node.bcatch) {
+                        push();
+                        node.bcatch.walk(tw);
+                        pop();
+                    }
+                    if (node.bfinally) node.bfinally.walk(tw);
+                    return true;
+                }
+                if (node instanceof AST_SwitchBranch) {
                     push();
                     descend();
                     pop();

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -2187,3 +2187,34 @@ issue_1814_2: {
     }
     expect_stdout: "0 '321'"
 }
+
+try_abort: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        !function() {
+            try {
+                var a = 1;
+                throw "";
+                var b = 2;
+            } catch (e) {
+            }
+            console.log(a, b);
+        }();
+    }
+    expect: {
+        !function() {
+            try {
+                var a = 1;
+                throw "";
+                var b = 2;
+            } catch (e) {
+            }
+            console.log(a, b);
+        }();
+    }
+    expect_stdout: "1 undefined"
+}


### PR DESCRIPTION
Possible partial execution due to exceptions.

Found by `test/ufuzz.js`, so that well still hasn't completed dried out yet. :wink: 

Another backport candidate for `2.x` branch.