### PR TITLE
mangle destructuring function parameters

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -51,7 +51,6 @@ function SymbolDef(scope, index, orig) {
     this.global = false;
     this.export = false;
     this.mangled_name = null;
-    this.object_destructuring_arg = false;
     this.undeclared = false;
     this.index = index;
     this.id = SymbolDef.next_id++;
@@ -65,7 +64,6 @@ SymbolDef.prototype = {
 
         return (this.global && !options.toplevel)
             || this.export
-            || this.object_destructuring_arg
             || this.undeclared
             || (!options.eval && (this.scope.uses_eval || this.scope.uses_with))
             || (options.keep_fnames
@@ -167,9 +165,6 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
         }
         if (node instanceof AST_Symbol) {
             node.scope = scope;
-        }
-        if (node instanceof AST_SymbolFunarg) {
-            node.object_destructuring_arg = !!in_destructuring;
         }
         if (node instanceof AST_Label) {
             node.thedef = node;
@@ -378,7 +373,6 @@ AST_Scope.DEFMETHOD("def_variable", function(symbol){
     if (!this.variables.has(symbol.name)) {
         def = new SymbolDef(this, this.variables.size(), symbol);
         this.variables.set(symbol.name, def);
-        def.object_destructuring_arg = symbol.object_destructuring_arg;
         def.global = !this.parent_scope;
     } else {
         def = this.variables.get(symbol.name);

--- a/test/compress/destructuring.js
+++ b/test/compress/destructuring.js
@@ -562,9 +562,8 @@ anon_func_with_destructuring_args: {
         })({bar: 5 - 0}, [, 6]);
     }
     expect: {
-        (function({foo: foo = 1, bar: bar = 2}, [o = 3, a = 4]){
-            // FIXME: `foo` and `bar` should be mangled
-            console.log(foo, bar, o, a)
+        (function({foo: o = 1, bar: n = 2}, [a = 3, b = 4]) {
+            console.log(o, n, a, b);
         })({bar: 5}, [, 6]);
     }
     expect_stdout: "1 5 3 6"
@@ -589,9 +588,8 @@ arrow_func_with_destructuring_args: {
         })({bar: 5 - 0}, [, 6]);
     }
     expect: {
-        (({foo: foo = 1, bar: bar = 2},[o = 3, a = 4]) => {
-            // FIXME: `foo` and `bar` should be mangled
-            console.log(foo, bar, o, a)
+        (({foo: o = 1, bar: n = 2}, [a = 3, b = 4]) => {
+            console.log(o, n, a, b);
         })({bar: 5}, [, 6]);
     }
     expect_stdout: "1 5 3 6"

--- a/test/compress/issue-203.js
+++ b/test/compress/issue-203.js
@@ -26,9 +26,7 @@ compress_new_function_with_destruct: {
     }
     expect: {
         Function("a", "[b]", "return a");
-        Function("a", "{bb}", "return a");
-        Function("[[a]]", "[{bb}]", 'return a');
+        Function("a", "{bb:b}", "return a");
+        Function("[[a]]", "[{bb:b}]", 'return a');
     }
 }
-
-


### PR DESCRIPTION
fixes #2025

A wise visionary already created the test cases in advance, so all I had to do was updating `expect`s and removing `FIXME`s.