### PR TITLE
[ES6] fix class expression statements

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2610,6 +2610,7 @@ merge(Compressor.prototype, {
         def(AST_Accessor, return_null);
         def(AST_Function, return_null);
         def(AST_Arrow, return_null);
+        def(AST_ClassExpression, return_null);
         def(AST_Binary, function(compressor, first_in_statement){
             var right = this.right.drop_side_effect_free(compressor);
             if (!right) return this.left.drop_side_effect_free(compressor, first_in_statement);

--- a/lib/output.js
+++ b/lib/output.js
@@ -642,6 +642,10 @@ function OutputStream(options) {
         return p instanceof AST_PropAccess && p.expression === this;
     });
 
+    PARENS(AST_ClassExpression, function(output){
+        return output.parent() instanceof AST_SimpleStatement;
+    });
+
     // same goes for an object literal, because otherwise it would be
     // interpreted as a block of code.
     PARENS(AST_Object, function(output){

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -619,3 +619,48 @@ issue_2028: {
     expect_stdout: "hello"
     node_version: ">=6"
 }
+
+class_expression_statement: {
+    options = {
+        toplevel: false,
+        side_effects: false,
+        unused: false,
+    }
+    input: {
+        (class {});
+        (class NamedClassExpr {});
+        let expr = (class AnotherClassExpr {});
+        class C {}
+    }
+    expect_exact: "(class{});(class NamedClassExpr{});let expr=class AnotherClassExpr{};class C{}"
+}
+
+class_expression_statement_unused: {
+    options = {
+        toplevel: false,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        (class {});
+        (class NamedClassExpr {});
+        let expr = (class AnotherClassExpr {});
+        class C {}
+    }
+    expect_exact: "let expr=class{};class C{}"
+}
+
+class_expression_statement_unused_toplevel: {
+    options = {
+        toplevel: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        (class {});
+        (class NamedClassExpr {});
+        let expr = (class AnotherClassExpr {});
+        class C {}
+    }
+    expect_exact: ""
+}


### PR DESCRIPTION
- class expression statements require parentheses
- allow unused class expression statements to be dropped