### PR TITLE
avoid `arguments` and `eval` in `reduce_vars`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -354,10 +354,14 @@ merge(Compressor.prototype, {
                         // So existing transformation rules can work on them.
                         node.argnames.forEach(function(arg, i) {
                             var d = arg.definition();
-                            d.fixed = function() {
-                                return iife.args[i] || make_node(AST_Undefined, iife);
-                            };
-                            mark(d, true);
+                            if (!node.uses_arguments && d.fixed === undefined) {
+                                d.fixed = function() {
+                                    return iife.args[i] || make_node(AST_Undefined, iife);
+                                };
+                                mark(d, true);
+                            } else {
+                                d.fixed = false;
+                            }
                         });
                     }
                     descend();
@@ -491,7 +495,9 @@ merge(Compressor.prototype, {
 
         function reset_def(def) {
             def.escaped = false;
-            if (!def.global || def.orig[0] instanceof AST_SymbolConst || compressor.toplevel(def)) {
+            if (def.scope.uses_eval) {
+                def.fixed = false;
+            } else if (!def.global || def.orig[0] instanceof AST_SymbolConst || compressor.toplevel(def)) {
                 def.fixed = undefined;
             } else {
                 def.fixed = false;

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -41,20 +41,20 @@ reduce_vars: {
         var A = 1;
         (function() {
             console.log(-3);
-            console.log(-4);
+            console.log(A - 5);
         })();
         (function f1() {
             var a = 2;
-            console.log(-3);
+            console.log(a - 5);
             eval("console.log(a);");
         })();
         (function f2(eval) {
             var a = 2;
-            console.log(-3);
+            console.log(a - 5);
             eval("console.log(a);");
         })(eval);
         "yes";
-        console.log(2);
+        console.log(A + 1);
     }
     expect_stdout: true
 }
@@ -1749,7 +1749,10 @@ redefine_arguments_3: {
         console.log(function() {
             var arguments;
             return typeof arguments;
-        }(), "number", "undefined");
+        }(), "number", function(x) {
+            var arguments = x;
+            return typeof arguments;
+        }());
     }
     expect_stdout: "object number undefined"
 }
@@ -2460,4 +2463,48 @@ issue_1865: {
         }());
     }
     expect_stdout: true
+}
+
+issue_1922_1: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        console.log(function(a) {
+            arguments[0] = 2;
+            return a;
+        }(1));
+    }
+    expect: {
+        console.log(function(a) {
+            arguments[0] = 2;
+            return a;
+        }(1));
+    }
+    expect_stdout: "2"
+}
+
+issue_1922_2: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        console.log(function() {
+            var a;
+            eval("a = 1");
+            return a;
+        }(1));
+    }
+    expect: {
+        console.log(function() {
+            var a;
+            eval("a = 1");
+            return a;
+        }(1));
+    }
+    expect_stdout: "1"
 }


### PR DESCRIPTION
fixes #1922

Backport candidate for `v2.x`

(TODO: minimise false positives of `AST_Scope.uses_arguments` and `AST_Scope.uses_eval`)