### PR TITLE
handle non-ES5 node types in `inline`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -4277,9 +4277,11 @@ merge(Compressor.prototype, {
                 } else if (scope instanceof AST_Catch) {
                     catches[scope.argname.name] = true;
                 }
-            } while (!(scope instanceof AST_Scope));
+            } while (!(scope instanceof AST_Scope) || scope instanceof AST_Arrow);
             var safe_to_inject = compressor.toplevel.vars || !(scope instanceof AST_Toplevel);
             return all(fn.argnames, function(arg) {
+                if (arg instanceof AST_DefaultAssign) return arg.left.__unused;
+                if (arg instanceof AST_Destructuring) return false;
                 if (arg instanceof AST_Expansion) return arg.expression.__unused;
                 return arg.__unused
                     || safe_to_inject
@@ -4295,7 +4297,7 @@ merge(Compressor.prototype, {
             for (var len = fn.argnames.length, i = len; --i >= 0;) {
                 var name = fn.argnames[i];
                 var value = self.args[i];
-                if (name.__unused || name instanceof AST_Expansion) {
+                if (name.__unused || !name.name) {
                     if (value || expressions.length) {
                         expressions.unshift(value || make_node(AST_Undefined, self));
                     }

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -1456,3 +1456,95 @@ issue_2630_5: {
     }
     expect_stdout: "155"
 }
+
+issue_2647_1: {
+    options = {
+        inline: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        (function(n, o = "FAIL") {
+            console.log(n);
+        })("PASS");
+        (function(n, o = "PASS") {
+            console.log(o);
+        })("FAIL");
+        (function(o = "PASS") {
+            console.log(o);
+        })();
+        (function(n, {o = "FAIL"}) {
+            console.log(n);
+        })("PASS", {});
+    }
+    expect: {
+        console.log("PASS");
+        (function(n, o = "PASS") {
+            console.log(o);
+        })();
+        (function(o = "PASS") {
+            console.log(o);
+        })();
+        (function(n, {o = "FAIL"}) {
+            console.log("PASS");
+        })(0, {});
+    }
+    expect_stdout: [
+        "PASS",
+        "PASS",
+        "PASS",
+        "PASS",
+    ]
+    node_version: ">=6"
+}
+
+issue_2647_2: {
+    options = {
+        collapse_vars: true,
+        inline: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        (function() {
+            function foo(x) {
+                return x.toUpperCase();
+            }
+            console.log((() => foo("pass"))());
+        }());
+    }
+    expect: {
+        (function() {
+            console.log("pass".toUpperCase());
+        })();
+    }
+    expect_stdout: "PASS"
+    node_version: ">=4"
+}
+
+issue_2647_3: {
+    options = {
+        collapse_vars: true,
+        inline: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        (function() {
+            function foo(x) {
+                return x.toUpperCase();
+            }
+            console.log((() => {
+                return foo("pass");
+            })());
+        }());
+    }
+    expect: {
+        (function() {
+            console.log("pass".toUpperCase());
+        })();
+    }
+    expect_stdout: "PASS"
+    node_version: ">=4"
+}


### PR DESCRIPTION
fixes #2647