### PR TITLE
extend `test/ufuzz.js` to `inline` & `reduce_funcs`

### DIFF
--- a/test/ufuzz.json
+++ b/test/ufuzz.json
@@ -15,15 +15,12 @@
     },
     {},
     {
-        "compress": {
-            "hoist_props": true
-        },
         "toplevel": true
     },
     {
         "compress": {
             "keep_fargs": false,
-            "passes": 3
+            "passes": 100
         }
     }
 ]


### PR DESCRIPTION
https://github.com/mishoo/UglifyJS2/pull/2533#issuecomment-347728278

@kzc I've also adjusted `test/ufuzz.json`, the highlight being `unsafe` as `rename` should now circumvent any corner cases regarding `Infinity`, `NaN` or `undefined`.