### PR TITLE
account for `catch` variable when `inline`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3924,10 +3924,20 @@ merge(Compressor.prototype, {
         return self;
 
         function can_flatten_args(fn) {
-            var scope = compressor.find_parent(AST_Scope);
+            var scope, level = 0;
+            var catches = Object.create(null);
+            do {
+                scope = compressor.parent(level++);
+                if (scope instanceof AST_Catch) {
+                    catches[scope.argname.name] = true;
+                }
+            } while (!(scope instanceof AST_Scope));
             var safe_to_inject = compressor.toplevel.vars || !(scope instanceof AST_Toplevel);
             return all(fn.argnames, function(arg) {
-                return arg.__unused || safe_to_inject && !scope.var_names()[arg.name];
+                return arg.__unused
+                    || safe_to_inject
+                        && !catches[arg.name]
+                        && !scope.var_names()[arg.name];
             }) && scope;
         }
 

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -847,3 +847,79 @@ issue_2601_2: {
     }
     expect_stdout: "PASS"
 }
+
+issue_2604_1: {
+    options = {
+        inline: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        var a = "FAIL";
+        (function() {
+            try {
+                throw 1;
+            } catch (b) {
+                (function f(b) {
+                    b && b();
+                })();
+                b && (a = "PASS");
+            }
+        })();
+        console.log(a);
+    }
+    expect: {
+        var a = "FAIL";
+        (function() {
+            try {
+                throw 1;
+            } catch (b) {
+                (function(b) {
+                    b && b();
+                })();
+                b && (a = "PASS");
+            }
+        })();
+        console.log(a);
+    }
+    expect_stdout: "PASS"
+}
+
+issue_2604_2: {
+    rename = true
+    options = {
+        evaluate: true,
+        inline: true,
+        passes: 3,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+    }
+    mangle = {}
+    input: {
+        var a = "FAIL";
+        (function() {
+            try {
+                throw 1;
+            } catch (b) {
+                (function f(b) {
+                    b && b();
+                })();
+                b && (a = "PASS");
+            }
+        })();
+        console.log(a);
+    }
+    expect: {
+        var a = "FAIL";
+        (function() {
+            try {
+                throw 1;
+            } catch (o) {
+                o && (a = "PASS");
+            }
+        })();
+        console.log(a);
+    }
+    expect_stdout: "PASS"
+}


### PR DESCRIPTION
fixes #2604