### PR TITLE
fix #1914: AST_Node.from_mozilla_ast fails on setter

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -122,10 +122,10 @@
               case "init":
                 return new AST_ObjectKeyVal(args);
               case "set":
-                args.value.name = from_moz(key);
+                args.key = from_moz(key);
                 return new AST_ObjectSetter(args);
               case "get":
-                args.value.name = from_moz(key);
+                args.key = from_moz(key);
                 return new AST_ObjectGetter(args);
             }
         },


### PR DESCRIPTION
This patch sets an `AST_ObjectSetter` node's  `value.name` to `null` as well as its `key` to a `AST_Token` node.