### PR TITLE
[ES6] fix `pure_getters` on spread of objects

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1427,8 +1427,13 @@ merge(Compressor.prototype, {
         def(AST_Object, function(compressor) {
             if (!is_strict(compressor)) return false;
             for (var i = this.properties.length; --i >=0;)
-                if (this.properties[i].value instanceof AST_Accessor) return true;
+                if (this.properties[i]._dot_throw(compressor)) return true;
             return false;
+        });
+        def(AST_ObjectProperty, return_false);
+        def(AST_ObjectGetter, return_true);
+        def(AST_Expansion, function(compressor) {
+            return this.expression._dot_throw(compressor);
         });
         def(AST_Function, return_false);
         def(AST_Arrow, return_false);

--- a/test/compress/pure_getters.js
+++ b/test/compress/pure_getters.js
@@ -385,3 +385,76 @@ set_mutable_2: {
     }
     expect_stdout: "PASS"
 }
+
+issue_2265_1: {
+    options = {
+        pure_getters: "strict",
+        side_effects: true,
+    }
+    input: {
+        ({ ...{} }).p;
+        ({ ...g }).p;
+    }
+    expect: {
+        ({ ...g }).p;
+    }
+}
+
+issue_2265_2: {
+    options = {
+        pure_getters: "strict",
+        reduce_vars: true,
+        side_effects: true,
+        toplevel: true,
+    }
+    input: {
+        var a = {
+            get b() {
+                throw 0;
+            }
+        };
+        ({...a}).b;
+    }
+    expect: {
+        var a = {
+            get b() {
+                throw 0;
+            }
+        };
+        ({...a}).b;
+    }
+}
+
+issue_2265_3: {
+    options = {
+        pure_getters: "strict",
+        reduce_vars: true,
+        side_effects: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        var a = {
+            set b() {
+                throw 0;
+            }
+        };
+        ({...a}).b;
+    }
+    expect: {}
+}
+
+issue_2265_4: {
+    options = {
+        pure_getters: "strict",
+        reduce_vars: true,
+        side_effects: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        var a = { b: 1 };
+        ({...a}).b;
+    }
+    expect: {}
+}


### PR DESCRIPTION
@kzc this is https://github.com/mishoo/UglifyJS2/pull/2265#discussion_r131325111 minus `def(AST_Accessor)` since AFAICT it's unreachable.