### PR TITLE
deprecate low level API

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -89,7 +89,7 @@ if (program.mangleProps) {
         if (typeof program.mangleProps != "object") program.mangleProps = {};
         if (!Array.isArray(program.mangleProps.reserved)) program.mangleProps.reserved = [];
         require("../tools/domprops").forEach(function(name) {
-            UglifyJS.push_uniq(program.mangleProps.reserved, name);
+            UglifyJS._push_uniq(program.mangleProps.reserved, name);
         });
     }
     if (typeof options.mangle != "object") options.mangle = {};
@@ -187,7 +187,7 @@ function run() {
         }
         var result = UglifyJS.minify(files, options);
     } catch (ex) {
-        if (ex instanceof UglifyJS.JS_Parse_Error) {
+        if (ex.name == "SyntaxError") {
             console.error("Parse error at " + ex.filename + ":" + ex.line + "," + ex.col);
             var col = ex.col;
             var lines = files[ex.filename].split(/\r?\n/);

--- a/test/exports.js
+++ b/test/exports.js
@@ -1,0 +1,13 @@
+exports["Compressor"] = Compressor;
+exports["JS_Parse_Error"] = JS_Parse_Error;
+exports["OutputStream"] = OutputStream;
+exports["SourceMap"] = SourceMap;
+exports["TreeWalker"] = TreeWalker;
+exports["base54"] = base54;
+exports["defaults"] = defaults;
+exports["mangle_properties"] = mangle_properties;
+exports["minify"] = minify;
+exports["parse"] = parse;
+exports["string_template"] = string_template;
+exports["tokenizer"] = tokenizer;
+exports["is_identifier"] = is_identifier;

--- a/test/mocha/accessorTokens-1492.js
+++ b/test/mocha/accessorTokens-1492.js
@@ -1,4 +1,4 @@
-var UglifyJS = require('../../');
+var UglifyJS = require("../node");
 var assert = require("assert");
 
 describe("Accessor tokens", function() {

--- a/test/mocha/arguments.js
+++ b/test/mocha/arguments.js
@@ -1,4 +1,4 @@
-var UglifyJS = require('../../');
+var UglifyJS = require("../node");
 var assert = require("assert");
 
 describe("arguments", function() {

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -19,7 +19,7 @@ describe("bin/uglifyjs", function () {
             eval(stdout);
 
             assert.strictEqual(typeof WrappedUglifyJS, 'object');
-            assert.strictEqual(true, WrappedUglifyJS.parse('foo;') instanceof WrappedUglifyJS.AST_Node);
+            assert.strictEqual(WrappedUglifyJS.minify("foo([true,,2+3]);").code, "foo([!0,,5]);");
 
             done();
         });

--- a/test/mocha/comment-filter.js
+++ b/test/mocha/comment-filter.js
@@ -1,4 +1,4 @@
-var UglifyJS = require('../../');
+var UglifyJS = require("../node");
 var assert = require("assert");
 
 describe("comment filters", function() {

--- a/test/mocha/comment.js
+++ b/test/mocha/comment.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var uglify = require("../../");
+var uglify = require("../node");
 
 describe("Comment", function() {
     it("Should recognize eol of single line comments", function() {

--- a/test/mocha/directives.js
+++ b/test/mocha/directives.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var uglify = require("../../");
+var uglify = require("../node");
 
 describe("Directives", function() {
     it ("Should allow tokenizer to store directives state", function() {

--- a/test/mocha/getter-setter.js
+++ b/test/mocha/getter-setter.js
@@ -1,4 +1,4 @@
-var UglifyJS = require('../../');
+var UglifyJS = require("../node");
 var assert = require("assert");
 
 describe("Getters and setters", function() {

--- a/test/mocha/line-endings.js
+++ b/test/mocha/line-endings.js
@@ -1,4 +1,4 @@
-var Uglify = require('../../');
+var Uglify = require("../node");
 var assert = require("assert");
 
 describe("line-endings", function() {

--- a/test/mocha/minify.js
+++ b/test/mocha/minify.js
@@ -183,13 +183,4 @@ describe("minify", function() {
             });
         });
     });
-
-    describe("Compressor", function() {
-        it("should be backward compatible with ast.transform(compressor)", function() {
-            var ast = Uglify.parse("function f(a){for(var i=0;i<a;i++)console.log(i)}");
-            ast.figure_out_scope();
-            ast = ast.transform(Uglify.Compressor());
-            assert.strictEqual(ast.print_to_string(), "function f(a){for(var i=0;i<a;i++)console.log(i)}");
-        });
-    })
 });

--- a/test/mocha/number-literal.js
+++ b/test/mocha/number-literal.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var uglify = require("../../");
+var uglify = require("../node");
 
 describe("Number literals", function () {
     it("Should not allow legacy octal literals in strict mode", function() {

--- a/test/mocha/operator.js
+++ b/test/mocha/operator.js
@@ -1,4 +1,4 @@
-var UglifyJS = require("../../");
+var UglifyJS = require("../node");
 var assert = require("assert");
 
 describe("operator", function() {

--- a/test/mocha/spidermonkey.js
+++ b/test/mocha/spidermonkey.js
@@ -1,6 +1,6 @@
 var assert = require("assert");
 var exec = require("child_process").exec;
-var uglify = require("../../");
+var uglify = require("../node");
 
 describe("spidermonkey export/import sanity test", function() {
     it("should produce a functional build when using --self with spidermonkey", function(done) {
@@ -15,18 +15,7 @@ describe("spidermonkey export/import sanity test", function() {
 
             eval(stdout);
             assert.strictEqual(typeof SpiderUglify, "object");
-
-            var ast = SpiderUglify.parse("foo([true,,2+3]);");
-            assert.strictEqual(true, ast instanceof SpiderUglify.AST_Node);
-
-            ast.figure_out_scope();
-            ast = SpiderUglify.Compressor({}).compress(ast);
-            assert.strictEqual(true, ast instanceof SpiderUglify.AST_Node);
-
-            var stream = SpiderUglify.OutputStream({});
-            ast.print(stream);
-            var code = stream.toString();
-            assert.strictEqual(code, "foo([!0,,5]);");
+            assert.strictEqual(SpiderUglify.minify("foo([true,,2+3]);").code, "foo([!0,,5]);");
 
             done();
         });

--- a/test/mocha/string-literal.js
+++ b/test/mocha/string-literal.js
@@ -1,4 +1,4 @@
-var UglifyJS = require('../../');
+var UglifyJS = require("../node");
 var assert = require("assert");
 
 describe("String literals", function() {

--- a/test/mocha/with.js
+++ b/test/mocha/with.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var uglify = require("../../");
+var uglify = require("../node");
 
 describe("With", function() {
     it("Should throw syntaxError when using with statement in strict mode", function() {

--- a/test/mozilla-ast.js
+++ b/test/mozilla-ast.js
@@ -1,7 +1,7 @@
 // Testing UglifyJS <-> SpiderMonkey AST conversion
 // through generative testing.
 
-var UglifyJS = require(".."),
+var UglifyJS = require("./node"),
     escodegen = require("escodegen"),
     esfuzz = require("esfuzz"),
     estraverse = require("estraverse"),

--- a/test/node.js
+++ b/test/node.js
@@ -1,0 +1,6 @@
+var fs = require("fs");
+
+new Function("MOZ_SourceMap", "exports", require("../tools/node").FILES.map(function(file) {
+    if (/exports\.js$/.test(file)) file = require.resolve("./exports");
+    return fs.readFileSync(file, "utf8");
+}).join("\n\n"))(require("source-map"), exports);

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-var U = require("../tools/node");
+var U = require("./node");
 var path = require("path");
 var fs = require("fs");
 var assert = require("assert");

--- a/test/sourcemaps.js
+++ b/test/sourcemaps.js
@@ -1,4 +1,4 @@
-var UglifyJS = require("..");
+var UglifyJS = require("./node");
 var ok = require("assert");
 
 module.exports = function () {

--- a/test/ufuzz.js
+++ b/test/ufuzz.js
@@ -12,7 +12,7 @@
         stream._handle.setBlocking(true);
 });
 
-var UglifyJS = require("..");
+var UglifyJS = require("./node");
 var randomBytes = require("crypto").randomBytes;
 var sandbox = require("./sandbox");
 

--- a/tools/exports.js
+++ b/tools/exports.js
@@ -1,15 +1,4 @@
-exports["Compressor"] = Compressor;
 exports["Dictionary"] = Dictionary;
-exports["JS_Parse_Error"] = JS_Parse_Error;
-exports["OutputStream"] = OutputStream;
-exports["SourceMap"] = SourceMap;
 exports["TreeWalker"] = TreeWalker;
-exports["base54"] = base54;
-exports["defaults"] = defaults;
-exports["mangle_properties"] = mangle_properties;
 exports["minify"] = minify;
-exports["parse"] = parse;
-exports["push_uniq"] = push_uniq;
-exports["string_template"] = string_template;
-exports["tokenizer"] = tokenizer;
-exports["is_identifier"] = is_identifier;
+exports["_push_uniq"] = push_uniq;

--- a/tools/node.js
+++ b/tools/node.js
@@ -18,15 +18,19 @@ var FILES = UglifyJS.FILES = [
     return require.resolve(file);
 });
 
-new Function("MOZ_SourceMap", "exports", FILES.map(function(file){
-    return fs.readFileSync(file, "utf8");
-}).join("\n\n"))(
+new Function("MOZ_SourceMap", "exports", function() {
+    var code = FILES.map(function(file) {
+        return fs.readFileSync(file, "utf8");
+    });
+    code.push("exports.describe_ast = " + describe_ast.toString());
+    return code.join("\n\n");
+}())(
     require("source-map"),
     UglifyJS
 );
 
-UglifyJS.describe_ast = function() {
-    var out = UglifyJS.OutputStream({ beautify: true });
+function describe_ast() {
+    var out = OutputStream({ beautify: true });
     function doitem(ctor) {
         out.print("AST_" + ctor.TYPE);
         var props = ctor.SELF_PROPS.filter(function(prop){
@@ -56,6 +60,6 @@ UglifyJS.describe_ast = function() {
             });
         }
     };
-    doitem(UglifyJS.AST_Node);
+    doitem(AST_Node);
     return out + "";
-};
+}


### PR DESCRIPTION
fixes #1872

After this PR, the following API remains:
- `AST_*`
- `describe_ast()`
- `Dictionary` (name cache manipulation?)
- `minify()`
- `_push_uniq()` (only `bin/uglifyjs` needs this)
- `TreeWalker`