### PR TITLE
toplevel shorthand for `ecma`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ a double dash to prevent input files being used as option arguments:
                                 sequences.
     --config-file <file>        Read `minify()` options from JSON file.
     -d, --define <expr>[=value] Global definitions.
+    --ecma <version>            Specifiy ECMAScript release: 5, 6, 7 or 8.
     --ie8                       Support non-standard Internet Explorer 8.
                                 Equivalent to setting `ie8: true` in `minify()`
                                 for `compress`, `mangle` and `output` options.

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -44,6 +44,7 @@ program.option("-o, --output <file>", "Output file (default STDOUT).");
 program.option("--comments [filter]", "Preserve copyright comments in the output.");
 program.option("--config-file <file>", "Read minify() options from JSON file.");
 program.option("-d, --define <expr>[=value]", "Global definitions.", parse_js("define"));
+program.option("--ecma <version>", "Specifiy ECMAScript release: 5, 6, 7 or 8.");
 program.option("--ie8", "Support non-standard Internet Explorer 8.");
 program.option("--keep-fnames", "Do not mangle/drop function names. Useful for code relying on Function.prototype.name.");
 program.option("--name-cache <file>", "File to hold mangled name mappings.");
@@ -73,6 +74,10 @@ if (!program.output && program.sourceMap && program.sourceMap.url != "inline") {
         options[name] = program[name];
     }
 });
+if ("ecma" in program) {
+    if (program.ecma != (program.ecma | 0)) fatal("ERROR: ecma must be an integer");
+    options.ecma = program.ecma | 0;
+}
 if (program.beautify) {
     options.output = typeof program.beautify == "object" ? program.beautify : {};
     if (!("beautify" in options.output)) {

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -32,6 +32,7 @@ function minify(files, options) {
     try {
         options = defaults(options, {
             compress: {},
+            ecma: undefined,
             ie8: false,
             keep_fnames: false,
             mangle: {},
@@ -46,6 +47,7 @@ function minify(files, options) {
         var timings = options.timings && {
             start: Date.now()
         };
+        set_shorthand("ecma", options, [ "parse", "compress", "output" ]);
         set_shorthand("ie8", options, [ "compress", "mangle", "output" ]);
         set_shorthand("keep_fnames", options, [ "compress", "mangle" ]);
         set_shorthand("toplevel", options, [ "compress", "mangle" ]);


### PR DESCRIPTION
Pending on #2156 so we can add `"parse"` to the list in `lib/minify.js`