### PR TITLE
[ES6] fix `export default expression;`

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2302,39 +2302,39 @@ function parse($TEXT, options) {
         if (is("keyword", "default")) {
             is_default = true;
             next();
-        }
+        } else {
+            exported_names = import_names(false);
 
-        exported_names = import_names(false);
+            if (exported_names) {
+                if (is("name", "from")) {
+                    next();
 
-        if (exported_names) {
-            if (is("name", "from")) {
-                next();
+                    var mod_str = S.token;
+                    if (mod_str.type !== 'string') {
+                        unexpected();
+                    }
+                    next();
 
-                var mod_str = S.token;
-                if (mod_str.type !== 'string') {
-                    unexpected();
+                    return new AST_Export({
+                        start: start,
+                        is_default: is_default,
+                        exported_names: exported_names,
+                        module_name: new AST_String({
+                            start: mod_str,
+                            value: mod_str.value,
+                            quote: mod_str.quote,
+                            end: mod_str,
+                        }),
+                        end: prev(),
+                    });
+                } else {
+                    return new AST_Export({
+                        start: start,
+                        is_default: is_default,
+                        exported_names: exported_names,
+                        end: prev(),
+                    });
                 }
-                next();
-
-                return new AST_Export({
-                    start: start,
-                    is_default: is_default,
-                    exported_names: exported_names,
-                    module_name: new AST_String({
-                        start: mod_str,
-                        value: mod_str.value,
-                        quote: mod_str.quote,
-                        end: mod_str,
-                    }),
-                    end: prev(),
-                });
-            } else {
-                return new AST_Export({
-                    start: start,
-                    is_default: is_default,
-                    exported_names: exported_names,
-                    end: prev(),
-                });
             }
         }
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -239,6 +239,10 @@ TreeTransformer.prototype = new TreeWalker;
         self.expression = self.expression.transform(tw);
     });
 
+    _(AST_Export, function(self, tw){
+        if (self.exported_value) self.exported_value = self.exported_value.transform(tw);
+    });
+
     _(AST_TemplateString, function(self, tw) {
         for (var i = 0; i < self.segments.length; i++) {
             if (!(self.segments[i] instanceof AST_TemplateSegment)) {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -203,15 +203,42 @@ import_all_statement: {
 }
 
 export_statement: {
+    options = {
+        evaluate: true,
+    }
     input: {
-        export default 1;
+        export default 1 + 2;
         export var foo = 4;
         export let foo = 6;
         export const foo = 6;
         export function foo() {};
         export class foo { };
     }
-    expect_exact: "export default 1;export var foo=4;export let foo=6;export const foo=6;export function foo(){};export class foo{};"
+    expect_exact: "export default 3;export var foo=4;export let foo=6;export const foo=6;export function foo(){};export class foo{};"
+}
+
+export_default_object_expression: {
+    options = {
+        evaluate: true,
+    }
+    input: {
+        export default {
+            foo: 1 + 2,
+            bar() { return 4; },
+            get baz() { return this.foo; },
+        };
+    }
+    expect_exact: "export default{foo:3,bar(){return 4},get baz(){return this.foo}};"
+}
+
+export_default_array: {
+    options = {
+        evaluate: true,
+    }
+    input: {
+        export default [ 1 + 2, foo ];
+    }
+    expect_exact: "export default[3,foo];"
 }
 
 export_module_statement: {


### PR DESCRIPTION
With this PR can now parse the ES2015 code bases of Rollup, Buble and Butternut.