### PR TITLE
[ES6] extend `collapse_vars` to `let` and `const`

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -697,7 +697,7 @@ var AST_Export = DEFNODE("Export", "exported_definition exported_value is_defaul
 var AST_VarDef = DEFNODE("VarDef", "name value", {
     $documentation: "A variable declaration; only appears in a AST_Definitions node",
     $propdoc: {
-        name: "[AST_SymbolVar|AST_SymbolConst|AST_Destructuring] name of the variable",
+        name: "[AST_Destructuring|AST_SymbolConst|AST_SymbolLet|AST_SymbolVar] name of the variable",
         value: "[AST_Node?] initializer, or null of there's no initializer"
     },
     _walk: function(visitor) {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -302,6 +302,7 @@ merge(Compressor.prototype, {
             if (reduce_vars) {
                 if (node instanceof AST_Toplevel) node.globals.each(reset_def);
                 if (node instanceof AST_Scope) node.variables.each(reset_def);
+                if (node.block_scope) node.block_scope.variables.each(reset_def);
                 if (node instanceof AST_SymbolRef) {
                     var d = node.definition();
                     d.references.push(node);

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -116,7 +116,7 @@ AST_Toplevel.DEFMETHOD("figure_out_scope", function(options){
     var tw = new TreeWalker(function(node, descend){
         if (node.is_block_scope()) {
             var save_scope = scope;
-            scope = new AST_Scope(node);
+            node.block_scope = scope = new AST_Scope(node);
             scope.init_scope_vars(save_scope);
             if (!(node instanceof AST_Scope)) {
                 scope.uses_with = save_scope.uses_with;

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -2548,3 +2548,71 @@ duplicate_argname: {
     }
     expect_stdout: "PASS"
 }
+
+issue_2250_1: {
+    options = {
+        collapse_vars: true,
+        conditionals: true,
+        reduce_vars: true,
+    }
+    input: {
+        function f(x) {
+            if (x) {
+                const a = foo();
+                x(a);
+            }
+        }
+        function g(x) {
+            if (x) {
+                let a = foo();
+                x(a);
+            }
+        }
+        function h(x) {
+            if (x) {
+                var a = foo();
+                x(a);
+            }
+        }
+    }
+    expect: {
+        function f(x) {
+            x && x(foo());
+        }
+        function g(x) {
+            x && x(foo());
+        }
+        function h(x) {
+            x && x(foo());
+        }
+    }
+}
+
+issue_2250_2: {
+    options = {
+        collapse_vars: true,
+        passes: 2,
+        reduce_vars: true,
+        side_effects: true,
+        toplevel: true,
+    }
+    input: {
+        {
+            const foo = function(){};
+            foo(bar());
+        }
+        {
+            let foo = function(){};
+            foo(bar());
+        }
+        {
+            var foo = function(){};
+            foo(bar());
+        }
+    }
+    expect: {
+        bar();
+        bar();
+        bar();
+    }
+}


### PR DESCRIPTION
fixes #2250

@kzc thanks for the test cases and even the title - creating this PR is thus pretty mechanical :+1: 