### PR TITLE
`arrows` fix for object literal methods containing `arguments`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -5414,6 +5414,7 @@ merge(Compressor.prototype, {
         // p(){return x;} ---> p:()=>x
         if (compressor.option("arrows")
             && compressor.parent() instanceof AST_Object
+            && !self.value.uses_arguments
             && self.value.body.length == 1
             && self.value.body[0] instanceof AST_Return
             && self.value.body[0].value

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -5415,6 +5415,7 @@ merge(Compressor.prototype, {
         if (compressor.option("arrows")
             && compressor.parent() instanceof AST_Object
             && !self.value.uses_arguments
+            && !self.value.uses_eval
             && self.value.body.length == 1
             && self.value.body[0] instanceof AST_Return
             && self.value.body[0].value

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -1154,7 +1154,7 @@ array_literal_with_spread_4: {
     node_version: ">=6"
 }
 
-methods_using_arguments: {
+object_literal_method_using_arguments: {
     options = {
         arrows: true,
     }
@@ -1164,12 +1164,6 @@ methods_using_arguments: {
                 return arguments[0];
             }
         }).m("PASS"));
-
-        console.log(new class {
-            m() {
-                return arguments[0];
-            }
-        }().m("PASS"));
     }
     expect: {
         console.log(({
@@ -1177,16 +1171,29 @@ methods_using_arguments: {
                 return arguments[0];
             }
         }).m("PASS"));
+    }
+    expect_stdout: "PASS"
+    node_version: ">=6"
+}
 
+class_method_using_arguments: {
+    options = {
+        arrows: true,
+    }
+    input: {
         console.log(new class {
             m() {
                 return arguments[0];
             }
         }().m("PASS"));
     }
-    expect_stdout: [
-        "PASS",
-        "PASS",
-    ]
+    expect: {
+        console.log(new class {
+            m() {
+                return arguments[0];
+            }
+        }().m("PASS"));
+    }
+    expect_stdout: "PASS"
     node_version: ">=6"
 }

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -1153,3 +1153,40 @@ array_literal_with_spread_4: {
     ]
     node_version: ">=6"
 }
+
+methods_using_arguments: {
+    options = {
+        arrows: true,
+    }
+    input: {
+        console.log(({
+            m() {
+                return arguments[0];
+            }
+        }).m("PASS"));
+
+        console.log(new class {
+            m() {
+                return arguments[0];
+            }
+        }().m("PASS"));
+    }
+    expect: {
+        console.log(({
+            m() {
+                return arguments[0];
+            }
+        }).m("PASS"));
+
+        console.log(new class {
+            m() {
+                return arguments[0];
+            }
+        }().m("PASS"));
+    }
+    expect_stdout: [
+        "PASS",
+        "PASS",
+    ]
+    node_version: ">=6"
+}


### PR DESCRIPTION
fixes #2631 