### PR TITLE
Update Readme.md `mangle` settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ a double dash to prevent input files being used as option arguments:
                                               not used.
     -m, --mangle [options]      Mangle names/specify mangler options:
                                 `reserved`  List of names that should not be mangled.
+                                `cache` Boolean for cache determination.
+                                `eval` Boolean for mangling `eval` statements.
+                                `ie8` Mangle support for ie8.
+                                `keep_fnames` Keep function names.
+                                `properties` Mangle properties.
+                                `safari10` Boolean flag used to bypass Safari 10 `let` bug.
+                                `toplevel` Boolean flag to determine toplevel.                                
     --mangle-props [options]    Mangle properties/specify mangler options:
                                 `builtins`  Mangle property names that overlaps
                                             with standard JavaScript globals.
@@ -745,9 +752,16 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
   Useful for code relying on `Function.prototype.name`. See also: the `keep_fnames`
   [compress option](#compress-options).
 
-- `eval` (default `false`). Pass `true` to mangle names visible in scopes
-  where `eval` or `with` are used.
+- `cache` (default `false`). Boolean for cache determination.
 
+- `eval` (default `false`). Pass `true` to mangle names visible in scopes where `eval` or `with` are used.
+
+- `ie8` (default `false`). Mangle support for ie8.
+
+- `properties` (default `false`). Mangle properties.
+
+- `safari10` (default `false`). Boolean flag used to bypass Safari 10 `let` bug.
+                                
 Examples:
 
 ```javascript


### PR DESCRIPTION
These are based off https://github.com/Perlmint/UglifyJS2/blob/0976fc3e4b303be6de8a366f8406d8906b5521e1/lib/minify.js#L54-L61
And had no documentation update from this issue #1753 and this PR #1851.

Discovered when working on this Pull Request https://github.com/devpunks/snuggsi/issues/78

Please let me know where i can better update copy text. Difficult to know what the flags do without a readme for the flags. ;-)

Thanks!

/cc @brandondees @robcole @angelocordon