### PR TITLE
[ES6] fix compress of IIFE with destructuring args

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -372,14 +372,16 @@ merge(Compressor.prototype, {
                         //   (function(a,b) {...})(c,d) => (function() {var a=c,b=d; ...})()
                         // So existing transformation rules can work on them.
                         node.argnames.forEach(function(arg, i) {
-                            var d = arg.definition();
-                            if (!node.uses_arguments && d.fixed === undefined) {
-                                d.fixed = function() {
-                                    return iife.args[i] || make_node(AST_Undefined, iife);
-                                };
-                                mark(d, true);
-                            } else {
-                                d.fixed = false;
+                            if (arg.definition) {
+                                var d = arg.definition();
+                                if (!node.uses_arguments && d.fixed === undefined) {
+                                    d.fixed = function() {
+                                        return iife.args[i] || make_node(AST_Undefined, iife);
+                                    };
+                                    mark(d, true);
+                                } else {
+                                    d.fixed = false;
+                                }
                             }
                         });
                     }

--- a/test/compress/destructuring.js
+++ b/test/compress/destructuring.js
@@ -543,3 +543,57 @@ mangle_destructuring_decl_array: {
     expect_stdout: "8 7 6 undefined 2 [ 3 ]"
     node_version: ">=6"
 }
+
+anon_func_with_destructuring_args: {
+    options = {
+        evaluate: true,
+        unused: true,
+        toplevel: true,
+    }
+    mangle = {
+        toplevel: true,
+    }
+    beautify = {
+        ecma: 5,
+    }
+    input: {
+        (function({foo = 1 + 0, bar = 2}, [car = 3, far = 4]) {
+            console.log(foo, bar, car, far);
+        })({bar: 5 - 0}, [, 6]);
+    }
+    expect: {
+        (function({foo: foo = 1, bar: bar = 2}, [o = 3, a = 4]){
+            // FIXME: `foo` and `bar` should be mangled
+            console.log(foo, bar, o, a)
+        })({bar: 5}, [, 6]);
+    }
+    expect_stdout: "1 5 3 6"
+    node_version: ">=6"
+}
+
+arrow_func_with_destructuring_args: {
+    options = {
+        evaluate: true,
+        unused: true,
+        toplevel: true,
+    }
+    mangle = {
+        toplevel: true,
+    }
+    beautify = {
+        ecma: 5,
+    }
+    input: {
+        (({foo = 1 + 0, bar = 2}, [car = 3, far = 4]) => {
+            console.log(foo, bar, car, far);
+        })({bar: 5 - 0}, [, 6]);
+    }
+    expect: {
+        (({foo: foo = 1, bar: bar = 2},[o = 3, a = 4]) => {
+            // FIXME: `foo` and `bar` should be mangled
+            console.log(foo, bar, o, a)
+        })({bar: 5}, [, 6]);
+    }
+    expect_stdout: "1 5 3 6"
+    node_version: ">=6"
+}


### PR DESCRIPTION
Fixes:
```
$ bin/uglifyjs -V
uglify-es 3.0.13
```
```
$ echo '(function({x, y = 2}){console.log(x, y)})({x: 3});' | bin/uglifyjs -c
ERROR: arg.definition is not a function
```