### PR TITLE
drop property assignment to constants

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1708,6 +1708,11 @@ merge(Compressor.prototype, {
             return this.consequent._dot_throw(compressor)
                 || this.alternative._dot_throw(compressor);
         })
+        def(AST_Dot, function(compressor) {
+            if (!is_strict(compressor)) return false;
+            if (this.expression instanceof AST_Function && this.property == "prototype") return false;
+            return true;
+        });
         def(AST_Sequence, function(compressor) {
             return this.tail_node()._dot_throw(compressor);
         });
@@ -3184,8 +3189,14 @@ merge(Compressor.prototype, {
             }
         });
         def(AST_Assign, function(compressor){
-            this.write_only = !this.left.has_side_effects(compressor);
-            return this;
+            var left = this.left;
+            if (left.has_side_effects(compressor)) return this;
+            this.write_only = true;
+            while (left instanceof AST_PropAccess) {
+                left = left.expression;
+            }
+            if (left instanceof AST_Symbol) return this;
+            return this.right.drop_side_effect_free(compressor);
         });
         def(AST_Conditional, function(compressor){
             var consequent = this.consequent.drop_side_effect_free(compressor);

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -1054,3 +1054,43 @@ issue_2513: {
         "undefined undefined",
     ]
 }
+
+const_prop_assign_strict: {
+    options = {
+        pure_getters: "strict",
+        side_effects: true,
+    }
+    input: {
+        function Simulator() {
+            /abc/.index = 1;
+            this._aircraft = [];
+        }
+        (function() {}).prototype.destroy = x();
+    }
+    expect: {
+        function Simulator() {
+            this._aircraft = [];
+        }
+        x();
+    }
+}
+
+const_prop_assign_pure: {
+    options = {
+        pure_getters: true,
+        side_effects: true,
+    }
+    input: {
+        function Simulator() {
+            /abc/.index = 1;
+            this._aircraft = [];
+        }
+        (function() {}).prototype.destroy = x();
+    }
+    expect: {
+        function Simulator() {
+            this._aircraft = [];
+        }
+        x();
+    }
+}


### PR DESCRIPTION
Only difference is with `ember.prod.js` under `-mc passes=2` (or more)

#### master
```
http://builds.emberjs.com/tags/v2.11.0/ember.prod.js
- parse: 0.750s
- rename: 0.515s
- compress: 5.922s
- scope: 0.156s
- mangle: 0.313s
- properties: 0.000s
- output: 0.234s
- total: 7.890s

Original: 1852178 bytes
Uglified: 525313 bytes
GZipped:  128593 bytes
SHA1 sum: 5604c9f51b22ae0d38f652ed429e0e179c6261af
```

#### This PR
```
http://builds.emberjs.com/tags/v2.11.0/ember.prod.js
- parse: 0.734s
- rename: 0.594s
- compress: 5.828s
- scope: 0.141s
- mangle: 0.312s
- properties: 0.000s
- output: 0.313s
- total: 7.922s

Original: 1852178 bytes
Uglified: 525190 bytes
GZipped:  128563 bytes
SHA1 sum: 429e537397492cd76cdaf500f12f3f49d900ea5f
```