### PR TITLE
fix `unsafe` `evaluate` of `Object` static methods

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1853,10 +1853,6 @@ merge(Compressor.prototype, {
                 "isFinite",
                 "isNaN",
             ],
-            Object: [
-                "keys",
-                "getOwnPropertyNames",
-            ],
             String: [
                 "fromCharCode",
             ],
@@ -3496,7 +3492,9 @@ merge(Compressor.prototype, {
                                 operator: car.operator,
                                 expression: left
                             });
-                        } else car.write_only = false;
+                        } else {
+                            car.write_only = false;
+                        }
                         if (parent) {
                             parent[field] = car;
                             expressions[i] = expressions[j];

--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -1157,3 +1157,31 @@ issue_2207_3: {
     }
     expect_stdout: true
 }
+
+issue_2231_1: {
+    options = {
+        evaluate: true,
+        unsafe: true,
+    }
+    input: {
+        console.log(Object.keys(void 0));
+    }
+    expect: {
+        console.log(Object.keys(void 0));
+    }
+    expect_stdout: true
+}
+
+issue_2231_2: {
+    options = {
+        evaluate: true,
+        unsafe: true,
+    }
+    input: {
+        console.log(Object.getOwnPropertyNames(null));
+    }
+    expect: {
+        console.log(Object.getOwnPropertyNames(null));
+    }
+    expect_stdout: true
+}


### PR DESCRIPTION
fixes #2231