### PR TITLE
fix `const` under `collapse_vars` without `unused`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1070,7 +1070,8 @@ merge(Compressor.prototype, {
                     candidates.push(expr);
                 } else if (expr instanceof AST_Sequence) {
                     expr.expressions.forEach(extract_candidates);
-                } else if (expr instanceof AST_Definitions) {
+                } else if (expr instanceof AST_Definitions
+                    && (compressor.option("unused") || !(expr instanceof AST_Const))) {
                     expr.definitions.forEach(function(var_def) {
                         if (var_def.value) candidates.push(var_def);
                     });

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -3355,3 +3355,25 @@ issue_2437: {
         }();
     }
 }
+
+issue_2453: {
+    options = {
+        collapse_vars: true,
+        toplevel: true,
+    }
+    input: {
+        function log(n) {
+            console.log(n);
+        }
+        const a = 42;
+        log(a);
+    }
+    expect: {
+        function log(n) {
+            console.log(n);
+        }
+        const a = 42;
+        log(a);
+    }
+    expect_stdout: "42"
+}


### PR DESCRIPTION
fixes #2453