### PR TITLE
[ES6] suppress `unused` on block variables

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -545,11 +545,11 @@ merge(Compressor.prototype, {
         return lhs instanceof AST_SymbolRef && lhs.definition().orig[0] instanceof AST_SymbolLambda;
     }
 
-    function is_reference_const(ref) {
+    function is_ref_of(ref, type) {
         if (!(ref instanceof AST_SymbolRef)) return false;
         var orig = ref.definition().orig;
         for (var i = orig.length; --i >= 0;) {
-            if (orig[i] instanceof AST_SymbolConst) return true;
+            if (orig[i] instanceof type) return true;
         }
     }
 
@@ -828,7 +828,7 @@ merge(Compressor.prototype, {
                     }
                 } else {
                     var lhs = expr[expr instanceof AST_Assign ? "left" : "expression"];
-                    return !is_reference_const(lhs) && lhs;
+                    return !is_ref_of(lhs, AST_SymbolConst) && lhs;
                 }
             }
 
@@ -2056,7 +2056,7 @@ merge(Compressor.prototype, {
                     && node instanceof AST_Assign
                     && node.operator == "="
                     && node.left instanceof AST_SymbolRef
-                    && !is_reference_const(node.left)
+                    && !is_ref_of(node.left, AST_SymbolBlockDeclaration)
                     && scope === self) {
                     node.right.walk(tw);
                     return true;
@@ -3160,7 +3160,6 @@ merge(Compressor.prototype, {
                     // Symbol's argument is only used for debugging.
                     self.args = [];
                     return self;
-                    break;
                 }
             }
             else if (exp instanceof AST_Dot && exp.property == "toString" && self.args.length == 0) {
@@ -3343,7 +3342,7 @@ merge(Compressor.prototype, {
                     && (left.operator == "++" || left.operator == "--")) {
                     left = left.expression;
                 } else left = null;
-                if (!left || is_lhs_read_only(left) || is_reference_const(left)) {
+                if (!left || is_lhs_read_only(left) || is_ref_of(left, AST_SymbolConst)) {
                     expressions[++i] = cdr;
                     continue;
                 }

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -1253,3 +1253,30 @@ reassign_const: {
     }
     expect_stdout: true
 }
+
+issue_1968: {
+    options = {
+        unused: true,
+    }
+    input: {
+        function f(c) {
+            var a;
+            if (c) {
+                let b;
+                return (a = 2) + (b = 3);
+            }
+        }
+        console.log(f(1));
+    }
+    expect: {
+        function f(c) {
+            if (c) {
+                let b;
+                return 2 + (b = 3);
+            }
+        }
+        console.log(f(1));
+    }
+    expect_stdout: "5"
+    node_version: ">=6"
+}


### PR DESCRIPTION
fixes #1968