### PR TITLE
[ES6] fix `side_effects` on `AST_Class`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -251,7 +251,7 @@ merge(Compressor.prototype, {
                     })
                 });
             }
-            if (node instanceof AST_Lambda && node !== self) {
+            if (node instanceof AST_Class || node instanceof AST_Lambda && node !== self) {
                 return node;
             }
             if (node instanceof AST_Block) {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -583,3 +583,39 @@ class_extends_regex: {
     }
     expect_exact: "function f(){class rx1 extends(/rx/){}}"
 }
+
+issue_2028: {
+    options = {
+        side_effects: true,
+    }
+    input: {
+        var a = {};
+        (function(x) {
+            x.X = function() {
+                return X;
+            };
+            class X {
+                static hello() {
+                    console.log("hello");
+                }
+            }
+        }(a));
+        a.X().hello();
+    }
+    expect: {
+        var a = {};
+        (function(x) {
+            x.X = function() {
+                return X;
+            };
+            class X {
+                static hello() {
+                    console.log("hello");
+                }
+            }
+        }(a));
+        a.X().hello();
+    }
+    expect_stdout: "hello"
+    node_version: ">=6"
+}


### PR DESCRIPTION
fixes #2028

`AST_Arrow` also have non-standard `body`, but luckily it's a descendant of `AST_Lambda` thus already taken care of by the existing escape condition.