### PR TITLE
fix parsing of property access after new line

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -285,7 +285,11 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
         S.regex_allowed = ((type == "operator" && !UNARY_POSTFIX(value)) ||
                            (type == "keyword" && KEYWORDS_BEFORE_EXPRESSION(value)) ||
                            (type == "punc" && PUNC_BEFORE_EXPRESSION(value)));
-        prev_was_dot = (type == "punc" && value == ".");
+        if (type == "punc" && value == ".") {
+            prev_was_dot = true;
+        } else if (!is_comment) {
+            prev_was_dot = false;
+        }
         var ret = {
             type    : type,
             value   : value,

--- a/test/compress/issue-1943.js
+++ b/test/compress/issue-1943.js
@@ -1,0 +1,31 @@
+operator: {
+    input: {
+        a. //comment
+        typeof
+    }
+    expect_exact: "a.typeof;"
+}
+
+name: {
+    input: {
+        a. //comment
+        b
+    }
+    expect_exact: "a.b;"
+}
+
+keyword: {
+    input: {
+        a. //comment
+        default
+    }
+    expect_exact: "a.default;"
+}
+
+atom: {
+    input: {
+        a. //comment
+        true
+    }
+    expect_exact: "a.true;"
+}


### PR DESCRIPTION
Account for comments when detecting property access in `tokenizer`.

fixes #1943