### PR TITLE
handle global constant collision with local variable after `inline`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -4028,13 +4028,16 @@ merge(Compressor.prototype, {
                         expressions.unshift(value || make_node(AST_Undefined, self));
                     }
                 } else {
+                    var def = name.definition();
                     scope.var_names()[name.name] = true;
+                    scope.variables.set(name.name, def);
+                    scope.enclosed.push(def);
                     decls.unshift(make_node(AST_VarDef, name, {
                         name: name,
                         value: null
                     }));
                     var sym = make_node(AST_SymbolRef, name, name);
-                    name.definition().references.push(sym);
+                    def.references.push(sym);
                     expressions.unshift(make_node(AST_Assign, self, {
                         operator: "=",
                         left: sym,

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -1049,3 +1049,37 @@ unsafe_call_2: {
     }
     expect_stdout: true
 }
+
+issue_2616: {
+    options = {
+        evaluate: true,
+        inline: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        var c = "FAIL";
+        (function() {
+            function f() {
+                function g(NaN) {
+                    (true << NaN) - 0/0 || (c = "PASS");
+                }
+                g([]);
+            }
+            f();
+        })();
+        console.log(c);
+    }
+    expect: {
+        var c = "FAIL";
+        (function() {
+            (function() {
+                NaN = [], (true << NaN) - 0/0 || (c = "PASS");
+                var NaN;
+            })();
+        })();
+        console.log(c);
+    }
+    expect_stdout: "PASS"
+}


### PR DESCRIPTION
fixes #2616