### PR TITLE
allow `expect_stdout` to specify `Error`

### DIFF
--- a/test/compress/node_version.js
+++ b/test/compress/node_version.js
@@ -1,4 +1,4 @@
-eval_let: {
+eval_let_6: {
     input: {
         eval("let a;");
         console.log();
@@ -9,4 +9,30 @@ eval_let: {
     }
     expect_stdout: ""
     node_version: ">=6"
+}
+
+eval_let_4: {
+    input: {
+        eval("let a;");
+        console.log();
+    }
+    expect: {
+        eval("let a;");
+        console.log();
+    }
+    expect_stdout: SyntaxError("Block-scoped declarations (let, const, function, class) not yet supported outside strict mode")
+    node_version: "4"
+}
+
+eval_let_0: {
+    input: {
+        eval("let a;");
+        console.log();
+    }
+    expect: {
+        eval("let a;");
+        console.log();
+    }
+    expect_stdout: SyntaxError("Unexpected identifier")
+    node_version: "<=0.12"
 }


### PR DESCRIPTION
https://github.com/mishoo/UglifyJS2/pull/2081#issuecomment-307672137