### PR TITLE
suppress `hoist_props` on `export`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2895,7 +2895,8 @@ merge(Compressor.prototype, {
         self.variables.each(function(def, name) {
             var_names[name] = true;
         });
-        return self.transform(new TreeTransformer(function(node) {
+        var tt = new TreeTransformer(function(node) {
+            if (node instanceof AST_Definitions && tt.parent() instanceof AST_Export) return node;
             if (node instanceof AST_VarDef) {
                 var sym = node.name, def, value;
                 if (sym.scope === self
@@ -2946,7 +2947,8 @@ merge(Compressor.prototype, {
                 var_names[name] = true;
                 return new_var;
             }
-        }));
+        });
+        return self.transform(tt);
     });
 
     // drop_side_effect_free()

--- a/lib/output.js
+++ b/lib/output.js
@@ -1361,6 +1361,7 @@ function OutputStream(options) {
             self.exported_value.print(output);
         } else if (self.exported_definition) {
             self.exported_definition.print(output);
+            if (self.exported_definition instanceof AST_Definitions) return;
         }
         if (self.module_name) {
             output.space();

--- a/test/compress/export.js
+++ b/test/compress/export.js
@@ -250,3 +250,13 @@ dynamic_import: {
         r.foo();
     }
 }
+
+trailing_comma: {
+    beautify = {
+        beautify: true,
+    }
+    input: {
+        export const a = 1;
+    }
+    expect_exact: "export const a = 1;"
+}

--- a/test/compress/hoist_props.js
+++ b/test/compress/hoist_props.js
@@ -511,3 +511,22 @@ new_this: {
     }
     expect_stdout: "1 2"
 }
+
+issue_2462: {
+    options = {
+        hoist_props: true,
+        reduce_vars: true,
+    }
+    input: {
+        export const Foo = {
+            a: 1,
+            b: () => 2
+        };
+    }
+    expect: {
+        export const Foo = {
+            a: 1,
+            b: () => 2
+        };
+    }
+}


### PR DESCRIPTION
Miscellaneous
- fix double semi-colons from `beautify` in `export`

fixes #2462

/cc @kzc