### PR TITLE
marshal `mangle[.properties].reserved` from non-Array values

### DIFF
--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -78,7 +78,8 @@ function mangle_properties(ast, options) {
         reserved: null,
     });
 
-    var reserved = options.reserved || [];
+    var reserved = options.reserved;
+    if (!Array.isArray(reserved)) reserved = [];
     if (!options.builtins) find_builtins(reserved);
 
     var cache = options.cache;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -377,13 +377,15 @@ AST_Symbol.DEFMETHOD("global", function(){
 });
 
 AST_Toplevel.DEFMETHOD("_default_mangler_options", function(options){
-    return defaults(options, {
+    options = defaults(options, {
         eval        : false,
         ie8         : false,
         keep_fnames : false,
         reserved    : [],
         toplevel    : false,
     });
+    if (!Array.isArray(options.reserved)) options.reserved = [];
+    return options;
 });
 
 AST_Toplevel.DEFMETHOD("mangle_names", function(options){

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -546,4 +546,24 @@ describe("bin/uglifyjs", function () {
             done();
         });
     });
+    it("Should work with --mangle reserved=[]", function (done) {
+        var command = uglifyjscmd + ' test/input/issue-505/input.js -m reserved=[callback]';
+
+        exec(command, function (err, stdout) {
+            if (err) throw err;
+
+            assert.strictEqual(stdout, 'function test(callback){"aaaaaaaaaaaaaaaa";callback(err,data);callback(err,data)}\n');
+            done();
+        });
+    });
+    it("Should work with --mangle reserved=false", function (done) {
+        var command = uglifyjscmd + ' test/input/issue-505/input.js -m reserved=false';
+
+        exec(command, function (err, stdout) {
+            if (err) throw err;
+
+            assert.strictEqual(stdout, 'function test(a){"aaaaaaaaaaaaaaaa";a(err,data);a(err,data)}\n');
+            done();
+        });
+    });
 });


### PR DESCRIPTION
I hit this when running `test/ufuzz.js`, when it attempts to test for `mangle.reserved=false` during failed tests.

But rather than patching `test/ufuzz.js`, I reckon it would be beneficial if `mangle.reserved` and `mangle.properties.reserved` can accept and treat these values as `[]`.