### PR TITLE
fix `collapse_vars` on default function argument

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -847,7 +847,7 @@ merge(Compressor.prototype, {
                         if (sym.name in names) continue;
                         names[sym.name] = true;
                         var arg = iife.args[i];
-                        if (!arg) arg = make_node(AST_Undefined, sym);
+                        if (!arg) arg = make_node(AST_Undefined, sym).transform(compressor);
                         else {
                             var tw = new TreeWalker(function(node) {
                                 if (!arg) return true;

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -2342,3 +2342,45 @@ duplicate_argname: {
     }
     expect_stdout: "PASS"
 }
+
+issue_2298: {
+    options = {
+        collapse_vars: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        !function() {
+            function f() {
+                var a = undefined;
+                var undefined = a++;
+                try {
+                    !function g(b) {
+                        b[1] = "foo";
+                    }();
+                    console.log("FAIL");
+                } catch (e) {
+                    console.log("PASS");
+                }
+            }
+            f();
+        }();
+    }
+    expect: {
+        !function() {
+            (function() {
+                var a = undefined;
+                var undefined = a++;
+                try {
+                    !function(b) {
+                        (void 0)[1] = "foo";
+                    }();
+                    console.log("FAIL");
+                } catch (e) {
+                    console.log("PASS");
+                }
+            })();
+        }();
+    }
+    expect_stdout: "PASS"
+}


### PR DESCRIPTION
Avoid collision with local variable `undefined` under certain corner cases.

fixes #2298