### PR TITLE
[ES6] add new compress option `unsafe_methods` for ecma >= 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,11 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
 - `unsafe_math` (default: false) -- optimize numerical expressions like
   `2 * x * 3` into `6 * x`, which may give imprecise floating point results.
 
+- `unsafe_methods` (default: false) -- Converts `{ m: function(){} }` to
+  `{ m(){} }`. `ecma` must be set to `6` or greater to enable this transform.
+  Note: if enabled there is a risk of getting a "`<method name>` is not a
+  constructor" TypeError should any code try to `new` the former function.
+
 - `unsafe_proto` (default: false) -- optimize expressions like
   `Array.prototype.slice.call(a)` into `[].slice.call(a)`
 

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -88,6 +88,7 @@ function Compressor(options, false_by_default) {
         unsafe_comps  : false,
         unsafe_Func   : false,
         unsafe_math   : false,
+        unsafe_methods: false,
         unsafe_proto  : false,
         unsafe_regexp : false,
         unused        : !false_by_default,
@@ -4866,7 +4867,7 @@ merge(Compressor.prototype, {
         // p:async function(){} ---> async p(){}
         // p:()=>{} ---> p(){}
         // p:async()=>{} ---> async p(){}
-        if (compressor.option("ecma") >= 6) {
+        if (compressor.option("unsafe_methods") && compressor.option("ecma") >= 6) {
             var key = self.key;
             var value = self.value;
             var is_arrow_with_block = value instanceof AST_Arrow

--- a/test/compress/arrow.js
+++ b/test/compress/arrow.js
@@ -290,6 +290,7 @@ issue_2105_1: {
         passes: 3,
         reduce_vars: true,
         side_effects: true,
+        unsafe_methods: true,
         unused: true,
     }
     input: {

--- a/test/compress/object.js
+++ b/test/compress/object.js
@@ -516,6 +516,7 @@ variable_as_computed_property: {
 prop_func_to_concise_method: {
     options = {
         ecma: 6,
+        unsafe_methods: true,
     }
     input: {
         ({
@@ -544,6 +545,7 @@ prop_func_to_concise_method: {
 prop_arrow_to_concise_method: {
     options = {
         ecma: 6,
+        unsafe_methods: true,
     }
     input: {
         ({
@@ -592,6 +594,7 @@ concise_method_to_prop_arrow: {
 prop_func_to_async_concise_method: {
     options = {
         ecma: 8,
+        unsafe_methods: true,
     }
     input: {
         ({
@@ -614,6 +617,7 @@ prop_func_to_async_concise_method: {
 prop_func_to_concise_method_various: {
     options = {
         ecma: 6,
+        unsafe_methods: true,
     }
     input: {
         ({
@@ -646,6 +650,7 @@ prop_func_to_concise_method_various: {
 prop_arrows_to_concise_method_various: {
     options = {
         ecma: 6,
+        unsafe_methods: true,
     }
     input: {
         ({
@@ -674,6 +679,7 @@ prop_arrows_to_concise_method_various: {
 prop_arrow_with_this: {
     options = {
         ecma: 6,
+        unsafe_methods: true,
     }
     input: {
         function run(arg) {
@@ -711,6 +717,7 @@ prop_arrow_with_this: {
 prop_arrow_with_nested_this: {
     options = {
         ecma: 6,
+        unsafe_methods: true,
     }
     input: {
         function run(arg) {

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -887,6 +887,7 @@ methods_keep_quoted_true: {
     options = {
         arrows: true,
         ecma: 6,
+        unsafe_methods: true,
     }
     mangle = {
         properties: {
@@ -906,6 +907,7 @@ methods_keep_quoted_false: {
     options = {
         arrows: true,
         ecma: 6,
+        unsafe_methods: true,
     }
     mangle = {
         properties: {
@@ -931,6 +933,7 @@ methods_keep_quoted_from_dead_code: {
         evaluate: true,
         reduce_vars: true,
         side_effects: true,
+        unsafe_methods: true,
     }
     mangle = {
         properties: {
@@ -963,4 +966,36 @@ issue_2256: {
     expect: {
         g.keep = g.g;
     }
+}
+
+issue_2321: {
+    options = {
+        ecma: 6,
+        unsafe_methods: false,
+    }
+    input: {
+        var f = {
+            foo: function(){ console.log("foo") },
+            bar() { console.log("bar") }
+        };
+        var foo = new f.foo();
+        var bar =     f.bar();
+    }
+    expect: {
+        var f = {
+            foo: function() {
+                console.log("foo");
+            },
+            bar() {
+                console.log("bar");
+            }
+        };
+        var foo = new f.foo();
+        var bar = f.bar();
+    }
+    expect_stdout: [
+        "foo",
+        "bar",
+    ]
+    node_version: ">=6"
 }


### PR DESCRIPTION
New `compress` option `unsafe_methods` converts `{ m: function(){} }` to `{ m(){} }`. 

`ecma` must be set to `6` or greater to enable this transform.

Note: if enabled there is a risk of getting a "`<method name>` is not a constructor" TypeError should any code try to `new` the former function.

Fixes: #2321 