### PR TITLE
fix `cascade` on multi-branch evaluations

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3187,17 +3187,16 @@ merge(Compressor.prototype, {
                     if (exp.argnames.length > 0) {
                         fn.body.push(make_node(AST_Var, self, {
                             definitions: exp.argnames.map(function(sym, i) {
-                                var arg = self.args[i];
                                 return make_node(AST_VarDef, sym, {
                                     name: sym,
-                                    value: arg ? arg.clone(true) : make_node(AST_Undefined, self)
+                                    value: self.args[i] || make_node(AST_Undefined, self)
                                 });
                             })
                         }));
                     }
                     if (self.args.length > exp.argnames.length) {
                         fn.body.push(make_node(AST_SimpleStatement, self, {
-                            body: make_sequence(self, self.args.slice(exp.argnames.length)).clone(true)
+                            body: make_sequence(self, self.args.slice(exp.argnames.length))
                         }));
                     }
                     fn.body.push(make_node(AST_Return, self, {
@@ -3316,6 +3315,7 @@ merge(Compressor.prototype, {
                     continue;
                 }
                 var parent = null, field;
+                expressions[j] = cdr = cdr.clone();
                 while (true) {
                     if (cdr.equivalent_to(left)) {
                         var car = expressions[i];
@@ -3352,7 +3352,7 @@ merge(Compressor.prototype, {
                         break;
                     }
                     parent = cdr;
-                    cdr = cdr[field];
+                    cdr = cdr[field] = cdr[field].clone();
                 }
             }
             end = i;

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -710,3 +710,23 @@ issue_27: {
         })(jQuery);
     }
 }
+
+issue_2062: {
+    options = {
+        booleans: true,
+        cascade: true,
+        conditionals: true,
+        side_effects: true,
+    }
+    input: {
+        var a = 1;
+        if ([ a || a++ + a--, a++ + a--, a && a.var ]);
+        console.log(a);
+    }
+    expect: {
+        var a = 1;
+        a || (a++, a--), a++, --a && a.var;
+        console.log(a);
+    }
+    expect_stdout: "1"
+}


### PR DESCRIPTION
Partially reverts #2059 as this has better coverage and performance.

fixes #2062