### PR TITLE
enhance `passes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
   compressor from discarding function names.  Useful for code relying on
   `Function.prototype.name`. See also: the `keep_fnames` [mangle option](#mangle).
 
-- `passes` -- default `1`. Number of times to run compress with a maximum of 3.
+- `passes` -- default `1`. The maximum number of times to run compress.
   In some cases more than one pass leads to further compressed code.  Keep in
   mind more passes will take more time.
 

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -148,10 +148,20 @@ merge(Compressor.prototype, {
             node.process_expression(true);
         }
         var passes = +this.options.passes || 1;
-        for (var pass = 0; pass < passes && pass < 3; ++pass) {
+        var last_count = 1 / 0;
+        for (var pass = 0; pass < passes; pass++) {
             if (pass > 0 || this.option("reduce_vars"))
                 node.reset_opt_flags(this, true);
             node = node.transform(this);
+            if (passes > 1) {
+                var count = 0;
+                node.walk(new TreeWalker(function() {
+                    count++;
+                }));
+                this.info("pass " + pass + ": last_count: " + last_count + ", count: " + count);
+                if (count >= last_count) break;
+                last_count = count;
+            }
         }
         if (this.option("expression")) {
             node.process_expression(false);

--- a/test/compress/issue-1034.js
+++ b/test/compress/issue-1034.js
@@ -71,11 +71,13 @@ non_hoisted_function_after_return_2a: {
         "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:51,16]",
         "WARN: Dropping unused variable a [test/compress/issue-1034.js:48,20]",
         "WARN: Dropping unused function nope [test/compress/issue-1034.js:55,21]",
+        "WARN: pass 0: last_count: Infinity, count: 37",
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:53,12]",
         "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:53,12]",
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:56,12]",
         "WARN: Dropping unused variable b [test/compress/issue-1034.js:51,20]",
         "WARN: Dropping unused variable c [test/compress/issue-1034.js:53,16]",
+        "WARN: pass 1: last_count: 37, count: 18",
     ]
 }
 
@@ -109,11 +111,11 @@ non_hoisted_function_after_return_2b: {
     }
     expect_warnings: [
         // duplicate warnings no longer emitted
-        "WARN: Dropping unreachable code [test/compress/issue-1034.js:95,16]",
-        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:95,16]",
-        "WARN: Dropping unreachable code [test/compress/issue-1034.js:97,12]",
-        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:97,12]",
-        "WARN: Dropping unreachable code [test/compress/issue-1034.js:101,12]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:97,16]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:97,16]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:99,12]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:99,12]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:103,12]",
     ]
 }
 
@@ -151,10 +153,10 @@ non_hoisted_function_after_return_strict: {
     }
     expect_stdout: "8 7"
     expect_warnings: [
-        'WARN: Dropping unreachable code [test/compress/issue-1034.js:131,16]',
-        "WARN: Dropping unreachable code [test/compress/issue-1034.js:134,16]",
-        "WARN: Dropping unreachable code [test/compress/issue-1034.js:137,12]",
-        "WARN: Dropping unused function UnusedFunction [test/compress/issue-1034.js:138,21]"
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:133,16]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:136,16]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:139,12]",
+        "WARN: Dropping unused function UnusedFunction [test/compress/issue-1034.js:140,21]",
     ]
 }
 
@@ -194,17 +196,19 @@ non_hoisted_function_after_return_2a_strict: {
     }
     expect_stdout: "5 6"
     expect_warnings: [
-        "WARN: Dropping unreachable code [test/compress/issue-1034.js:173,16]",
-        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:173,16]",
-        "WARN: Dropping unreachable code [test/compress/issue-1034.js:176,16]",
-        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:176,16]",
-        "WARN: Dropping unused variable a [test/compress/issue-1034.js:173,20]",
-        "WARN: Dropping unused function nope [test/compress/issue-1034.js:180,21]",
-        "WARN: Dropping unreachable code [test/compress/issue-1034.js:178,12]",
-        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:178,12]",
-        "WARN: Dropping unreachable code [test/compress/issue-1034.js:181,12]",
-        "WARN: Dropping unused variable b [test/compress/issue-1034.js:176,20]",
-        "WARN: Dropping unused variable c [test/compress/issue-1034.js:178,16]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:175,16]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:175,16]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:178,16]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:178,16]",
+        "WARN: Dropping unused variable a [test/compress/issue-1034.js:175,20]",
+        "WARN: Dropping unused function nope [test/compress/issue-1034.js:182,21]",
+        "WARN: pass 0: last_count: Infinity, count: 48",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:180,12]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:180,12]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:183,12]",
+        "WARN: Dropping unused variable b [test/compress/issue-1034.js:178,20]",
+        "WARN: Dropping unused variable c [test/compress/issue-1034.js:180,16]",
+        "WARN: pass 1: last_count: 48, count: 29",
     ]
 }
 
@@ -243,10 +247,10 @@ non_hoisted_function_after_return_2b_strict: {
     expect_stdout: "5 6"
     expect_warnings: [
         // duplicate warnings no longer emitted
-        "WARN: Dropping unreachable code [test/compress/issue-1034.js:225,16]",
-        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:225,16]",
-        "WARN: Dropping unreachable code [test/compress/issue-1034.js:227,12]",
-        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:227,12]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:229,16]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:229,16]",
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:231,12]",
+        "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:231,12]",
+        "WARN: Dropping unreachable code [test/compress/issue-1034.js:235,12]",
     ]
 }


### PR DESCRIPTION
- remove hardcoded upper limit
- continue based on node count reduction
- emit verbose statistics

fixes #2226

@kzc can't think of a good test case for this, nor did `node test/benchmark.js -mc passes=100,unsafe --toplevel` makes any difference from `passes=3`