### PR TITLE
parse `@global_defs` as expressions

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -92,12 +92,9 @@ function Compressor(options, false_by_default) {
     var global_defs = this.options["global_defs"];
     if (typeof global_defs == "object") for (var key in global_defs) {
         if (/^@/.test(key) && HOP(global_defs, key)) {
-            var ast = parse(global_defs[key]);
-            if (ast.body.length == 1 && ast.body[0] instanceof AST_SimpleStatement) {
-                global_defs[key.slice(1)] = ast.body[0].body;
-            } else throw new Error(string_template("Can't handle expression: {value}", {
-                value: global_defs[key]
-            }));
+            global_defs[key.slice(1)] = parse(global_defs[key], {
+                expression: true
+            });
         }
     }
     var pure_funcs = this.options["pure_funcs"];

--- a/test/compress/global_defs.js
+++ b/test/compress/global_defs.js
@@ -174,3 +174,24 @@ issue_1986: {
         console.log(42);
     }
 }
+
+issue_2167: {
+    options = {
+        conditionals: true,
+        dead_code: true,
+        evaluate: true,
+        global_defs: {
+            "@isDevMode": "function(){}",
+        },
+        side_effects: true,
+    }
+    input: {
+        if (isDevMode()) {
+            greetOverlord();
+        }
+        doWork();
+    }
+    expect: {
+        doWork();
+    }
+}

--- a/test/mocha/minify.js
+++ b/test/mocha/minify.js
@@ -212,7 +212,7 @@ describe("minify", function() {
             });
             var err = result.error;
             assert.ok(err instanceof Error);
-            assert.strictEqual(err.stack.split(/\n/)[0], "Error: Can't handle expression: debugger");
+            assert.strictEqual(err.stack.split(/\n/)[0], "SyntaxError: Unexpected token: keyword (debugger)");
         });
         it("should skip inherited properties", function() {
             var foo = Object.create({ skip: this });


### PR DESCRIPTION
- let parser rejects non-conformant input
- eliminate need for extraneous parenthesis

#2167 prompted me to review the `@global_defs` syntax, and realise we can reuse the `expression` logic from `lib/parse.js`