### PR TITLE
make `expect_stdout` node version specific

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "devDependencies": {
     "acorn": "~5.0.3",
-    "mocha": "~2.3.4"
+    "mocha": "~2.3.4",
+    "semver": "~5.3.0"
   },
   "scripts": {
     "test": "node test/run-tests.js"

--- a/test/compress/node_version.js
+++ b/test/compress/node_version.js
@@ -1,0 +1,12 @@
+eval_let: {
+    input: {
+        eval("let a;");
+        console.log();
+    }
+    expect: {
+        eval("let a;");
+        console.log();
+    }
+    expect_stdout: ""
+    node_version: ">=6"
+}

--- a/test/sandbox.js
+++ b/test/sandbox.js
@@ -1,3 +1,4 @@
+var semver = require("semver");
 var vm = require("vm");
 
 function safe_log(arg, level) {
@@ -63,7 +64,7 @@ exports.run_code = function(code) {
         process.stdout.write = original_write;
     }
 };
-exports.same_stdout = ~process.version.lastIndexOf("v0.12.", 0) ? function(expected, actual) {
+exports.same_stdout = semver.satisfies(process.version, "0.12") ? function(expected, actual) {
     if (typeof expected != typeof actual) return false;
     if (typeof expected != "string") {
         if (expected.name != actual.name) return false;


### PR DESCRIPTION
... via semver string on `node_version` label.

`semver` is the module `npm` uses natively for semver string handling, and it doesn't pull in any additional dependencies.

I have tested locally, but I can think of any immediate use of this feature on `master` so I haven't commited a test case with this PR.

The idea is for this to merge onto `harmony` to address https://github.com/mishoo/UglifyJS2/pull/1953#issuecomment-301820266

/cc @kzc @OndrejSpanel 