### PR TITLE
remove hack in `collapse_vars`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1062,7 +1062,7 @@ merge(Compressor.prototype, {
                 var found = false;
                 return statements[stat_index].transform(new TreeTransformer(function(node, descend, in_list) {
                     if (found) return node;
-                    if (node === expr) {
+                    if (node === expr || node.body === expr) {
                         found = true;
                         if (node instanceof AST_VarDef) {
                             drop_decl(node.name.definition());
@@ -1076,7 +1076,6 @@ merge(Compressor.prototype, {
                       case 0: return null;
                       case 1: return node.expressions[0];
                     }
-                    if (node instanceof AST_SimpleStatement && !node.body) return null;
                 }));
             }
 

--- a/test/mocha/minify.js
+++ b/test/mocha/minify.js
@@ -297,4 +297,36 @@ describe("minify", function() {
             assert.strictEqual(result.code, "alert({bar:42});");
         });
     });
+
+    describe("collapse_vars", function() {
+        it("Should not produce invalid AST", function() {
+            var code = [
+                "function f(a) {",
+                "    a = x();",
+                "    return a;",
+                "}",
+                "f();",
+            ].join("\n");
+            var ast = Uglify.minify(code, {
+                compress: false,
+                mangle: false,
+                output: {
+                    ast: true
+                },
+            }).ast;
+            assert.strictEqual(ast.TYPE, "Toplevel");
+            assert.strictEqual(ast.body.length, 2);
+            assert.strictEqual(ast.body[0].TYPE, "Defun");
+            assert.strictEqual(ast.body[0].body.length, 2);
+            assert.strictEqual(ast.body[0].body[0].TYPE, "SimpleStatement");
+            var stat = ast.body[0].body[0];
+            Uglify.minify(ast, {
+                compress: {
+                    sequences: false
+                }
+            });
+            assert.ok(stat.body);
+            assert.strictEqual(stat.print_to_string(), "a=x()");
+        });
+    });
 });


### PR DESCRIPTION
fixes #2456

@kzc now the challenge is to come up with a test case :wink: 

`test/benchmark.js` gives identical results as master for:
- `-mc`
- `-mc sequences=0`
- `-mc unsafe,keep_fargs=0,pure_getters,passes=1000`