### PR TITLE
improve `compress` granularity through `typeofs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,10 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
 - `booleans` -- various optimizations for boolean context, for example `!!a
   ? b : c → a ? b : c`
 
+- `typeofs` -- default `true`.  Transforms `typeof foo == "undefined"` into
+  `foo === void 0`.  Note: recommend to set this value to `false` for IE10 and
+  earlier versions due to known issues.
+
 - `loops` -- optimizations for `do`, `while` and `for` loops when we can
   statically determine the condition
 
@@ -873,7 +877,6 @@ when this flag is on:
 - `new Object()` → `{}`
 - `String(exp)` or `exp.toString()` → `"" + exp`
 - `new Object/RegExp/Function/Error/Array (...)` → we discard the `new`
-- `typeof foo == "undefined"` → `foo === void 0`
 - `void 0` → `undefined` (if there is a variable named "undefined" in
   scope; we do it because the variable name will be mangled, typically
   reduced to a single character)
@@ -1050,5 +1053,5 @@ uglifyjs file.js -m
 ```
 To enable fast minify mode with the API use:
 ```js
-UglifyJS.minify(code, { compress: false, mangle: true }); 
+UglifyJS.minify(code, { compress: false, mangle: true });
 ```

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -80,6 +80,7 @@ function Compressor(options, false_by_default) {
         switches      : !false_by_default,
         top_retain    : null,
         toplevel      : !!(options && options["top_retain"]),
+        typeofs       : !false_by_default,
         unsafe        : false,
         unsafe_comps  : false,
         unsafe_Func   : false,
@@ -3591,7 +3592,8 @@ merge(Compressor.prototype, {
           case "==":
           case "!=":
             // "undefined" == typeof x => undefined === x
-            if (self.left instanceof AST_String
+            if (compressor.option("typeofs")
+                && self.left instanceof AST_String
                 && self.left.value == "undefined"
                 && self.right instanceof AST_UnaryPrefix
                 && self.right.operator == "typeof") {

--- a/test/compress/issue-1446.js
+++ b/test/compress/issue-1446.js
@@ -1,6 +1,7 @@
 typeof_eq_undefined: {
     options = {
-        comparisons: true
+        comparisons: true,
+        typeofs: true,
     }
     input: {
         var a = typeof b != "undefined";
@@ -24,6 +25,7 @@ typeof_eq_undefined_ie8: {
     options = {
         comparisons: true,
         ie8: true,
+        typeofs: true,
     }
     input: {
         var a = typeof b != "undefined";
@@ -45,7 +47,8 @@ typeof_eq_undefined_ie8: {
 
 undefined_redefined: {
     options = {
-        comparisons: true
+        comparisons: true,
+        typeofs: true,
     }
     input: {
         function f(undefined) {
@@ -58,7 +61,8 @@ undefined_redefined: {
 
 undefined_redefined_mangle: {
     options = {
-        comparisons: true
+        comparisons: true,
+        typeofs: true,
     }
     mangle = {}
     input: {

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -1469,6 +1469,7 @@ issue_1670_1: {
         reduce_vars: true,
         side_effects: true,
         switches: true,
+        typeofs: true,
         unused: true,
     }
     input: {
@@ -1532,6 +1533,7 @@ issue_1670_3: {
         reduce_vars: true,
         side_effects: true,
         switches: true,
+        typeofs: true,
         unused: true,
     }
     input: {


### PR DESCRIPTION
fixes #2198