### PR TITLE
add `Date` and other known globals to `unsafe` compress option

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -693,7 +693,7 @@ merge(Compressor.prototype, {
         return node instanceof AST_SymbolRef && node.definition().undeclared;
     }
 
-    var global_names = makePredicate("Array Boolean console Error Function Math Number RegExp Object String");
+    var global_names = makePredicate("Array Boolean console Date Error Function Math Number RegExp Object String");
     AST_SymbolRef.DEFMETHOD("is_declared", function(compressor) {
         return !this.definition().undeclared
             || compressor.option("unsafe") && global_names(this.name);

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -693,7 +693,7 @@ merge(Compressor.prototype, {
         return node instanceof AST_SymbolRef && node.definition().undeclared;
     }
 
-    var global_names = makePredicate("Array Boolean console Date Error EvalError Function JSON Math Number parseInt RangeError ReferenceError RegExp Object String SyntaxError TypeError URIError");
+    var global_names = makePredicate("Array Boolean clearInterval clearTimeout console Date decodeURI decodeURIComponent encodeURI encodeURIComponent Error escape eval EvalError Function isFinite isNaN JSON Math Number parseFloat parseInt RangeError ReferenceError RegExp Object setInterval setTimeout String SyntaxError TypeError unescape URIError");
     AST_SymbolRef.DEFMETHOD("is_declared", function(compressor) {
         return !this.definition().undeclared
             || compressor.option("unsafe") && global_names(this.name);

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -693,7 +693,7 @@ merge(Compressor.prototype, {
         return node instanceof AST_SymbolRef && node.definition().undeclared;
     }
 
-    var global_names = makePredicate("Array Boolean console Date Error Function Math Number RegExp Object String");
+    var global_names = makePredicate("Array Boolean console Date Error EvalError Function JSON Math Number parseInt RangeError ReferenceError RegExp Object String SyntaxError TypeError URIError");
     AST_SymbolRef.DEFMETHOD("is_declared", function(compressor) {
         return !this.definition().undeclared
             || compressor.option("unsafe") && global_names(this.name);

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -240,22 +240,36 @@ issue_2233_1: {
     input: {
         Array.isArray;
         Boolean;
+        //clearInterval;
+        //clearTimeout;
         console.log;
         Date;
+        decodeURI;
+        decodeURIComponent;
+        encodeURI;
+        encodeURIComponent;
         Error.name;
+        escape;
+        eval;
         EvalError;
         Function.length;
+        isFinite;
+        isNaN;
         JSON;
         Math.random;
         Number.isNaN;
+        parseFloat;
         parseInt;
         RegExp;
         Object.defineProperty;
         String.fromCharCode;
         RangeError;
         ReferenceError;
+        //setInterval;
+        //setTimeout;
         SyntaxError;
         TypeError;
+        unescape;
         URIError;
     }
     expect: {}

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -241,6 +241,7 @@ issue_2233_1: {
         Array.isArray;
         Boolean;
         console.log;
+        Date;
         Error.name;
         Function.length;
         Math.random;

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -240,8 +240,6 @@ issue_2233_1: {
     input: {
         Array.isArray;
         Boolean;
-        //clearInterval;
-        //clearTimeout;
         console.log;
         Date;
         decodeURI;
@@ -265,8 +263,6 @@ issue_2233_1: {
         String.fromCharCode;
         RangeError;
         ReferenceError;
-        //setInterval;
-        //setTimeout;
         SyntaxError;
         TypeError;
         unescape;
@@ -274,6 +270,23 @@ issue_2233_1: {
     }
     expect: {}
     expect_stdout: true
+}
+
+global_timeout_and_interval_symbols: {
+    options = {
+        pure_getters: "strict",
+        side_effects: true,
+        unsafe: true,
+    }
+    input: {
+        // These global symbols do not exist in the test sandbox
+        // and must be tested separately.
+        clearInterval;
+        clearTimeout;
+        setInterval;
+        setTimeout;
+    }
+    expect: {}
 }
 
 issue_2233_2: {

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -243,12 +243,20 @@ issue_2233_1: {
         console.log;
         Date;
         Error.name;
+        EvalError;
         Function.length;
+        JSON;
         Math.random;
         Number.isNaN;
+        parseInt;
         RegExp;
         Object.defineProperty;
         String.fromCharCode;
+        RangeError;
+        ReferenceError;
+        SyntaxError;
+        TypeError;
+        URIError;
     }
     expect: {}
     expect_stdout: true


### PR DESCRIPTION
We missed this one in #2236.

I think `Date` has been in javascript from the start.