### PR TITLE
Introduce new compress option `unsafe_arrows`

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
 - `arrows` (default `true`) -- Converts `()=>{return x}` to `()=>x`. Class
   and object literal methods will also be converted to arrow expressions if
   the resultant code is shorter: `m(){return x}` becomes `m:()=>x`.
+  This transform requires that the `ecma` compress option is set to `6` or greater.
 
 - `unsafe_arrows` (default `false`) -- Convert ES5 style anonymous function
   expressions to arrow functions if the function body does not reference `this`.

--- a/README.md
+++ b/README.md
@@ -646,9 +646,15 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
 
 - `evaluate` -- attempt to evaluate constant expressions
 
-- `arrows` (default `true`) -- convert ES5 style anonymous function expressions
-  to arrow functions if permissible by language semantics.
-  Note: `arrows` requires that the `ecma` compress option is set to `6` or greater.
+- `arrows` (default `true`) -- Converts `()=>{return x}` to `()=>x`. Class
+  and object literal methods will also be converted to arrow expressions if
+  the resultant code is shorter: `m(){return x}` becomes `m:()=>x`.
+
+- `unsafe_arrows` (default `false`) -- Convert ES5 style anonymous function
+  expressions to arrow functions if the function body does not reference `this`.
+  Note: it is not always safe to perform this conversion if code relies on the
+  the function having a `prototype`, which arrow functions lack.
+  This transform requires that the `ecma` compress option is set to `6` or greater.
 
 - `booleans` -- various optimizations for boolean context, for example `!!a
   ? b : c → a ? b : c`

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -84,6 +84,7 @@ function Compressor(options, false_by_default) {
         toplevel      : !!(options && options["top_retain"]),
         typeofs       : !false_by_default,
         unsafe        : false,
+        unsafe_arrows : false,
         unsafe_comps  : false,
         unsafe_Func   : false,
         unsafe_math   : false,
@@ -4748,7 +4749,7 @@ merge(Compressor.prototype, {
 
     OPT(AST_Function, function(self, compressor){
         tighten_body(self.body, compressor);
-        if (compressor.option("arrows")
+        if (compressor.option("unsafe_arrows")
             && compressor.option("ecma") >= 6
             && !self.name
             && !self.is_generator

--- a/test/compress/arrow.js
+++ b/test/compress/arrow.js
@@ -629,5 +629,4 @@ issue_2271: {
         new Foo().set("PASS").print();
     }
     expect_stdout: "PASS"
-    node_version: ">=6"
 }

--- a/test/compress/arrow.js
+++ b/test/compress/arrow.js
@@ -213,7 +213,7 @@ no_leading_parentheses: {
 
 async_identifiers: {
     options = {
-        arrows: true,
+        unsafe_arrows: true,
         ecma: 6,
     }
     input: {
@@ -237,7 +237,7 @@ async_identifiers: {
 
 async_function_expression: {
     options = {
-        arrows: true,
+        unsafe_arrows: true,
         ecma: 6,
         evaluate: true,
         side_effects: true,
@@ -262,7 +262,7 @@ async_function_expression: {
 
 issue_27: {
     options = {
-        arrows: true,
+        unsafe_arrows: true,
         collapse_vars: true,
         ecma: 6,
         unused: true,
@@ -283,7 +283,7 @@ issue_27: {
 
 issue_2105_1: {
     options = {
-        arrows: true,
+        unsafe_arrows: true,
         collapse_vars: true,
         ecma: 6,
         inline: true,
@@ -501,7 +501,7 @@ issue_485_crashing_1530: {
 
 issue_2084: {
     options = {
-        arrows: true,
+        unsafe_arrows: true,
         collapse_vars: true,
         conditionals: true,
         ecma: 6,
@@ -577,6 +577,7 @@ concise_methods_with_computed_property2: {
 async_object_literal: {
     options = {
         arrows: true,
+        unsafe_arrows: true,
         ecma: 6,
         evaluate: true,
     }
@@ -596,4 +597,37 @@ async_object_literal: {
             anon: async () => await foo(2)
         };
     }
+}
+
+issue_2271: {
+    options = {
+        arrows: true,
+        ecma: 6,
+        evaluate: true,
+        unsafe_arrows: false,
+    }
+    input: {
+        var Foo = function() {};
+        Foo.prototype.set = function(value) {
+            this.value = value;
+            return this;
+        }
+        Foo.prototype.print = function() {
+            console.log(this.value);
+        }
+        new Foo().set("PASS").print();
+    }
+    expect: {
+        var Foo = function() {};
+        Foo.prototype.set = function(value) {
+            this.value = value;
+            return this;
+        }
+        Foo.prototype.print = function() {
+            console.log(this.value);
+        }
+        new Foo().set("PASS").print();
+    }
+    expect_stdout: "PASS"
+    node_version: ">=6"
 }

--- a/test/compress/issue-203.js
+++ b/test/compress/issue-203.js
@@ -49,8 +49,8 @@ compress_new_function_with_destruct_arrows: {
         new Function("[[aa]], [{bb}]", 'return aa;');
     }
     expect: {
-        Function("n,[a]", "return n");
-        Function("b,{bb:n}", "return b");
-        Function("[[b]],[{bb:n}]", "return b");
+        Function("n,[r]", "return n");
+        Function("n,{bb:b}", "return n");
+        Function("[[n]],[{bb:b}]", "return n");
     }
 }

--- a/test/compress/issue-203.js
+++ b/test/compress/issue-203.js
@@ -36,9 +36,10 @@ compress_new_function_with_destruct: {
 compress_new_function_with_destruct_arrows: {
     options = {
         arrows: true,
+        unsafe_arrows: true,
         unsafe: true,
         unsafe_Func: true,
-        ecma: 6
+        ecma: 6,
     }
     beautify = {
         ecma: 6
@@ -49,8 +50,8 @@ compress_new_function_with_destruct_arrows: {
         new Function("[[aa]], [{bb}]", 'return aa;');
     }
     expect: {
-        Function("n,[r]", "return n");
-        Function("n,{bb:b}", "return n");
-        Function("[[n]],[{bb:b}]", "return n");
+        Function("n,[a]", "return n");
+        Function("b,{bb:n}", "return b");
+        Function("[[b]],[{bb:n}]", "return b");
     }
 }


### PR DESCRIPTION
* Not always safe to convert a function expression to an arrow
  function when code depends on the function prototype existing.

Fixes #2271