### PR TITLE
extend `cascade` into `a.b`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3132,6 +3132,7 @@ merge(Compressor.prototype, {
                             field = "left";
                         }
                     } else if (cdr instanceof AST_Call
+                        || cdr instanceof AST_PropAccess
                         || cdr instanceof AST_Unary && !unary_side_effects(cdr.operator)) {
                         field = "expression";
                     } else {

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -688,3 +688,25 @@ side_effects_cascade_3: {
         }
     }
 }
+
+issue_27: {
+    options = {
+        cascade: true,
+        passes: 2,
+        sequences: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        (function(jQuery) {
+            var $;
+            $ = jQuery;
+            $("body").addClass("foo");
+        })(jQuery);
+    }
+    expect: {
+        (function(jQuery) {
+            jQuery("body").addClass("foo");
+        })(jQuery);
+    }
+}


### PR DESCRIPTION
fixes #27