### PR TITLE
[ES6] fix `collapse_vars` on destructuring declarations

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -799,7 +799,7 @@ merge(Compressor.prototype, {
             }
 
             function get_lhs(expr) {
-                if (expr instanceof AST_VarDef) {
+                if (expr instanceof AST_VarDef && expr.name instanceof AST_SymbolDeclaration) {
                     var def = expr.name.definition();
                     if (def.orig.length > 1
                         || def.references.length == 1 && (!def.global || compressor.toplevel(def))) {

--- a/test/compress/destructuring.js
+++ b/test/compress/destructuring.js
@@ -315,3 +315,18 @@ unused: {
         console.log(a);
     }
 }
+
+issue_1886: {
+    options = {
+        collapse_vars: true,
+    }
+    input: {
+        let [a] = [1];
+        console.log(a);
+    }
+    expect: {
+        let [a] = [1];
+        console.log(a);
+    }
+    expect_exact: "1"
+}


### PR DESCRIPTION
fixes #1886