### PR TITLE
[ES6] fix `unsafe` join() on array literal with spread

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3437,7 +3437,9 @@ merge(Compressor.prototype, {
                 }
                 var elements = [];
                 var consts = [];
-                exp.expression.elements.forEach(function(el) {
+                for (var i = 0, len = exp.expression.elements.length; i < len; i++) {
+                    var el = exp.expression.elements[i];
+                    if (el instanceof AST_Expansion) break EXIT;
                     var value = el.evaluate(compressor);
                     if (value !== el) {
                         consts.push(value);
@@ -3450,7 +3452,7 @@ merge(Compressor.prototype, {
                         }
                         elements.push(el);
                     }
-                });
+                }
                 if (consts.length > 0) {
                     elements.push(make_node(AST_String, self, {
                         value: consts.join(separator)

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -839,3 +839,27 @@ class_name_can_be_preserved_with_reserved: {
         }
     }
 }
+
+issue_2345: {
+    options = {
+        evaluate: true,
+        side_effects: true,
+        unsafe: true,
+        unused: true,
+    }
+    input: {
+        console.log([...[3, 2, 1]].join("-"));
+        var a = [3, 2, 1];
+        console.log([...a].join("-"));
+    }
+    expect: {
+        console.log([...[3, 2, 1]].join("-"));
+        var a = [3, 2, 1];
+        console.log([...a].join("-"));
+    }
+    expect_stdout: [
+        "3-2-1",
+        "3-2-1",
+    ]
+    node_version: ">=6"
+}


### PR DESCRIPTION
Fixes #2345 