### PR TITLE
return `Error` from `minify()`

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -172,7 +172,7 @@ function run() {
     UglifyJS.AST_Node.warn_function = function(msg) {
         console.error("WARN:", msg);
     };
-    if (program.stats)  program.stats = Date.now();
+    if (program.stats) program.stats = Date.now();
     try {
         if (program.parse) {
             if (program.parse.acorn) {
@@ -192,8 +192,12 @@ function run() {
                 });
             }
         }
-        var result = UglifyJS.minify(files, options);
     } catch (ex) {
+        fatal("ERROR: " + ex.message);
+    }
+    var result = UglifyJS.minify(files, options);
+    if (result.error) {
+        var ex = result.error;
         if (ex.name == "SyntaxError") {
             console.error("Parse error at " + ex.filename + ":" + ex.line + "," + ex.col);
             var col = ex.col;
@@ -217,8 +221,7 @@ function run() {
             console.error(ex.defs);
         }
         fatal("ERROR: " + ex.message);
-    }
-    if (program.output == "ast") {
+    } else if (program.output == "ast") {
         console.log(JSON.stringify(result.ast, function(key, value) {
             if (skip_key(key)) return;
             if (value instanceof UglifyJS.AST_Token) return;

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -146,6 +146,8 @@ function minify(files, options) {
             result.warnings = warnings;
         }
         return result;
+    } catch (ex) {
+        return { error: ex };
     } finally {
         AST_Node.warn_function = warn_function;
     }

--- a/test/mocha/minify.js
+++ b/test/mocha/minify.js
@@ -114,17 +114,18 @@ describe("minify", function() {
             }
         });
         it("Should fail with multiple input and inline source map", function() {
-            assert.throws(function() {
-                Uglify.minify([
-                    read("./test/input/issue-520/input.js"),
-                    read("./test/input/issue-520/output.js")
-                ], {
-                    sourceMap: {
-                        content: "inline",
-                        url: "inline"
-                    }
-                });
+            var result = Uglify.minify([
+                read("./test/input/issue-520/input.js"),
+                read("./test/input/issue-520/output.js")
+            ], {
+                sourceMap: {
+                    content: "inline",
+                    url: "inline"
+                }
             });
+            var err = result.error;
+            assert.ok(err instanceof Error);
+            assert.strictEqual(err.stack.split(/\n/)[0], "Error: inline source map only works with singular input");
         });
     });
 
@@ -170,17 +171,14 @@ describe("minify", function() {
     });
 
     describe("JS_Parse_Error", function() {
-        it("should throw syntax error", function() {
-            assert.throws(function() {
-                Uglify.minify("function f(a{}");
-            }, function(err) {
-                assert.ok(err instanceof Error);
-                assert.strictEqual(err.stack.split(/\n/)[0], "SyntaxError: Unexpected token punc «{», expected punc «,»");
-                assert.strictEqual(err.filename, "0");
-                assert.strictEqual(err.line, 1);
-                assert.strictEqual(err.col, 12);
-                return true;
-            });
+        it("should return syntax error", function() {
+            var result = Uglify.minify("function f(a{}");
+            var err = result.error;
+            assert.ok(err instanceof Error);
+            assert.strictEqual(err.stack.split(/\n/)[0], "SyntaxError: Unexpected token punc «{», expected punc «,»");
+            assert.strictEqual(err.filename, "0");
+            assert.strictEqual(err.line, 1);
+            assert.strictEqual(err.col, 12);
         });
     });
 });


### PR DESCRIPTION
Have `minify()` return `Error` in `result.error` rather than throwing it.

https://github.com/mishoo/UglifyJS2/pull/1877#discussion_r115150972