### PR TITLE
fix & improve `AST_TemplateString`

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -448,10 +448,8 @@ var AST_TemplateString = DEFNODE("TemplateString", "segments", {
     },
     _walk: function(visitor) {
         return visitor._visit(this, function(){
-            this.segments.forEach(function(seg, i){
-                if (i % 2 !== 0) {
-                    seg._walk(visitor);
-                }
+            this.segments.forEach(function(seg){
+                seg._walk(visitor);
             });
         });
     }

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2230,6 +2230,10 @@ merge(Compressor.prototype, {
                 return expression.has_side_effects(compressor);
             });
         });
+        def(AST_TemplateSegment, return_false);
+        def(AST_TemplateString, function(compressor){
+            return any(this.segments, compressor);
+        });
     })(function(node, func){
         node.DEFMETHOD("has_side_effects", func);
     });
@@ -2943,6 +2947,11 @@ merge(Compressor.prototype, {
         });
         def(AST_Expansion, function(compressor, first_in_statement){
             return this.expression.drop_side_effect_free(compressor, first_in_statement);
+        });
+        def(AST_TemplateSegment, return_null);
+        def(AST_TemplateString, function(compressor){
+            var values = trim(this.segments, compressor, first_in_statement);
+            return values && make_sequence(this, values);
         });
     })(function(node, func){
         node.DEFMETHOD("drop_side_effect_free", func);
@@ -4888,7 +4897,7 @@ merge(Compressor.prototype, {
         }
         self.segments = segments;
 
-        return self;
+        return segments.length == 1 ? make_node(AST_String, self, segments[0]) : self;
     });
 
     OPT(AST_PrefixedTemplateString, function(self, compressor){

--- a/lib/output.js
+++ b/lib/output.js
@@ -262,7 +262,7 @@ function OutputStream(options) {
         }
     } : noop;
 
-    var requireSemicolonChars = makePredicate("( [ + * / - , .");
+    var requireSemicolonChars = makePredicate("( [ + * / - , . `");
 
     function print(str) {
         str = String(str);

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -262,11 +262,7 @@ TreeTransformer.prototype = new TreeWalker;
     });
 
     _(AST_TemplateString, function(self, tw) {
-        for (var i = 0; i < self.segments.length; i++) {
-            if (!(self.segments[i] instanceof AST_TemplateSegment)) {
-                self.segments[i] = self.segments[i].transform(tw);
-            }
-        }
+        self.segments = do_list(self.segments, tw);
     });
 
     _(AST_PrefixedTemplateString, function(self, tw) {


### PR DESCRIPTION
- resolve `semicolons:false` ambiguity with tagged literals
- allow `side_effects` to work on template literals
- traverse `AST_TemplateString` properly

fixes #2401

/cc @kzc