### PR TITLE
ensure mangling works if catch reuses a scope variable

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -79,7 +79,7 @@ SymbolDef.prototype = {
             if (options.ie8 && sym instanceof AST_SymbolLambda)
                 s = s.parent_scope;
             var def;
-            if (this.defun && (def = this.defun.variables.get(this.name))) {
+            if (def = this.redefined()) {
                 this.mangled_name = def.mangled_name || def.name;
             } else
                 this.mangled_name = s.next_mangled(options, this);
@@ -87,6 +87,9 @@ SymbolDef.prototype = {
                 cache.set(this.name, this.mangled_name);
             }
         }
+    },
+    redefined: function() {
+        return this.defun && this.defun.variables.get(this.name);
     }
 };
 
@@ -205,6 +208,16 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
             node.thedef = sym;
             node.reference(options);
             return true;
+        }
+        // ensure mangling works if catch reuses a scope variable
+        var def;
+        if (node instanceof AST_SymbolCatch && (def = node.definition().redefined())) {
+            var s = node.scope;
+            while (s) {
+                push_uniq(s.enclosed, def);
+                if (s === def.scope) break;
+                s = s.parent_scope;
+            }
         }
     });
     self.walk(tw);

--- a/test/compress/screw-ie8.js
+++ b/test/compress/screw-ie8.js
@@ -255,3 +255,73 @@ issue_1586_2: {
     }
     expect_exact: "function f(){try{x()}catch(c){console.log(c.message)}}"
 }
+
+issue_2120_1: {
+    mangle = {
+        ie8: false,
+    }
+    input: {
+        "aaaaaaaa";
+        var a = 1, b = "FAIL";
+        try {
+            throw 1;
+        } catch (c) {
+            try {
+                throw 0;
+            } catch (a) {
+                if (c) b = "PASS";
+            }
+        }
+        console.log(b);
+    }
+    expect: {
+        "aaaaaaaa";
+        var a = 1, b = "FAIL";
+        try {
+            throw 1;
+        } catch (t) {
+            try {
+                throw 0;
+            } catch (a) {
+                if (t) b = "PASS";
+            }
+        }
+        console.log(b);
+    }
+    expect_stdout: "PASS"
+}
+
+issue_2120_2: {
+    mangle = {
+        ie8: true,
+    }
+    input: {
+        "aaaaaaaa";
+        var a = 1, b = "FAIL";
+        try {
+            throw 1;
+        } catch (c) {
+            try {
+                throw 0;
+            } catch (a) {
+                if (c) b = "PASS";
+            }
+        }
+        console.log(b);
+    }
+    expect: {
+        "aaaaaaaa";
+        var a = 1, b = "FAIL";
+        try {
+            throw 1;
+        } catch (c) {
+            try {
+                throw 0;
+            } catch (a) {
+                if (c) b = "PASS";
+            }
+        }
+        console.log(b);
+    }
+    expect_stdout: "PASS"
+}


### PR DESCRIPTION
fixes #2120