### PR TITLE
improve return optimization for constant expressions

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1780,6 +1780,35 @@ merge(Compressor.prototype, {
         node.DEFMETHOD("has_side_effects", func);
     });
 
+    // determine if expression is constant
+    (function(def){
+        function all(list) {
+            for (var i = list.length; --i >= 0;)
+                if (!list[i].is_constant_expression())
+                    return false;
+            return true;
+        }
+        def(AST_Node, return_false);
+        def(AST_Constant, return_true);
+        def(AST_Unary, function(){
+            return this.expression.is_constant_expression();
+        });
+        def(AST_Binary, function(){
+            return this.left.is_constant_expression() && this.right.is_constant_expression();
+        });
+        def(AST_Array, function(){
+            return all(this.elements);
+        });
+        def(AST_Object, function(){
+            return all(this.properties);
+        });
+        def(AST_ObjectProperty, function(){
+            return this.value.is_constant_expression();
+        });
+    })(function(node, func){
+        node.DEFMETHOD("is_constant_expression", func);
+    });
+
     // tell me if a statement aborts
     function aborts(thing) {
         return thing && thing.aborts();
@@ -3004,7 +3033,7 @@ merge(Compressor.prototype, {
         if (exp instanceof AST_Function) {
             if (exp.body[0] instanceof AST_Return) {
                 var value = exp.body[0].value;
-                if (!value || value.is_constant()) {
+                if (!value || value.is_constant_expression()) {
                     var args = self.args.concat(value || make_node(AST_Undefined, self));
                     return make_sequence(self, args).transform(compressor);
                 }

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -145,3 +145,25 @@ issue_1841_2: {
     }
     expect_exact: "42"
 }
+
+function_returning_constant_literal: {
+    options = {
+        reduce_vars: true,
+        unsafe: true,
+        toplevel: true,
+        evaluate: true,
+        cascade: true,
+        unused: true,
+    }
+    input: {
+        function greeter() {
+            return { message: 'Hello there' };
+        }
+        var greeting = greeter();
+        console.log(greeting.message);
+    }
+    expect: {
+        console.log("Hello there");
+    }
+    expect_stdout: "Hello there"
+}

--- a/test/compress/issue-1787.js
+++ b/test/compress/issue-1787.js
@@ -10,10 +10,6 @@ unary_prefix: {
             return x;
         }());
     }
-    expect: {
-        console.log(function() {
-            return -2 / 3;
-        }());
-    }
+    expect_exact: "console.log(-2/3);"
     expect_stdout: true
 }

--- a/test/compress/negate-iife.js
+++ b/test/compress/negate-iife.js
@@ -25,11 +25,9 @@ negate_iife_2: {
         negate_iife: true
     };
     input: {
-        (function(){ return {} })().x = 10; // should not transform this one
-    }
-    expect: {
         (function(){ return {} })().x = 10;
     }
+    expect_exact: "({}).x=10;"
 }
 
 negate_iife_2_side_effects: {
@@ -38,11 +36,9 @@ negate_iife_2_side_effects: {
         side_effects: true,
     }
     input: {
-        (function(){ return {} })().x = 10; // should not transform this one
-    }
-    expect: {
         (function(){ return {} })().x = 10;
     }
+    expect_exact: "({}).x=10;"
 }
 
 negate_iife_3: {


### PR DESCRIPTION
Inspired by: http://www.syntaxsuccess.com/viewarticle/closure-compiler-vs-uglifyjs

With this PR:
```
$ cat greeter.js 
function greeter() {
  return {message: 'Hello there'};
}
var greeting = greeter();
alert(greeting.message);
```
```
$ bin/uglifyjs greeter.js -c toplevel,unsafe -m
alert("Hello there");
```

@alexlamsl Note that there are still some known suboptimal code issues with this PR. But they can be addressed in future PR(s).

Consider:
```
$ echo 'function greeter(){return{12345678: "Hello there"}}var greeting=greeter();console.log(greeting[12345678]);' | bin/uglifyjs -c toplevel,unsafe
console.log("Hello there");
```
versus:
```
$ echo 'function greeter(){return{1: "Hello there"}}var greeting=greeter();console.log(greeting[1]);' | bin/uglifyjs -c toplevel,unsafe,passes=3
var greeting={1:"Hello there"};console.log(greeting[1]);
```
