### PR TITLE
[ES6] fix `toplevel` on `export`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -129,7 +129,9 @@ function Compressor(options, false_by_default) {
         this.toplevel.funcs = /funcs/.test(toplevel);
         this.toplevel.vars = /vars/.test(toplevel);
     } else {
-        this.toplevel = toplevel ? return_true : return_false;
+        this.toplevel = toplevel ? function(def) {
+            return !def.export;
+        } : return_false;
         this.toplevel.funcs = this.toplevel.vars = toplevel;
     }
     var sequences = this.options["sequences"];
@@ -141,6 +143,7 @@ Compressor.prototype = new TreeTransformer;
 merge(Compressor.prototype, {
     option: function(key) { return this.options[key] },
     toplevel: function(def) {
+        if (def.export) return false;
         for (var i = 0, len = def.orig.length; i < len; i++)
             if (!this.toplevel[def.orig[i] instanceof AST_SymbolDefun ? "funcs" : "vars"])
                 return false;

--- a/test/compress/export.js
+++ b/test/compress/export.js
@@ -120,3 +120,37 @@ async_func: {
         export async function Foo(){};
     }
 }
+
+issue_2134_1: {
+    options = {
+        keep_fargs: false,
+        reduce_vars: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        export function Foo(x){};
+        Foo.prototype = {};
+    }
+    expect: {
+        export function Foo(){};
+        Foo.prototype = {};
+    }
+}
+
+issue_2134_2: {
+    options = {
+        keep_fargs: false,
+        reduce_vars: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        export async function Foo(x){};
+        Foo.prototype = {};
+    }
+    expect: {
+        export async function Foo(){};
+        Foo.prototype = {};
+    }
+}


### PR DESCRIPTION
fixes #2134