### PR TITLE
fix `reduce_vars` on boolean binary expressions

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -340,6 +340,14 @@ merge(Compressor.prototype, {
                         });
                     }
                 }
+                if (node instanceof AST_Binary
+                    && (node.operator == "&&" || node.operator == "||")) {
+                    node.left.walk(tw);
+                    push();
+                    node.right.walk(tw);
+                    pop();
+                    return true;
+                }
                 if (node instanceof AST_If) {
                     node.condition.walk(tw);
                     push();

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -2218,3 +2218,26 @@ try_abort: {
     }
     expect_stdout: "1 undefined"
 }
+
+boolean_binary_assign: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        !function() {
+            var a;
+            void 0 && (a = 1);
+            console.log(a);
+        }();
+    }
+    expect: {
+        !function() {
+            var a;
+            void 0;
+            console.log(a);
+        }();
+    }
+    expect_stdout: "undefined"
+}


### PR DESCRIPTION
Side effects of `&&` and `||` have not mattered until #1814, which takes assignment expressions into account.