### PR TITLE
support safe reassignments in `reduce_vars`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -277,7 +277,7 @@ merge(Compressor.prototype, {
                 }
                 if (node instanceof AST_VarDef) {
                     var d = node.name.definition();
-                    if (safe_to_assign(d, node.value)) {
+                    if (d.fixed === undefined || safe_to_assign(d, node.value)) {
                         if (node.value) {
                             d.fixed = function() {
                                 return node.value;
@@ -297,9 +297,7 @@ merge(Compressor.prototype, {
                     && node.operator == "="
                     && node.left instanceof AST_SymbolRef) {
                     var d = node.left.definition();
-                    if (HOP(safe_ids, d.id)
-                        && safe_to_read(d)
-                        && safe_to_assign(d, node.right)) {
+                    if (safe_to_assign(d, node.right)) {
                         d.references.push(node.left);
                         d.fixed = function() {
                             return node.right;
@@ -325,6 +323,7 @@ merge(Compressor.prototype, {
                     return true;
                 }
                 if (node instanceof AST_Function) {
+                    push();
                     var iife;
                     if (!node.name
                         && (iife = tw.parent()) instanceof AST_Call
@@ -340,7 +339,6 @@ merge(Compressor.prototype, {
                             mark(d, true);
                         });
                     }
-                    push();
                     descend();
                     pop();
                     return true;
@@ -451,7 +449,8 @@ merge(Compressor.prototype, {
         }
 
         function safe_to_assign(def, value) {
-            if (def.fixed === undefined) return true;
+            if (!HOP(safe_ids, def.id)) return false;
+            if (!safe_to_read(def)) return false;
             if (def.fixed === false) return false;
             if (def.fixed != null && (!value || def.references.length > 0)) return false;
             return !def.orig.some(function(sym) {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -267,7 +267,7 @@ merge(Compressor.prototype, {
                 if (node instanceof AST_SymbolRef) {
                     var d = node.definition();
                     d.references.push(node);
-                    if (d.fixed === undefined || !is_safe(d)
+                    if (d.fixed === undefined || !safe_to_read(d)
                         || is_modified(node, 0, is_immutable(node.fixed_value()))) {
                         d.fixed = false;
                     }
@@ -277,7 +277,7 @@ merge(Compressor.prototype, {
                 }
                 if (node instanceof AST_VarDef) {
                     var d = node.name.definition();
-                    if (d.fixed == null) {
+                    if (safe_to_assign(d, node.value)) {
                         if (node.value) {
                             d.fixed = function() {
                                 return node.value;
@@ -297,7 +297,7 @@ merge(Compressor.prototype, {
                     && node.operator == "="
                     && node.left instanceof AST_SymbolRef) {
                     var d = node.left.definition();
-                    if (HOP(safe_ids, d.id) && d.fixed == null) {
+                    if (HOP(safe_ids, d.id) && safe_to_assign(d, node.right)) {
                         d.fixed = function() {
                             return node.right;
                         };
@@ -309,7 +309,7 @@ merge(Compressor.prototype, {
                 }
                 if (node instanceof AST_Defun) {
                     var d = node.name.definition();
-                    if (!toplevel && d.global || is_safe(d)) {
+                    if (!toplevel && d.global || safe_to_read(d)) {
                         d.fixed = false;
                     } else {
                         d.fixed = node;
@@ -385,11 +385,19 @@ merge(Compressor.prototype, {
                 }
                 if (node instanceof AST_For) {
                     if (node.init) node.init.walk(tw);
+                    if (node.condition) {
+                        push();
+                        node.condition.walk(tw);
+                        pop();
+                    }
                     push();
-                    if (node.condition) node.condition.walk(tw);
                     node.body.walk(tw);
-                    if (node.step) node.step.walk(tw);
                     pop();
+                    if (node.step) {
+                        push();
+                        node.step.walk(tw);
+                        pop();
+                    }
                     return true;
                 }
                 if (node instanceof AST_ForIn) {
@@ -426,7 +434,7 @@ merge(Compressor.prototype, {
             safe_ids[def.id] = safe;
         }
 
-        function is_safe(def) {
+        function safe_to_read(def) {
             if (safe_ids[def.id]) {
                 if (def.fixed == null) {
                     var orig = def.orig[0];
@@ -435,6 +443,17 @@ merge(Compressor.prototype, {
                 }
                 return true;
             }
+        }
+
+        function safe_to_assign(def, value) {
+            if (def.fixed === undefined) return true;
+            if (def.fixed === false) return false;
+            if (def.fixed != null && (!value || def.references.length > 0)) return false;
+            return !def.orig.some(function(sym) {
+                return sym instanceof AST_SymbolConst
+                    || sym instanceof AST_SymbolDefun
+                    || sym instanceof AST_SymbolLambda;
+            });
         }
 
         function push() {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -298,6 +298,7 @@ merge(Compressor.prototype, {
                     && node.left instanceof AST_SymbolRef) {
                     var d = node.left.definition();
                     if (HOP(safe_ids, d.id) && safe_to_assign(d, node.right)) {
+                        d.references.push(node.left);
                         d.fixed = function() {
                             return node.right;
                         };
@@ -321,13 +322,11 @@ merge(Compressor.prototype, {
                     safe_ids = save_ids;
                     return true;
                 }
-                var iife;
-                if (node instanceof AST_Function
-                    && (iife = tw.parent()) instanceof AST_Call
-                    && iife.expression === node) {
-                    if (node.name) {
-                        node.name.definition().fixed = node;
-                    } else {
+                if (node instanceof AST_Function) {
+                    var iife;
+                    if (!node.name
+                        && (iife = tw.parent()) instanceof AST_Call
+                        && iife.expression === node) {
                         // Virtually turn IIFE parameters into variable definitions:
                         //   (function(a,b) {...})(c,d) => (function() {var a=c,b=d; ...})()
                         // So existing transformation rules can work on them.
@@ -339,6 +338,10 @@ merge(Compressor.prototype, {
                             mark(d, true);
                         });
                     }
+                    push();
+                    descend();
+                    pop();
+                    return true;
                 }
                 if (node instanceof AST_Binary
                     && (node.operator == "&&" || node.operator == "||")) {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -297,7 +297,9 @@ merge(Compressor.prototype, {
                     && node.operator == "="
                     && node.left instanceof AST_SymbolRef) {
                     var d = node.left.definition();
-                    if (HOP(safe_ids, d.id) && safe_to_assign(d, node.right)) {
+                    if (HOP(safe_ids, d.id)
+                        && safe_to_read(d)
+                        && safe_to_assign(d, node.right)) {
                         d.references.push(node.left);
                         d.fixed = function() {
                             return node.right;

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -1592,3 +1592,25 @@ var_side_effects_3: {
     }
     expect_stdout: true
 }
+
+reduce_vars_assign: {
+    options = {
+        collapse_vars: true,
+        reduce_vars: true,
+    }
+    input: {
+        !function() {
+            var a = 1;
+            a = [].length,
+            console.log(a);
+        }();
+    }
+    expect: {
+        !function() {
+            var a = 1;
+            a = [].length,
+            console.log(a);
+        }();
+    }
+    expect_stdout: "0"
+}

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -2110,6 +2110,27 @@ var_assign_5: {
     expect_stdout: "2 undefined"
 }
 
+var_assign_6: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        !function() {
+            var a = function(){}(a = 1);
+            console.log(a);
+        }();
+    }
+    expect: {
+        !function() {
+            var a = function(){}(a = 1);
+            console.log(a);
+        }();
+    }
+    expect_stdout: "undefined"
+}
+
 immutable: {
     options = {
         evaluate: true,

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -2258,3 +2258,34 @@ cond_assign: {
     }
     expect_stdout: "undefined"
 }
+
+iife_assign: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        !function() {
+            var a = 1, b = 0;
+            !function() {
+                b++;
+                return;
+                a = 2;
+            }();
+            console.log(a);
+        }();
+    }
+    expect: {
+        !function() {
+            var a = 1, b = 0;
+            !function() {
+                b++;
+                return;
+                a = 2;
+            }();
+            console.log(a);
+        }();
+    }
+    expect_stdout: "1"
+}

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -66,7 +66,7 @@ modified: {
         conditionals  : true,
         evaluate      : true,
         reduce_vars   : true,
-        unused        : true
+        unused        : true,
     }
     input: {
         function f0() {
@@ -136,12 +136,11 @@ modified: {
         }
 
         function f2() {
-            var b = 2;
-            b = 3;
-            console.log(1 + b);
-            console.log(b + 3);
+            3;
             console.log(4);
-            console.log(1 + b + 3);
+            console.log(6);
+            console.log(4);
+            console.log(7);
         }
 
         function f3() {
@@ -375,12 +374,11 @@ passes: {
     }
     expect: {
         function f() {
-            var b = 2;
-            b = 3;
-            console.log(1 + b);
-            console.log(b + 3);
+            3;
             console.log(4);
-            console.log(1 + b + 3);
+            console.log(6);
+            console.log(4);
+            console.log(7);
         }
     }
 }
@@ -1828,10 +1826,7 @@ redefine_farg_3: {
         console.log(function(a) {
             var a;
             return typeof a;
-        }([]), "number", function(a) {
-            var a = void 0;
-            return typeof a;
-        }([]));
+        }([]), "number", "undefined");
     }
     expect_stdout: "object number undefined"
 }

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -571,7 +571,7 @@ inner_var_label: {
     }
 }
 
-inner_var_for: {
+inner_var_for_1: {
     options = {
         evaluate: true,
         reduce_vars: true,
@@ -598,6 +598,29 @@ inner_var_for: {
             x(1, b, 3, d, e);
         }
     }
+}
+
+inner_var_for_2: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        !function() {
+            var a = 1;
+            for (var b = 1; --b;) var a = 2;
+            console.log(a);
+        }();
+    }
+    expect: {
+        !function() {
+            a = 1;
+            for (var b = 1; --b;) var a = 2;
+            console.log(a);
+        }();
+    }
+    expect_stdout: "1"
 }
 
 inner_var_for_in_1: {


### PR DESCRIPTION
`var a=1;a=2;x(a)` => `x(2)`

Mostly from either transpiled code or dead code elimination.