### PR TITLE
docs: Fix spelling and style

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ a double dash to prevent input files being used as option arguments:
                                 sequences.
     --config-file <file>        Read `minify()` options from JSON file.
     -d, --define <expr>[=value] Global definitions.
-    --ecma <version>            Specifiy ECMAScript release: 5, 6, 7 or 8.
+    --ecma <version>            Specify ECMAScript release: 5, 6, 7 or 8.
     --ie8                       Support non-standard Internet Explorer 8.
                                 Equivalent to setting `ie8: true` in `minify()`
                                 for `compress`, `mangle` and `output` options.
@@ -219,7 +219,7 @@ to prevent the `require`, `exports` and `$` names from being changed.
 is a separate step, different from variable name mangling.  Pass
 `--mangle-props` to enable it.  It will mangle all properties in the
 input code with the exception of built in DOM properties and properties
-in core javascript classes.  For example:
+in core JavaScript classes.  For example:
 
 ```javascript
 // example.js
@@ -234,7 +234,7 @@ x.bar_ = 2;
 x["baz_"] = 3;
 console.log(x.calc());
 ```
-Mangle all properties (except for javascript `builtins`):
+Mangle all properties (except for JavaScript `builtins`):
 ```bash
 $ uglifyjs example.js -c -m --mangle-props
 ```
@@ -1103,7 +1103,7 @@ in total it's a bit more than just using UglifyJS's own parser.
 ### Uglify Fast Minify Mode
 
 It's not well known, but whitespace removal and symbol mangling accounts
-for 95% of the size reduction in minified code for most javascript - not
+for 95% of the size reduction in minified code for most JavaScript - not
 elaborate code transforms. One can simply disable `compress` to speed up
 Uglify builds by 3 to 4 times. In this fast `mangle`-only mode Uglify has
 comparable minify speeds and gzip sizes to

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -44,7 +44,7 @@ program.option("-o, --output <file>", "Output file (default STDOUT).");
 program.option("--comments [filter]", "Preserve copyright comments in the output.");
 program.option("--config-file <file>", "Read minify() options from JSON file.");
 program.option("-d, --define <expr>[=value]", "Global definitions.", parse_js("define"));
-program.option("--ecma <version>", "Specifiy ECMAScript release: 5, 6, 7 or 8.");
+program.option("--ecma <version>", "Specify ECMAScript release: 5, 6, 7 or 8.");
 program.option("--ie8", "Support non-standard Internet Explorer 8.");
 program.option("--keep-fnames", "Do not mangle/drop function names. Useful for code relying on Function.prototype.name.");
 program.option("--name-cache <file>", "File to hold mangled name mappings.");


### PR DESCRIPTION
Fixes:

* Typo `Specifiy`
* Usage of `javascript` instead of `JavaScript` in copy