### PR TITLE
[ES6] Make sure globals can be accessed from the browser

### DIFF
--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -48,9 +48,10 @@ function find_builtins(reserved) {
     // Compatibility fix for some standard defined globals not defined on every js environment
     var new_globals = ["Symbol", "Map", "Promise", "Proxy", "Reflect", "Set", "WeakMap", "WeakSet"];
     var objects = {};
+    var global_ref = typeof global === "object" ? global : self;
 
     new_globals.forEach(function (new_global) {
-        objects[new_global] = global[new_global] || new Function();
+        objects[new_global] = global_ref[new_global] || new Function();
     });
 
     // NaN will be included due to Number.NaN


### PR DESCRIPTION
Note: no tests as there are no integration tests

Explanation: the harmony specific globals are tested if they are available in the global scope. But the global scope is differently represented in nodejs than the browser, which use respectively `global` and `window`. The included patch should make sure that the globals can be read from both platforms without issues. 