### PR TITLE
[ES8] fix `await` parens for property expressions and calls

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -673,6 +673,12 @@ function OutputStream(options) {
                 && this.operator !== "--";
     });
 
+    PARENS(AST_Await, function(output){
+        var p = output.parent();
+        return p instanceof AST_PropAccess && p.expression === this
+            || p instanceof AST_Call && p.expression === this;
+    });
+
     PARENS(AST_Sequence, function(output){
         var p = output.parent();
         return p instanceof AST_Call                          // (foo, bar)() or foo(1, (2, 3), 4)

--- a/test/compress/async.js
+++ b/test/compress/async.js
@@ -6,6 +6,22 @@ await_precedence: {
     expect_exact: "async function f1(){await x+y}async function f2(){await(x+y)}"
 }
 
+await_precedence_prop: {
+    input: {
+        async function f1(){ return (await foo()).bar; }
+        async function f2(){ return (await foo().bar); }
+    }
+    expect_exact: "async function f1(){return(await foo()).bar}async function f2(){return await foo().bar}"
+}
+
+await_precedence_call: {
+    input: {
+        async function f3(){ return (await foo())(); }
+        async function f4(){ return await (foo()()); }
+    }
+    expect_exact: "async function f3(){return(await foo())()}async function f4(){return await foo()()}"
+}
+
 async_function_declaration: {
     options = {
         side_effects: true,


### PR DESCRIPTION
Fixes #2179 