### PR TITLE
make defensive copies when `inline`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3177,16 +3177,19 @@ merge(Compressor.prototype, {
                     if (exp.argnames.length > 0) {
                         fn.body.push(make_node(AST_Var, self, {
                             definitions: exp.argnames.map(function(sym, i) {
+                                var arg = self.args[i];
                                 return make_node(AST_VarDef, sym, {
                                     name: sym,
-                                    value: self.args[i] || make_node(AST_Undefined, self)
+                                    value: arg ? arg.clone(true) : make_node(AST_Undefined, self)
                                 });
                             })
                         }));
                     }
                     if (self.args.length > exp.argnames.length) {
                         fn.body.push(make_node(AST_SimpleStatement, self, {
-                            body: make_sequence(self, self.args.slice(exp.argnames.length))
+                            body: make_sequence(self, self.args.slice(exp.argnames.length).map(function(node) {
+                                return node.clone(true);
+                            }))
                         }));
                     }
                     fn.body.push(make_node(AST_Return, self, {

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -443,3 +443,70 @@ issue_2107: {
     }
     expect_stdout: "5"
 }
+
+issue_2114_1: {
+    options = {
+        collapse_vars: true,
+        if_return: true,
+        inline: true,
+        keep_fargs: false,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        var c = 0;
+        !function(a) {
+            a = 0;
+        }([ {
+            0: c = c + 1,
+            length: c = 1 + c
+        }, typeof void function a() {
+            var b = function f1(a) {
+            }(b && (b.b += (c = c + 1, 0)));
+        }() ]);
+        console.log(c);
+    }
+    expect: {
+        var c = 0;
+        !function() {
+            0;
+        }((c += 1, c = 1 + c, function() {
+            var b = void (b && (b.b += (c += 1, 0)));
+        }()));
+        console.log(c);
+    }
+    expect_stdout: "2"
+}
+
+issue_2114_2: {
+    options = {
+        collapse_vars: true,
+        if_return: true,
+        inline: true,
+        keep_fargs: false,
+        passes: 2,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        var c = 0;
+        !function(a) {
+            a = 0;
+        }([ {
+            0: c = c + 1,
+            length: c = 1 + c
+        }, typeof void function a() {
+            var b = function f1(a) {
+            }(b && (b.b += (c = c + 1, 0)));
+        }() ]);
+        console.log(c);
+    }
+    expect: {
+        var c = 0;
+        c = 1 + (c += 1), function() {
+            var b = void (b && (b.b += (c += 1, 0)));
+        }();
+        console.log(c);
+    }
+    expect_stdout: "2"
+}


### PR DESCRIPTION
fixes #2114