### PR TITLE
Add question option to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-**Bug report or feature request?** 
+**Bug report, feature request or question?** 
 
 <!-- Note: sub-optimal but correct code is not a bug -->
 


### PR DESCRIPTION
This is mostly a question in the guise of a PR:

"where is the appropriate place for questions?"

There's no gitter/irc/slack link on the homepage, and I can't seem to find a mailing list.