### PR TITLE
consolidate single-use `function` reduction

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -315,12 +315,18 @@ merge(Compressor.prototype, {
                         d.fixed = false;
                     } else if (d.fixed) {
                         var value = node.fixed_value();
-                        if (unused) {
-                            d.single_use = value
-                                && d.references.length == 1
-                                && loop_ids[d.id] === in_loop
-                                && d.scope === node.scope
-                                && value.is_constant_expression();
+                        if (unused && value && d.references.length == 1) {
+                            if (value instanceof AST_Lambda) {
+                                d.single_use = d.scope === node.scope
+                                        && !(d.orig[0] instanceof AST_SymbolFunarg)
+                                    || value.is_constant_expression();
+                            } else {
+                                d.single_use = d.scope === node.scope
+                                    && loop_ids[d.id] === in_loop
+                                    && value.is_constant_expression();
+                                }
+                        } else {
+                            d.single_use = false;
                         }
                         if (is_modified(node, value, 0, is_immutable(value))) {
                             if (d.single_use) {
@@ -377,6 +383,10 @@ merge(Compressor.prototype, {
                     } else {
                         d.fixed = node;
                         mark(d, true);
+                        if (unused && d.references.length == 1) {
+                            d.single_use = d.scope === d.references[0].scope
+                                || node.is_constant_expression();
+                        }
                     }
                     var save_ids = safe_ids;
                     safe_ids = Object.create(null);
@@ -527,6 +537,7 @@ merge(Compressor.prototype, {
                 }
                 return true;
             }
+            return def.fixed instanceof AST_Defun;
         }
 
         function safe_to_assign(def, value) {
@@ -2165,7 +2176,7 @@ merge(Compressor.prototype, {
         }
         def(AST_Node, return_false);
         def(AST_Constant, return_true);
-        def(AST_Function, function(){
+        def(AST_Lambda, function(){
             var self = this;
             var result = true;
             self.walk(new TreeWalker(function(node) {
@@ -4221,10 +4232,7 @@ merge(Compressor.prototype, {
             if (compressor.option("unused")
                 && fixed
                 && d.references.length == 1
-                && (d.single_use || fixed instanceof AST_Function
-                    && !(d.scope.uses_arguments && d.orig[0] instanceof AST_SymbolFunarg)
-                    && !d.scope.uses_eval
-                    && compressor.find_parent(AST_Scope) === fixed.parent_scope)) {
+                && d.single_use) {
                 var value = fixed.optimize(compressor);
                 return value === fixed ? fixed.clone(true) : value;
             }

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -3379,3 +3379,75 @@ issue_2420_2: {
         "false false true",
     ]
 }
+
+issue_2423_1: {
+    options = {
+        reduce_vars: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        function c() { return 1; }
+        function p() { console.log(c()); }
+        p();
+        p();
+    }
+    expect: {
+        function p() { console.log(function() { return 1; }()); }
+        p();
+        p();
+    }
+}
+
+issue_2423_2: {
+    options = {
+        inline: true,
+        reduce_vars: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        function c() { return 1; }
+        function p() { console.log(c()); }
+        p();
+        p();
+    }
+    expect: {
+        function p() { console.log(1); }
+        p();
+        p();
+    }
+}
+
+issue_2423_3: {
+    options = {
+        reduce_vars: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        function c() { return 1; }
+        function p() { console.log(c()); }
+        p();
+    }
+    expect: {
+        (function() { console.log(function() { return 1; }()); })();
+    }
+}
+
+issue_2423_4: {
+    options = {
+        inline: true,
+        reduce_vars: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        function c() { return 1; }
+        function p() { console.log(c()); }
+        p();
+    }
+    expect: {
+        void console.log(1);
+    }
+}


### PR DESCRIPTION
fixes #2423

@kzc this combines #2053 from distant past with `.single_use` and should cover existing cases and a few more - please give it a spin :sunglasses: 