### PR TITLE
handle LHS side-effects on `cascade` & `collapse_vars`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -561,6 +561,7 @@ merge(Compressor.prototype, {
     });
 
     function is_lhs_read_only(lhs) {
+        if (lhs instanceof AST_This) return true;
         if (lhs instanceof AST_SymbolRef) return lhs.definition().orig[0] instanceof AST_SymbolLambda;
         if (lhs instanceof AST_PropAccess) {
             lhs = lhs.expression;
@@ -745,7 +746,7 @@ merge(Compressor.prototype, {
                 while (candidates.length > 0) {
                     var candidate = candidates.pop();
                     var lhs = get_lhs(candidate);
-                    if (!lhs || is_lhs_read_only(lhs)) continue;
+                    if (!lhs || is_lhs_read_only(lhs) || lhs.has_side_effects(compressor)) continue;
                     // Locate symbols which may execute code outside of scanning range
                     var lvalues = get_lvalues(candidate);
                     if (lhs instanceof AST_SymbolRef) lvalues[lhs.name] = false;
@@ -3496,7 +3497,7 @@ merge(Compressor.prototype, {
                     && (left.operator == "++" || left.operator == "--")) {
                     left = left.expression;
                 } else left = null;
-                if (!left || is_lhs_read_only(left)) {
+                if (!left || is_lhs_read_only(left) || left.has_side_effects(compressor)) {
                     expressions[++i] = cdr;
                     continue;
                 }

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -2384,3 +2384,70 @@ issue_2298: {
     }
     expect_stdout: "PASS"
 }
+
+issue_2313_1: {
+    options = {
+        collapse_vars: true,
+        conditionals: true,
+    }
+    input: {
+        var a = 0, b = 0;
+        var foo = {
+            get c() {
+                a++;
+                return 42;
+            },
+            set c(c) {
+                b++;
+            },
+            d: function() {
+                this.c++;
+                if (this.c) console.log(a, b);
+            }
+        }
+        foo.d();
+    }
+    expect: {
+        var a = 0, b = 0;
+        var foo = {
+            get c() {
+                a++;
+                return 42;
+            },
+            set c(c) {
+                b++;
+            },
+            d: function() {
+                this.c++;
+                this.c && console.log(a, b);
+            }
+        }
+        foo.d();
+    }
+    expect_stdout: "2 1"
+}
+
+issue_2313_2: {
+    options = {
+        collapse_vars: true,
+    }
+    input: {
+        var c = 0;
+        !function a() {
+            a && c++;
+            var a = 0;
+            a && c++;
+        }();
+        console.log(c);
+    }
+    expect: {
+        var c = 0;
+        !function a() {
+            a && c++;
+            var a = 0;
+            a && c++;
+        }();
+        console.log(c);
+    }
+    expect_stdout: "0"
+}

--- a/test/compress/pure_getters.js
+++ b/test/compress/pure_getters.js
@@ -385,3 +385,217 @@ set_mutable_2: {
     }
     expect_stdout: "PASS"
 }
+
+issue_2313_1: {
+    options = {
+        cascade: true,
+        conditionals: true,
+        pure_getters: "strict",
+        sequences: true,
+        side_effects: true,
+    }
+    input: {
+        function x() {
+            console.log(1);
+            return {
+                y: function() {
+                    console.log(2);
+                    return {
+                        z: 0
+                    };
+                }
+            };
+        }
+        x().y().z++;
+        if (x().y().z) {
+            console.log(3);
+        }
+    }
+    expect: {
+        function x() {
+            return console.log(1), {
+                y: function() {
+                    return console.log(2), {
+                        z: 0
+                    };
+                }
+            };
+        }
+        x().y().z++,
+        x().y().z && console.log(3);
+    }
+    expect_stdout: [
+        "1",
+        "2",
+        "1",
+        "2",
+    ]
+}
+
+issue_2313_2: {
+    options = {
+        cascade: true,
+        conditionals: true,
+        pure_getters: true,
+        sequences: true,
+        side_effects: true,
+    }
+    input: {
+        function x() {
+            console.log(1);
+            return {
+                y: function() {
+                    console.log(2);
+                    return {
+                        z: 0
+                    };
+                }
+            };
+        }
+        x().y().z++;
+        if (x().y().z) {
+            console.log(3);
+        }
+    }
+    expect: {
+        function x() {
+            return console.log(1), {
+                y: function() {
+                    return console.log(2), {
+                        z: 0
+                    };
+                }
+            };
+        }
+        x().y().z++,
+        x().y().z && console.log(3);
+    }
+    expect_stdout: [
+        "1",
+        "2",
+        "1",
+        "2",
+    ]
+}
+
+issue_2313_3: {
+    options = {
+        collapse_vars: true,
+        conditionals: true,
+        pure_getters: "strict",
+    }
+    input: {
+        function x() {
+            console.log(1);
+            return {
+                y: function() {
+                    console.log(2);
+                    return {
+                        z: 0
+                    };
+                }
+            };
+        }
+        x().y().z++;
+        if (x().y().z) {
+            console.log(3);
+        }
+    }
+    expect: {
+        function x() {
+            console.log(1);
+            return {
+                y: function() {
+                    console.log(2);
+                    return {
+                        z: 0
+                    };
+                }
+            };
+        }
+        x().y().z++;
+        x().y().z && console.log(3);
+    }
+    expect_stdout: [
+        "1",
+        "2",
+        "1",
+        "2",
+    ]
+}
+
+issue_2313_4: {
+    options = {
+        collapse_vars: true,
+        conditionals: true,
+        pure_getters: true,
+    }
+    input: {
+        function x() {
+            console.log(1);
+            return {
+                y: function() {
+                    console.log(2);
+                    return {
+                        z: 0
+                    };
+                }
+            };
+        }
+        x().y().z++;
+        if (x().y().z) {
+            console.log(3);
+        }
+    }
+    expect: {
+        function x() {
+            console.log(1);
+            return {
+                y: function() {
+                    console.log(2);
+                    return {
+                        z: 0
+                    };
+                }
+            };
+        }
+        x().y().z++;
+        x().y().z && console.log(3);
+    }
+    expect_stdout: [
+        "1",
+        "2",
+        "1",
+        "2",
+    ]
+}
+
+issue_2313_5: {
+    options = {
+        pure_getters: "strict",
+        side_effects: true,
+    }
+    input: {
+        x().y++;
+        x().y;
+    }
+    expect: {
+        x().y++;
+        x().y;
+    }
+}
+
+issue_2313_6: {
+    options = {
+        pure_getters: true,
+        side_effects: true,
+    }
+    input: {
+        x().y++;
+        x().y;
+    }
+    expect: {
+        x().y++;
+        x();
+    }
+}

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -739,3 +739,44 @@ issue_2062: {
     }
     expect_stdout: "1"
 }
+
+issue_2313: {
+    options = {
+        cascade: true,
+        sequences: true,
+        side_effects: true,
+    }
+    input: {
+        var a = 0, b = 0;
+        var foo = {
+            get c() {
+                a++;
+                return 42;
+            },
+            set c(c) {
+                b++;
+            },
+            d: function() {
+                this.c++;
+                if (this.c) console.log(a, b);
+            }
+        }
+        foo.d();
+    }
+    expect: {
+        var a = 0, b = 0;
+        var foo = {
+            get c() {
+                return a++, 42;
+            },
+            set c(c) {
+                b++;
+            },
+            d: function() {
+                if (this.c++, this.c) console.log(a, b);
+            }
+        }
+        foo.d();
+    }
+    expect_stdout: "2 1"
+}


### PR DESCRIPTION
fixes #2313

https://github.com/mishoo/UglifyJS2/issues/2313#issue-257874574 & https://github.com/mishoo/UglifyJS2/issues/2313#issuecomment-329653677 are technically two separate issues, but the fixes are minimal and around the same lines so no harm lumping them together.