### PR TITLE
clean up lazy operator detection

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -404,8 +404,7 @@ merge(Compressor.prototype, {
                     pop();
                     return true;
                 }
-                if (node instanceof AST_Binary
-                    && (node.operator == "&&" || node.operator == "||")) {
+                if (node instanceof AST_Binary && lazy_op(node.operator)) {
                     node.left.walk(tw);
                     push();
                     node.right.walk(tw);
@@ -845,8 +844,7 @@ merge(Compressor.prototype, {
                                && (lvalues[node.name]
                                    || side_effects && !references_in_scope(node.definition()))
                             || (sym = lhs_or_def(node)) && get_symbol(sym).name in lvalues
-                            || parent instanceof AST_Binary
-                                && (parent.operator == "&&" || parent.operator == "||")
+                            || parent instanceof AST_Binary && lazy_op(parent.operator)
                             || parent instanceof AST_Case
                             || parent instanceof AST_Conditional
                             || parent instanceof AST_For
@@ -1435,9 +1433,10 @@ merge(Compressor.prototype, {
             return member(this.operator, unary_bool);
         });
         def(AST_Binary, function(){
-            return member(this.operator, binary_bool) ||
-                ( (this.operator == "&&" || this.operator == "||") &&
-                  this.left.is_boolean() && this.right.is_boolean() );
+            return member(this.operator, binary_bool)
+                || lazy_op(this.operator)
+                    && this.left.is_boolean()
+                    && this.right.is_boolean();
         });
         def(AST_Conditional, function(){
             return this.consequent.is_boolean() && this.alternative.is_boolean();
@@ -1506,6 +1505,7 @@ merge(Compressor.prototype, {
         node.DEFMETHOD("is_string", func);
     });
 
+    var lazy_op = makePredicate("&& ||");
     var unary_side_effects = makePredicate("delete ++ --");
 
     function is_lhs(node, parent) {
@@ -2702,14 +2702,12 @@ merge(Compressor.prototype, {
         def(AST_Binary, function(compressor, first_in_statement){
             var right = this.right.drop_side_effect_free(compressor);
             if (!right) return this.left.drop_side_effect_free(compressor, first_in_statement);
-            switch (this.operator) {
-              case "&&":
-              case "||":
+            if (lazy_op(this.operator)) {
                 if (right === this.right) return this;
                 var node = this.clone();
                 node.right = right;
                 return node;
-              default:
+            } else {
                 var left = this.left.drop_side_effect_free(compressor, first_in_statement);
                 if (!left) return this.right.drop_side_effect_free(compressor, first_in_statement);
                 return make_sequence(this, [ left, right ]);
@@ -3575,7 +3573,7 @@ merge(Compressor.prototype, {
                     }
                     if (cdr instanceof AST_Binary && !(cdr instanceof AST_Assign)) {
                         if (cdr.left.is_constant()) {
-                            if (cdr.operator == "||" || cdr.operator == "&&") {
+                            if (lazy_op(cdr.operator)) {
                                 expressions[++i] = expressions[j];
                                 break;
                             }
@@ -4075,8 +4073,7 @@ merge(Compressor.prototype, {
         // "x" + (y + "z")==>  "x" + y + "z"
         if (self.right instanceof AST_Binary
             && self.right.operator == self.operator
-            && (self.operator == "&&"
-                || self.operator == "||"
+            && (lazy_op(self.operator)
                 || (self.operator == "+"
                     && (self.right.left.is_string(compressor)
                         || (self.left.is_string(compressor)


### PR DESCRIPTION
Straight-forward replacement of `node.operator == "&&" || node.operator == "||"` & friends.