### PR TITLE
[ES6][ES8] support shorthand property named "async"

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2012,7 +2012,7 @@ function parse($TEXT, options) {
               case "[":
                 return subscripts(array_(), allow_calls);
               case "{":
-                return subscripts(object_or_object_destructuring_(), allow_calls);
+                return subscripts(object_or_destructuring_(), allow_calls);
             }
             unexpected();
         }
@@ -2109,7 +2109,7 @@ function parse($TEXT, options) {
         return function_(AST_Accessor, is_generator, is_async);
     });
 
-    var object_or_object_destructuring_ = embed_tokens(function() {
+    var object_or_destructuring_ = embed_tokens(function object_or_destructuring_() {
         var start = S.token, first = true, a = [];
         expect("{");
         while (!is("punc", "}")) {
@@ -2231,7 +2231,7 @@ function parse($TEXT, options) {
             property_token = S.token;
             name = as_property_name();
         }
-        if (name === "async" && !is("punc", "(")) {
+        if (name === "async" && !is("punc", "(") && !is("punc", ",") && !is("punc", "}")) {
             is_async = true;
             property_token = S.token;
             name = as_property_name();

--- a/test/compress/async.js
+++ b/test/compress/async.js
@@ -185,6 +185,51 @@ async_identifiers: {
     node_version: ">=8"
 }
 
+async_shorthand_property: {
+    mangle = {
+        toplevel: true,
+    }
+    input: {
+        function print(o) { console.log(o.async + " " + o.await); }
+        var async = "Async", await = "Await";
+
+        print({ async });
+        print({ await });
+        print({ async, await });
+        print({ await, async });
+
+        print({ async: async });
+        print({ await: await });
+        print({ async: async, await: await });
+        print({ await: await, async: async });
+    }
+    expect: {
+        function a(a) { console.log(a.async + " " + a.await); }
+        var n = "Async", c = "Await";
+
+        a({ async: n });
+        a({ await: c });
+        a({ async: n, await: c });
+        a({ await: c, async: n });
+
+        a({ async: n });
+        a({ await: c });
+        a({ async: n, await: c });
+        a({ await: c, async: n });
+    }
+    expect_stdout: [
+        "Async undefined",
+        "undefined Await",
+        "Async Await",
+        "Async Await",
+        "Async undefined",
+        "undefined Await",
+        "Async Await",
+        "Async Await",
+    ]
+    node_version: ">=4"
+}
+
 /* FIXME: add test when supported by parser
 async_arrow: {
     input: {


### PR DESCRIPTION
~~This is where I'd normally write "`Fixes: #NNNN`" but the issue is no longer there.~~

LOL - the bug report was for a different project: https://github.com/rollup/rollup/issues/1447

`uglify-es` happened to have the same issue.