### PR TITLE
fix `hoist_funs` on block-scoped `function` under "use strict"

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2251,7 +2251,8 @@ merge(Compressor.prototype, {
                             dirs.push(node);
                             return make_node(AST_EmptyStatement, node);
                         }
-                        if (node instanceof AST_Defun && hoist_funs) {
+                        if (node instanceof AST_Defun && hoist_funs
+                            && (tt.parent() === self || !compressor.has_directive("use strict"))) {
                             hoisted.push(node);
                             return make_node(AST_EmptyStatement, node);
                         }

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2251,12 +2251,12 @@ merge(Compressor.prototype, {
                             dirs.push(node);
                             return make_node(AST_EmptyStatement, node);
                         }
-                        if (node instanceof AST_Defun && hoist_funs
+                        if (hoist_funs && node instanceof AST_Defun
                             && (tt.parent() === self || !compressor.has_directive("use strict"))) {
                             hoisted.push(node);
                             return make_node(AST_EmptyStatement, node);
                         }
-                        if (node instanceof AST_Var && hoist_vars) {
+                        if (hoist_vars && node instanceof AST_Var) {
                             node.definitions.forEach(function(def){
                                 vars.set(def.name.name, def);
                                 ++vars_found;

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -167,3 +167,81 @@ function_returning_constant_literal: {
     }
     expect_stdout: "Hello there"
 }
+
+hoist_funs: {
+    options = {
+        hoist_funs: true,
+    }
+    input: {
+        console.log(1, typeof f, typeof g);
+        if (console.log(2, typeof f, typeof g))
+            console.log(3, typeof f, typeof g);
+        else {
+            console.log(4, typeof f, typeof g);
+            function f() {}
+            console.log(5, typeof f, typeof g);
+        }
+        function g() {}
+        console.log(6, typeof f, typeof g);
+    }
+    expect: {
+        function f() {}
+        function g() {}
+        console.log(1, typeof f, typeof g);
+        if (console.log(2, typeof f, typeof g))
+            console.log(3, typeof f, typeof g);
+        else {
+            console.log(4, typeof f, typeof g);
+            console.log(5, typeof f, typeof g);
+        }
+        console.log(6, typeof f, typeof g);
+    }
+    expect_stdout: [
+        "1 'function' 'function'",
+        "2 'function' 'function'",
+        "4 'function' 'function'",
+        "5 'function' 'function'",
+        "6 'function' 'function'",
+    ]
+    node_version: "<=4"
+}
+
+hoist_funs_strict: {
+    options = {
+        hoist_funs: true,
+    }
+    input: {
+        "use strict";
+        console.log(1, typeof f, typeof g);
+        if (console.log(2, typeof f, typeof g))
+            console.log(3, typeof f, typeof g);
+        else {
+            console.log(4, typeof f, typeof g);
+            function f() {}
+            console.log(5, typeof f, typeof g);
+        }
+        function g() {}
+        console.log(6, typeof f, typeof g);
+    }
+    expect: {
+        "use strict";
+        function g() {}
+        console.log(1, typeof f, typeof g);
+        if (console.log(2, typeof f, typeof g))
+            console.log(3, typeof f, typeof g);
+        else {
+            console.log(4, typeof f, typeof g);
+            function f() {}
+            console.log(5, typeof f, typeof g);
+        }
+        console.log(6, typeof f, typeof g);
+    }
+    expect_stdout: [
+        "1 'undefined' 'function'",
+        "2 'undefined' 'function'",
+        "4 'function' 'function'",
+        "5 'function' 'function'",
+        "6 'undefined' 'function'",
+    ]
+    node_version: "=4"
+}


### PR DESCRIPTION
Technically not part of ES5, but commonly used code exists in the wild.

@kzc this should directly address https://github.com/mishoo/UglifyJS2/pull/1953#issuecomment-304013036