### PR TITLE
remove `space_colon`

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -70,7 +70,6 @@ function OutputStream(options) {
         semicolons       : true,
         shebang          : true,
         source_map       : null,
-        space_colon      : true,
         unescape_regexps : false,
         width            : 80,
         wrap_iife        : false,
@@ -357,7 +356,7 @@ function OutputStream(options) {
 
     function colon() {
         print(":");
-        if (options.space_colon) space();
+        space();
     };
 
     var add_mapping = options.source_map ? function(token, name) {


### PR DESCRIPTION
Always emit space after colon when `options.output.beautify` is enabled.

https://github.com/mishoo/UglifyJS2/pull/1958#issuecomment-301973283