### PR TITLE
[ES5] Reference README.md in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "uglify-js",
   "description": "JavaScript parser, mangler/compressor and beautifier toolkit",
+  "readme": "README.md",
   "homepage": "http://lisperator.net/uglifyjs",
   "author": "Mihai Bazon <mihai.bazon@gmail.com> (http://lisperator.net/)",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
Should eliminate the error message with `$ npm install` at:

``` json
  "readme": "ERROR: No README data found!",
```