### PR TITLE
fix loss of context in `collapse_vars` & `cascade`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -722,6 +722,7 @@ merge(Compressor.prototype, {
                         // Stop immediately if these node types are encountered
                         var parent = tt.parent();
                         if (node instanceof AST_Assign && node.operator != "=" && lhs.equivalent_to(node.left)
+                            || node instanceof AST_Call && lhs instanceof AST_PropAccess && lhs.equivalent_to(node.expression)
                             || node instanceof AST_Debugger
                             || node instanceof AST_IterationStatement && !(node instanceof AST_For)
                             || node instanceof AST_SymbolRef && node.undeclared()
@@ -3349,6 +3350,7 @@ merge(Compressor.prototype, {
                             field = "left";
                         }
                     } else if (cdr instanceof AST_Call
+                            && !(left instanceof AST_PropAccess && cdr.expression.equivalent_to(left))
                         || cdr instanceof AST_PropAccess
                         || cdr instanceof AST_Unary && !unary_side_effects(cdr.operator)) {
                         field = "expression";

--- a/test/compress/pure_getters.js
+++ b/test/compress/pure_getters.js
@@ -178,3 +178,66 @@ impure_getter_2: {
     }
     expect: {}
 }
+
+issue_2110_1: {
+    options = {
+        cascade: true,
+        pure_getters: "strict",
+        sequences: true,
+        side_effects: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        function f() {
+            function f() {}
+            function g() {
+                return this;
+            }
+            f.g = g;
+            return f.g();
+        }
+        console.log(typeof f());
+    }
+    expect: {
+        function f() {
+            function f() {}
+            return f.g = function() {
+                return this;
+            }, f.g();
+        }
+        console.log(typeof f());
+    }
+    expect_stdout: "function"
+}
+
+issue_2110_2: {
+    options = {
+        collapse_vars: true,
+        pure_getters: "strict",
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        function f() {
+            function f() {}
+            function g() {
+                return this;
+            }
+            f.g = g;
+            return f.g();
+        }
+        console.log(typeof f());
+    }
+    expect: {
+        function f() {
+            function f() {}
+            f.g = function() {
+                return this;
+            };
+            return f.g();
+        }
+        console.log(typeof f());
+    }
+    expect_stdout: "function"
+}


### PR DESCRIPTION
fixes #2110