### PR TITLE
inline single-use functions that are not constant expressions

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3530,6 +3530,7 @@ merge(Compressor.prototype, {
                 && !exp.uses_arguments
                 && !exp.uses_eval
                 && exp.body.length == 1
+                && !exp.contains_this()
                 && all(exp.argnames, function(arg) {
                     return arg.__unused;
                 })
@@ -3542,23 +3543,6 @@ merge(Compressor.prototype, {
                         operator: "void",
                         expression: stat.body
                     });
-                }
-                if (value) {
-                    var tw = new TreeWalker(function(node) {
-                        if (!value) return true;
-                        if (node instanceof AST_SymbolRef) {
-                            var ref = node.scope.find_variable(node);
-                            if (ref && ref.scope.parent_scope === fn.parent_scope) {
-                                value = null;
-                                return true;
-                            }
-                        }
-                        if (node instanceof AST_This && !tw.find_parent(AST_Scope)) {
-                            value = null;
-                            return true;
-                        }
-                    });
-                    value.walk(tw);
                 }
                 if (value) {
                     var args = self.args.concat(value);

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -150,7 +150,9 @@ merge(Compressor.prototype, {
         }
         var passes = +this.options.passes || 1;
         var last_count = 1 / 0;
+        var mangle = { ie8: this.option("ie8") };
         for (var pass = 0; pass < passes; pass++) {
+            node.figure_out_scope(mangle);
             if (pass > 0 || this.option("reduce_vars"))
                 node.reset_opt_flags(this);
             node = node.transform(this);

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -137,11 +137,9 @@ function minify(files, options) {
         if (options.wrap) {
             toplevel = toplevel.wrap_commonjs(options.wrap);
         }
-        if (timings) timings.scope1 = Date.now();
-        if (options.compress) toplevel.figure_out_scope(options.mangle);
         if (timings) timings.compress = Date.now();
         if (options.compress) toplevel = new Compressor(options.compress).compress(toplevel);
-        if (timings) timings.scope2 = Date.now();
+        if (timings) timings.scope = Date.now();
         if (options.mangle) toplevel.figure_out_scope(options.mangle);
         if (timings) timings.mangle = Date.now();
         if (options.mangle) {
@@ -199,9 +197,9 @@ function minify(files, options) {
         if (timings) {
             timings.end = Date.now();
             result.timings = {
-                parse: 1e-3 * (timings.scope1 - timings.parse),
-                scope: 1e-3 * (timings.compress - timings.scope1 + timings.mangle - timings.scope2),
-                compress: 1e-3 * (timings.scope2 - timings.compress),
+                parse: 1e-3 * (timings.compress - timings.parse),
+                compress: 1e-3 * (timings.scope - timings.compress),
+                scope: 1e-3 * (timings.mangle - timings.scope),
                 mangle: 1e-3 * (timings.properties - timings.mangle),
                 properties: 1e-3 * (timings.output - timings.properties),
                 output: 1e-3 * (timings.end - timings.output),

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -508,3 +508,41 @@ issue_2114_2: {
     }
     expect_stdout: "2"
 }
+
+issue_2428: {
+    options = {
+        collapse_vars: true,
+        inline: true,
+        passes: 2,
+        pure_getters: "strict",
+        reduce_vars: true,
+        side_effects: true,
+        toplevel: true,
+        unsafe: true,
+        unused: true,
+    }
+    input: {
+        function bar(k) {
+            console.log(k);
+        }
+        function foo(x) {
+            return bar(x);
+        }
+        function baz(a) {
+            foo(a);
+        }
+        baz(42);
+        baz("PASS");
+    }
+    expect: {
+        function baz(a) {
+            console.log(a);
+        }
+        baz(42);
+        baz("PASS");
+    }
+    expect_stdout: [
+        "42",
+        "PASS",
+    ]
+}


### PR DESCRIPTION
fixes #2428

@kzc here we use `.figure_out_scope()` to repair the scope tree after function inlining and/or variable substitution.