### PR TITLE
improve `collapse_vars`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1014,7 +1014,9 @@ merge(Compressor.prototype, {
                     var replace_all = value_def;
                     if (!replace_all && lhs instanceof AST_SymbolRef) {
                         var def = lhs.definition();
-                        replace_all = def.references.length - def.replaced == 1;
+                        if (def.references.length - def.replaced == (candidate instanceof AST_VarDef ? 1 : 2)) {
+                            replace_all = true;
+                        }
                     }
                     var side_effects = value_has_side_effects(candidate);
                     var may_throw = candidate.may_throw(compressor);
@@ -1097,6 +1099,9 @@ merge(Compressor.prototype, {
                 if (expr instanceof AST_Assign && !expr.left.has_side_effects(compressor)
                     || expr instanceof AST_Unary && (expr.operator == "++" || expr.operator == "--")) {
                     candidates.push(expr);
+                } else if (expr instanceof AST_Call) {
+                    extract_candidates(expr.expression);
+                    expr.args.forEach(extract_candidates);
                 } else if (expr instanceof AST_Case) {
                     extract_candidates(expr.expression);
                 } else if (expr instanceof AST_Conditional) {
@@ -1125,6 +1130,7 @@ merge(Compressor.prototype, {
 
             function find_stop(node, level) {
                 var parent = scanner.parent(level);
+                if (parent instanceof AST_Call) return node;
                 if (parent instanceof AST_Case) return node;
                 if (parent instanceof AST_Conditional) return node;
                 if (parent instanceof AST_Exit) return node;

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -1993,10 +1993,8 @@ undeclared: {
     }
     expect: {
         function f(x, y) {
-            var a;
-            a = x;
             b = y;
-            return b + a;
+            return b + x;
         }
     }
 }
@@ -3975,6 +3973,24 @@ cascade_switch: {
               case b(a = x()):
                 break;
             }
+        }
+    }
+}
+
+cascade_call: {
+    options = {
+        collapse_vars: true,
+        unused: true,
+    }
+    input: {
+        function f(a) {
+            var b;
+            return x((b = a, y(b)));
+        }
+    }
+    expect: {
+        function f(a) {
+            return x(y(a));
         }
     }
 }


### PR DESCRIPTION
- handle single-use assignments other than `AST_VarDef`
- scan `AST_Call` for candidates