### PR TITLE
fix parsing of `yield` as object key

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2411,7 +2411,8 @@ function parse($TEXT, options) {
                 unexpected(tmp);
             }
           case "name":
-            if (tmp.value === "yield" && S.input.has_directive("use strict") && !is_in_generator()) {
+            if (tmp.value == "yield" && !is_token(peek(), "punc", ":")
+                && S.input.has_directive("use strict") && !is_in_generator()) {
                 token_error(tmp, "Unexpected yield identifier inside strict mode");
             }
           case "string":

--- a/test/compress/yield.js
+++ b/test/compress/yield.js
@@ -190,3 +190,12 @@ yield_sub: {
     }
     expect_exact: 'function*foo(){yield x["foo"];(yield x)["foo"];yield(yield obj.foo())["bar"]()}'
 }
+
+yield_as_ES5_property: {
+    input: {
+        "use strict";
+        console.log({yield: 42}.yield);
+    }
+    expect_exact: '"use strict";console.log({yield:42}.yield);'
+    expect_stdout: "42"
+}

--- a/test/mocha/yield.js
+++ b/test/mocha/yield.js
@@ -65,9 +65,9 @@ describe("Yield", function() {
         );
     });
 
-    it("Should not allow yield to be used as symbol, identifier or property outside generators in strict mode", function() {
+    it("Should not allow yield to be used as symbol, identifier or shorthand property outside generators in strict mode", function() {
         var tests = [
-            // Fail as as_symbol
+            // Fail in as_symbol
             '"use strict"; import yield from "bar";',
             '"use strict"; yield = 123;',
             '"use strict"; yield: "123";',
@@ -79,13 +79,12 @@ describe("Yield", function() {
             '"use strict"; var yield = "foo";',
             '"use strict"; class yield {}',
 
-            // Fail as maybe_assign
+            // Fail in maybe_assign
             '"use strict"; var foo = yield;',
             '"use strict"; var foo = bar = yield',
 
-            // Fail as as_property_name
+            // Fail in as_property_name
             '"use strict"; var foo = {yield};',
-            '"use strict"; var bar = {yield: "foo"};'
         ];
 
         var fail = function(e) {


### PR DESCRIPTION
fixes #1974

@kzc FYI, `expect_stdout` won't be able to test cases that are specific to `"use strict";` due to limitations in `vm` (which I have yet to figure out). Does not affect this PR.