### PR TITLE
fix `unused` crash with top-level `AST_Var`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2278,7 +2278,9 @@ merge(Compressor.prototype, {
                     }
                     return node;
                 }
-                if (node instanceof AST_Definitions && !(parent instanceof AST_ForIn && parent.init === node)) {
+                if (node instanceof AST_Definitions
+                    && !(parent instanceof AST_ForIn && parent.init === node)
+                    && (drop_vars || !(parent instanceof AST_Toplevel) && !(node instanceof AST_Var))) {
                     // place uninitialized names at the start
                     var body = [], head = [], tail = [];
                     // for unused names whose initialization has

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -1280,3 +1280,17 @@ issue_1968: {
     expect_stdout: "5"
     node_version: ">=6"
 }
+
+issue_2063: {
+    options = {
+        unused: true,
+    }
+    input: {
+        var a;
+        var a;
+    }
+    expect: {
+        var a;
+        var a;
+    }
+}


### PR DESCRIPTION
fixes #2063