### PR TITLE
kill `opera`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1097,11 +1097,10 @@ merge(Compressor.prototype, {
             statements.forEach(function(stat){
                 if (prev) {
                     if (stat instanceof AST_For) {
-                        var opera = {};
                         try {
                             prev.body.walk(new TreeWalker(function(node){
                                 if (node instanceof AST_Binary && node.operator == "in")
-                                    throw opera;
+                                    throw cons_seq;
                             }));
                             if (stat.init && !(stat.init instanceof AST_Definitions)) {
                                 stat.init = cons_seq(stat.init);
@@ -1111,7 +1110,7 @@ merge(Compressor.prototype, {
                                 ret.pop();
                             }
                         } catch(ex) {
-                            if (ex !== opera) throw ex;
+                            if (ex !== cons_seq) throw ex;
                         }
                     }
                     else if (stat instanceof AST_If) {


### PR DESCRIPTION
Interferes with auto-completion of `operator` way too often.