### PR TITLE
[ES6] fix `drop_unused()` accounting of symbols within `export function`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2090,7 +2090,8 @@ merge(Compressor.prototype, {
         var tw = new TreeWalker(function(node, descend){
             if (node !== self) {
                 if (node instanceof AST_Defun || node instanceof AST_DefClass) {
-                    if (!drop_funcs && scope === self) {
+                    var in_export = tw.parent() instanceof AST_Export;
+                    if (in_export || !drop_funcs && scope === self) {
                         var node_def = node.name.definition();
                         if (node_def.global && !(node_def.id in in_use_ids)) {
                             in_use_ids[node_def.id] = true;
@@ -2227,7 +2228,6 @@ merge(Compressor.prototype, {
         // pass 3: we should drop declarations not in_use
         var tt = new TreeTransformer(
             function before(node, descend, in_list) {
-                var parent = tt.parent();
                 if (!compressor.option("keep_fnames")
                     && node.name && (node instanceof AST_Function || node instanceof AST_ClassExpression)) {
                     var def = node.name.definition();
@@ -2264,7 +2264,7 @@ merge(Compressor.prototype, {
                         }
                     }
                 }
-                if ((node instanceof AST_Defun || node instanceof AST_DefClass) && !(parent instanceof AST_Export) && node !== self) {
+                if ((node instanceof AST_Defun || node instanceof AST_DefClass) && node !== self) {
                     var keep = (node.name.definition().id in in_use_ids) || !drop_funcs && node.name.definition().global;
                     if (!keep) {
                         compressor[node.name.unreferenced() ? "warn" : "info"]("Dropping unused function {name} [{file}:{line},{col}]", template(node.name));
@@ -2272,6 +2272,7 @@ merge(Compressor.prototype, {
                     }
                     return node;
                 }
+                var parent = tt.parent();
                 if (node instanceof AST_Definitions
                     && !(parent instanceof AST_ForIn && parent.init === node)
                     && (drop_vars || !(parent instanceof AST_Toplevel) && !(node instanceof AST_Var))) {

--- a/test/compress/export.js
+++ b/test/compress/export.js
@@ -67,3 +67,31 @@ beautify: {
     }
     expect_exact: "export { A as B, C as D };"
 }
+
+issue_2131: {
+    options = {
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        function no() {
+            console.log(42);
+        }
+        function go() {
+            console.log(42);
+        }
+        var X = 1, Y = 2;
+        export function main() {
+            go(X);
+        };
+    }
+    expect: {
+        function go() {
+            console.log(42);
+        }
+        var X = 1;
+        export function main() {
+            go(X);
+        };
+    }
+}


### PR DESCRIPTION
fixes #2131