### PR TITLE
[WIP][ES6] Function declarations should be block scoped in ES2015

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -202,11 +202,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
             // scope when we encounter the AST_Defun node (which is
             // instanceof AST_Scope) but we get to the symbol a bit
             // later.
-            var parent_lambda = defun.parent_scope;
-            while (parent_lambda.is_block_scope()) {
-                parent_lambda = parent_lambda.parent_scope;
-            }
-            (node.scope = parent_lambda).def_function(node, in_export, in_block);
+            (node.scope = defun.parent_scope).def_function(node, in_export, in_block);
         }
         else if (node instanceof AST_SymbolClass) {
             defun.def_variable(node, in_export, in_block);

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -68,10 +68,9 @@ dead_code_constant_boolean_should_warn_more: {
         side_effects : true,
     };
     input: {
-        while (!((foo && bar) || (x + "0"))) {
+        while (!(foo || (x + "0"))) {
             console.log("unreachable");
             var foo;
-            function bar() {}
         }
         for (var x = 10, y; x && (y || x) && (!typeof x); ++x) {
             asdf();
@@ -81,7 +80,6 @@ dead_code_constant_boolean_should_warn_more: {
     }
     expect: {
         var foo;
-        function bar() {}
         // nothing for the while
         // as for the for, it should keep:
         var x = 10, y;


### PR DESCRIPTION
PR for #1952

The change is straighforward, function declaration is now handled like DefClass, no function scope search is performed.

The only expected change was I had to simplify one test case for dead code elimination which assumed functions are function scoped.

It might be nice to add some test for the case fixed by this, the only test I can think of is parsing AST, peforming `figure_out_scope()` and checking if symbol scopes match expectation.