### PR TITLE
fix issues related to `export` & `function`

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2417,11 +2417,16 @@ function parse($TEXT, options) {
             }
         }
 
-        var is_definition = is("keyword", "var") || is("keyword", "let") || is("keyword", "const");
+        var is_definition = is("keyword", "var")
+            || is("keyword", "let")
+            || is("keyword", "const")
+            || is("keyword", "function") && !is_default;
         if (is_definition) {
             exported_definition = statement();
+        } else if (is("keyword", "function")) {
+            exported_value = expr_atom(false);
         } else {
-            exported_value = expression();
+            exported_value = expression(false);
             semicolon();
         }
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -240,6 +240,7 @@ TreeTransformer.prototype = new TreeWalker;
     });
 
     _(AST_Export, function(self, tw){
+        if (self.exported_definition) self.exported_definition = self.exported_definition.transform(tw);
         if (self.exported_value) self.exported_value = self.exported_value.transform(tw);
     });
 

--- a/test/compress/issue-2001.js
+++ b/test/compress/issue-2001.js
@@ -1,0 +1,63 @@
+export_func_1: {
+    options = {
+        unused: true,
+    }
+    input: {
+        export function f(){};
+    }
+    expect_exact: "export function f(){};"
+}
+
+export_func_2: {
+    options = {
+        side_effects: false,
+        unused: true,
+    }
+    input: {
+        export function f(){}(1);
+    }
+    expect_exact: "export function f(){};1;"
+}
+
+export_func_3: {
+    options = {
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        export function f(){}(1);
+    }
+    expect_exact: "export function f(){};"
+}
+
+export_default_func_1: {
+    options = {
+        unused: true,
+    }
+    input: {
+        export default function f(){};
+    }
+    expect_exact: "export default function(){};"
+}
+
+export_default_func_2: {
+    options = {
+        side_effects: false,
+        unused: true,
+    }
+    input: {
+        export default function f(){}(1);
+    }
+    expect_exact: "export default function(){};1;"
+}
+
+export_default_func_3: {
+    options = {
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        export default function f(){}(1);
+    }
+    expect_exact: "export default function(){};"
+}


### PR DESCRIPTION
- `unused` function names
- confusion with function call syntax

fixes #2001

@kzc this addresses the following:
https://github.com/mishoo/UglifyJS2/issues/2001#issuecomment-303914163
https://github.com/mishoo/UglifyJS2/issues/2001#issuecomment-303935169
https://github.com/mishoo/UglifyJS2/issues/2001#issuecomment-303937937
