### PR TITLE
fix `unused` on for-in statements

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1970,7 +1970,7 @@ merge(Compressor.prototype, {
                         }
                         return node;
                     }
-                    if (drop_vars && node instanceof AST_Definitions && !(tt.parent() instanceof AST_ForIn)) {
+                    if (drop_vars && node instanceof AST_Definitions && !(tt.parent() instanceof AST_ForIn && tt.parent().init === node)) {
                         // place uninitialized names at the start
                         var body = [], head = [], tail = [];
                         // for unused names whose initialization has

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -93,3 +93,29 @@ issue_485_crashing_1530: {
         this, void 0;
     }
 }
+
+issue_1841: {
+    options = {
+        keep_fargs: false,
+        pure_getters: "strict",
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        var b = 10;
+        !function(arg) {
+            for (var key in "hi")
+                var n = arg.baz, n = [ b = 42 ];
+        }(--b);
+        console.log(b);
+    }
+    expect: {
+        var b = 10;
+        !function() {
+            for (var key in "hi")
+                b = 42;
+        }(--b);
+        console.log(b);
+    }
+    expect_exact: "42"
+}

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -94,7 +94,7 @@ issue_485_crashing_1530: {
     }
 }
 
-issue_1841: {
+issue_1841_1: {
     options = {
         keep_fargs: false,
         pure_getters: "strict",
@@ -114,6 +114,32 @@ issue_1841: {
         !function() {
             for (var key in "hi")
                 b = 42;
+        }(--b);
+        console.log(b);
+    }
+    expect_exact: "42"
+}
+
+issue_1841_2: {
+    options = {
+        keep_fargs: false,
+        pure_getters: false,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        var b = 10;
+        !function(arg) {
+            for (var key in "hi")
+                var n = arg.baz, n = [ b = 42 ];
+        }(--b);
+        console.log(b);
+    }
+    expect: {
+        var b = 10;
+        !function(arg) {
+            for (var key in "hi")
+                arg.baz, b = 42;
         }(--b);
         console.log(b);
     }


### PR DESCRIPTION
Only need to avoid `var` within the initialisation block.

fixes #1841