### PR TITLE
fix `reduce_vars` on `this`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -279,11 +279,11 @@ merge(Compressor.prototype, {
         var reduce_vars = rescan && compressor.option("reduce_vars");
         var safe_ids = Object.create(null);
         var suppressor = new TreeWalker(function(node) {
-            if (node instanceof AST_Symbol) {
-                var d = node.definition();
-                if (node instanceof AST_SymbolRef) d.references.push(node);
-                d.fixed = false;
-            }
+            if (!(node instanceof AST_Symbol)) return;
+            var d = node.definition();
+            if (!d) return;
+            if (node instanceof AST_SymbolRef) d.references.push(node);
+            d.fixed = false;
         });
         var tw = new TreeWalker(function(node, descend) {
             node._squeezed = false;

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -2575,3 +2575,28 @@ accessor: {
     }
     expect_stdout: "1 1"
 }
+
+for_in_prop: {
+    options = {
+        reduce_vars: true,
+    }
+    input: {
+        var a = {
+            foo: function() {
+                for (this.b in [1, 2]);
+            }
+        };
+        a.foo();
+        console.log(a.b);
+    }
+    expect: {
+        var a = {
+            foo: function() {
+                for (this.b in [1, 2]);
+            }
+        };
+        a.foo();
+        console.log(a.b);
+    }
+    expect_stdout: "1"
+}


### PR DESCRIPTION
fixes #2140

`reduce_vars` for `AST_Destructuring` relies on the same logic that is fixed by this PR.