### PR TITLE
Simplify transform

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -60,12 +60,9 @@ TreeTransformer.prototype = new TreeWalker;
             tw.push(this);
             if (tw.before) x = tw.before(this, descend, in_list);
             if (x === undefined) {
-                if (!tw.after) {
-                    x = this;
-                    descend(x, tw);
-                } else {
-                    tw.stack[tw.stack.length - 1] = x = this;
-                    descend(x, tw);
+                x = this;
+                descend(x, tw);
+                if (tw.after) {
                     y = tw.after(x, in_list);
                     if (y !== undefined) x = y;
                 }


### PR DESCRIPTION
Simplify `transform` as noted in https://github.com/mishoo/UglifyJS2/pull/940#discussion_r157693029

This is a code cleanup only, the cloning itself was removed long time ago.

Please note again: the documentation at http://lisperator.net/uglifyjs/transform mentions cloning behaviour several times:

> the tree walker will clone the current node, descend into it

> after the node has been cloned and its children transformed. If your after visitor returns a value !== undefined, then that value will replace the current node in the tree (that's non-destructive, since the node was cloned first)

> A quick note, because the transformer itself will clone nodes if an “after” visitor is present, we could also clone a whole tree with the following (might even be a bit more efficient):

It should be changed accordingly.

A cloning transformer now needs to do:

`ast.transform(new UglifyJS.TreeTransformer(null, function(node){return node.clone()}));`
