### PR TITLE
fix `AST_VarDef.may_throw()`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2399,6 +2399,7 @@ merge(Compressor.prototype, {
             return this.expression.may_throw(compressor);
         });
         def(AST_VarDef, function(compressor){
+            if (!this.value) return false;
             return this.value.may_throw(compressor);
         });
     })(function(node, func){

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -3785,3 +3785,23 @@ issue_2571_2: {
     }
     expect_stdout: "undefined"
 }
+
+may_throw: {
+    options = {
+        collapse_vars: true,
+    }
+    input: {
+        function f() {
+            var a_2 = function() {
+                var a;
+            }();
+        }
+    }
+    expect: {
+        function f() {
+            var a_2 = function() {
+                var a;
+            }();
+        }
+    }
+}


### PR DESCRIPTION
OT: here's an example of `test/sandbox.js` altering the test result, discovered by `test/ufuzz.js`
```js
$ node
> function f() {}
> for (var k in f) console.log(k, f[k]);
// nothing gets printed
> Function.prototype.toString = Function.prototype.valueOf = function() { return "[Func]" };
> for (var k in f) console.log(k, f[k]);
valueOf [Func]
```