### PR TITLE
drop local assign-only variable in `return`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -4666,6 +4666,24 @@ merge(Compressor.prototype, {
     var ASSIGN_OPS = [ '+', '-', '/', '*', '%', '>>', '<<', '>>>', '|', '^', '&' ];
     var ASSIGN_OPS_COMMUTATIVE = [ '*', '|', '^', '&' ];
     OPT(AST_Assign, function(self, compressor){
+        if (compressor.option("dead_code")
+            && self.left instanceof AST_SymbolRef
+            && self.left.definition().scope === compressor.find_parent(AST_Lambda)) {
+            var level = 0, node, parent = self;
+            do {
+                node = parent;
+                parent = compressor.parent(level++);
+                if (parent instanceof AST_Exit) {
+                    if (self.operator == "=") return self.right;
+                    return make_node(AST_Binary, self, {
+                        operator: self.operator.slice(0, -1),
+                        left: self.left,
+                        right: self.right
+                    }).optimize(compressor);
+                }
+            } while (parent instanceof AST_Binary && parent.right === node
+                || parent instanceof AST_Sequence && parent.tail_node() === node);
+        }
         self = self.lift_sequences(compressor);
         if (self.operator == "=" && self.left instanceof AST_SymbolRef && self.right instanceof AST_Binary) {
             // x = expr1 OP expr2

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -591,7 +591,7 @@ collapse_vars_switch: {
 
 collapse_vars_assignment: {
     options = {
-        collapse_vars:true, sequences:true, properties:true, dead_code:true, conditionals:true,
+        collapse_vars:true, sequences:true, properties:true, conditionals:true,
         comparisons:true, evaluate:true, booleans:true, loops:true, unused:true, hoist_funs:true,
         keep_fargs:true, if_return:true, join_vars:true, side_effects:true
     }
@@ -639,7 +639,7 @@ collapse_vars_assignment: {
             return a = a;
         }
         function f1(c) {
-            return 1 - 3 / c
+            return 1 - 3 / c;
         }
         function f2(c) {
             return log(c = 3 / c - 7);
@@ -664,7 +664,7 @@ collapse_vars_assignment: {
 
 collapse_vars_lvalues: {
     options = {
-        collapse_vars:true, sequences:true, properties:true, dead_code:true, conditionals:true,
+        collapse_vars:true, sequences:true, properties:true, conditionals:true,
         comparisons:true, evaluate:true, booleans:true, loops:true, unused:"keep_assign",
         hoist_funs:true, keep_fargs:true, if_return:true, join_vars:true,
         side_effects:true
@@ -697,7 +697,7 @@ collapse_vars_lvalues: {
 
 collapse_vars_lvalues_drop_assign: {
     options = {
-        collapse_vars:true, sequences:true, properties:true, dead_code:true, conditionals:true,
+        collapse_vars:true, sequences:true, properties:true, conditionals:true,
         comparisons:true, evaluate:true, booleans:true, loops:true, unused:true, hoist_funs:true,
         keep_fargs:true, if_return:true, join_vars:true, side_effects:true, passes:3
     }
@@ -729,7 +729,7 @@ collapse_vars_lvalues_drop_assign: {
 
 collapse_vars_misc1: {
     options = {
-        collapse_vars:true, sequences:true, properties:true, dead_code:true, conditionals:true,
+        collapse_vars:true, sequences:true, properties:true, conditionals:true,
         comparisons:true, evaluate:true, booleans:true, loops:true, unused:true, hoist_funs:true,
         keep_fargs:true, if_return:true, join_vars:true, side_effects:true,
         reduce_funcs: true, reduce_vars:true

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -417,3 +417,93 @@ global_fns: {
         "RangeError",
     ]
 }
+
+collapse_vars_assignment: {
+    options = {
+        collapse_vars: true,
+        dead_code: true,
+        passes: 2,
+        unused: true,
+    }
+    input: {
+        function f0(c) {
+            var a = 3 / c;
+            return a = a;
+        }
+    }
+    expect: {
+        function f0(c) {
+            return 3 / c;
+        }
+    }
+}
+
+collapse_vars_lvalues_drop_assign: {
+    options = {
+        collapse_vars: true,
+        dead_code: true,
+        unused: true,
+    }
+    input: {
+        function f0(x) { var i = ++x; return x += i; }
+        function f1(x) { var a = (x -= 3); return x += a; }
+        function f2(x) { var z = x, a = ++z; return z += a; }
+    }
+    expect: {
+        function f0(x) { var i = ++x; return x + i; }
+        function f1(x) { var a = (x -= 3); return x + a; }
+        function f2(x) { var z = x, a = ++z; return z + a; }
+    }
+}
+
+collapse_vars_misc1: {
+    options = {
+        collapse_vars: true,
+        dead_code: true,
+        unused: true,
+    }
+    input: {
+        function f10(x) { var a = 5, b = 3; return a += b; }
+        function f11(x) { var a = 5, b = 3; return a += --b; }
+    }
+    expect: {
+        function f10(x) { return 5 + 3; }
+        function f11(x) { var b = 3; return 5 + --b; }
+    }
+}
+
+return_assignment: {
+    options = {
+        dead_code: true,
+    }
+    input: {
+        function f1(a, b, c) {
+            return a = x(), b = y(), b = a && (c >>= 5);
+        }
+        function f2() {
+            return e = x();
+        }
+        function f3(e) {
+            return e = x();
+        }
+        function f4() {
+            var e;
+            return e = x();
+        }
+    }
+    expect: {
+        function f1(a, b, c) {
+            return a = x(), b = y(), a && (c >> 5);
+        }
+        function f2() {
+            return e = x();
+        }
+        function f3(e) {
+            return x();
+        }
+        function f4() {
+            var e;
+            return x();
+        }
+    }
+}

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -475,6 +475,7 @@ collapse_vars_misc1: {
 return_assignment: {
     options = {
         dead_code: true,
+        unused: true,
     }
     input: {
         function f1(a, b, c) {
@@ -493,7 +494,7 @@ return_assignment: {
     }
     expect: {
         function f1(a, b, c) {
-            return a = x(), b = y(), a && (c >> 5);
+            return a = x(), y(), a && (c >> 5);
         }
         function f2() {
             return e = x();
@@ -502,7 +503,6 @@ return_assignment: {
             return x();
         }
         function f4() {
-            var e;
             return x();
         }
     }


### PR DESCRIPTION
`return e = x();` turns up quite often as a by-product of other uglify rules.

This PR turns them into `return x();`