### PR TITLE
minor clean-up for IIFE

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -808,10 +808,8 @@ merge(Compressor.prototype, {
     };
 
     function is_iife_call(node) {
-        if (node instanceof AST_Call && !(node instanceof AST_New)) {
-            return node.expression instanceof AST_Function || is_iife_call(node.expression);
-        }
-        return false;
+        if (node.TYPE != "Call") return false;
+        return node.expression instanceof AST_Function || is_iife_call(node.expression);
     }
 
     function is_undeclared_ref(node) {
@@ -3099,14 +3097,9 @@ merge(Compressor.prototype, {
             }
             if (this.operator == "typeof" && this.expression instanceof AST_SymbolRef) return null;
             var expression = this.expression.drop_side_effect_free(compressor, first_in_statement);
-            if (first_in_statement
-                && this instanceof AST_UnaryPrefix
-                && is_iife_call(expression)) {
-                if (expression === this.expression && this.operator.length === 1) return this;
-                return make_node(AST_UnaryPrefix, this, {
-                    operator: this.operator.length === 1 ? this.operator : "!",
-                    expression: expression
-                });
+            if (first_in_statement && expression && is_iife_call(expression)) {
+                if (expression === this.expression && this.operator == "!") return this;
+                return expression.negate(compressor, first_in_statement);
             }
             return expression;
         });


### PR DESCRIPTION
- faster exact type match
- aggressively convert to `!`