### PR TITLE
fix invalid transform on `const`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -525,6 +525,14 @@ merge(Compressor.prototype, {
         return lhs instanceof AST_SymbolRef && lhs.definition().orig[0] instanceof AST_SymbolLambda;
     }
 
+    function is_reference_const(ref) {
+        if (!(ref instanceof AST_SymbolRef)) return false;
+        var orig = ref.definition().orig;
+        for (var i = orig.length; --i >= 0;) {
+            if (orig[i] instanceof AST_SymbolConst) return true;
+        }
+    }
+
     function find_variable(compressor, name) {
         var scope, i = 0;
         while (scope = compressor.parent(i++)) {
@@ -790,7 +798,8 @@ merge(Compressor.prototype, {
                         return make_node(AST_SymbolRef, expr.name, expr.name);
                     }
                 } else {
-                    return expr[expr instanceof AST_Assign ? "left" : "expression"];
+                    var lhs = expr[expr instanceof AST_Assign ? "left" : "expression"];
+                    return !is_reference_const(lhs) && lhs;
                 }
             }
 
@@ -1973,6 +1982,7 @@ merge(Compressor.prototype, {
                     && node instanceof AST_Assign
                     && node.operator == "="
                     && node.left instanceof AST_SymbolRef
+                    && !is_reference_const(node.left)
                     && scope === self) {
                     node.right.walk(tw);
                     return true;
@@ -3178,7 +3188,7 @@ merge(Compressor.prototype, {
                     && (left.operator == "++" || left.operator == "--")) {
                     left = left.expression;
                 } else left = null;
-                if (!left || is_lhs_read_only(left)) {
+                if (!left || is_lhs_read_only(left) || is_reference_const(left)) {
                     expressions[++i] = cdr;
                     continue;
                 }

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -2186,3 +2186,49 @@ compound_assignment: {
     }
     expect_stdout: "4"
 }
+
+reassign_const_1: {
+    options = {
+        collapse_vars: true,
+    }
+    input: {
+        function f() {
+            const a = 1;
+            a = 2;
+            return a;
+        }
+        console.log(f());
+    }
+    expect: {
+        function f() {
+            const a = 1;
+            a = 2;
+            return a;
+        }
+        console.log(f());
+    }
+    expect_stdout: true
+}
+
+reassign_const_2: {
+    options = {
+        collapse_vars: true,
+    }
+    input: {
+        function f() {
+            const a = 1;
+            ++a;
+            return a;
+        }
+        console.log(f());
+    }
+    expect: {
+        function f() {
+            const a = 1;
+            ++a;
+            return a;
+        }
+        console.log(f());
+    }
+    expect_stdout: true
+}

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -1147,3 +1147,28 @@ var_catch_toplevel: {
         }();
     }
 }
+
+reassign_const: {
+    options = {
+        cascade: true,
+        sequences: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        function f() {
+            const a = 1;
+            a = 2;
+            return a;
+        }
+        console.log(f());
+    }
+    expect: {
+        function f() {
+            const a = 1;
+            return a = 2, a;
+        }
+        console.log(f());
+    }
+    expect_stdout: true
+}

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -710,3 +710,27 @@ issue_27: {
         })(jQuery);
     }
 }
+
+reassign_const: {
+    options = {
+        cascade: true,
+        sequences: true,
+        side_effects: true,
+    }
+    input: {
+        function f() {
+            const a = 1;
+            a++;
+            return a;
+        }
+        console.log(f());
+    }
+    expect: {
+        function f() {
+            const a = 1;
+            return a++, a;
+        }
+        console.log(f());
+    }
+    expect_stdout: true
+}


### PR DESCRIPTION
- preserve (re)assignment to `const` for runtime error
- suppress `cascade` on `const`, as runtime behaviour is ill-defined

https://github.com/mishoo/UglifyJS2/issues/1500#issuecomment-300870165

Backport candidate for `v2.x`