### PR TITLE
improve `unused` over duplicate variable names

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2645,14 +2645,14 @@ merge(Compressor.prototype, {
         var tw = new TreeWalker(function(node, descend){
             if (node === self) return;
             if (node instanceof AST_Defun) {
+                var node_def = node.name.definition();
                 if (!drop_funcs && scope === self) {
-                    var node_def = node.name.definition();
                     if (!(node_def.id in in_use_ids)) {
                         in_use_ids[node_def.id] = true;
                         in_use.push(node_def);
                     }
                 }
-                initializations.add(node.name.name, node);
+                initializations.add(node_def.id, node);
                 return true; // don't go in nested scopes
             }
             if (node instanceof AST_SymbolFunarg && scope === self) {
@@ -2671,7 +2671,7 @@ merge(Compressor.prototype, {
                         }
                     }
                     if (def.value) {
-                        initializations.add(def.name.name, def.value);
+                        initializations.add(node_def.id, def.value);
                         if (def.value.has_side_effects(compressor)) {
                             def.value.walk(tw);
                         }
@@ -2686,13 +2686,10 @@ merge(Compressor.prototype, {
         // initialization code to figure out if it uses other
         // symbols (that may not be in_use).
         tw = new TreeWalker(scan_ref_scoped);
-        for (var i = 0; i < in_use.length; ++i) {
-            in_use[i].orig.forEach(function(decl){
-                // undeclared globals will be instanceof AST_SymbolRef
-                var init = initializations.get(decl.name);
-                if (init) init.forEach(function(init){
-                    init.walk(tw);
-                });
+        for (var i = 0; i < in_use.length; i++) {
+            var init = initializations.get(in_use[i].id);
+            if (init) init.forEach(function(init) {
+                init.walk(tw);
             });
         }
         // pass 3: we should drop declarations not in_use

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -1413,3 +1413,24 @@ issue_2516_2: {
         Baz(2);
     }
 }
+
+defun_lambda_same_name: {
+    options = {
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        function f(n) {
+            return n ? n * f(n - 1) : 1;
+        }
+        console.log(function f(n) {
+            return n ? n * f(n - 1) : 1;
+        }(5));
+    }
+    expect: {
+        console.log(function f(n) {
+            return n ? n * f(n - 1) : 1;
+        }(5));
+    }
+    expect_stdout: "120"
+}


### PR DESCRIPTION
@kzc this one is probably as old as `drop_unused()` itself - and `rename` would actually workaround it:
```js
$ cat test.js
function f(n) {
    return n ? n * f(n - 1) : 1;
}

console.log(function f(n) {
    return n ? n * f(n - 1) : 1;
}(5));
```
Before this PR:
```sh
$ uglifyjs test.js -bc toplevel
function f(n) {
    return n ? n * f(n - 1) : 1;
}

console.log(function f(n) {
    return n ? n * f(n - 1) : 1;
}(5));

$ uglifyjs test.js -bmc toplevel
console.log(function n(o) {
    return o ? o * n(o - 1) : 1;
}(5));
```
After this PR:
```sh
$ uglifyjs test.js -bc toplevel
console.log(function f(n) {
    return n ? n * f(n - 1) : 1;
}(5));
```
So if it weren't for #2628 we could have just left this alone :ghost: 