### PR TITLE
suppress `inline` within substituted `AST_Scope`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3985,7 +3985,7 @@ merge(Compressor.prototype, {
             do {
                 scope = compressor.parent(++level);
                 if (scope instanceof AST_SymbolRef) {
-                    scope = scope.fixed_value();
+                    if (scope.fixed_value() instanceof AST_Scope) return false;
                 } else if (scope instanceof AST_Catch) {
                     catches[scope.argname.name] = true;
                 }

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -1447,3 +1447,33 @@ recursive_inline: {
     }
     expect: {}
 }
+
+issue_2657: {
+    options = {
+        inline: true,
+        reduce_vars: true,
+        sequences: true,
+        unused: true,
+    }
+    input: {
+        "use strict";
+        console.log(function f() {
+            return h;
+            function g(b) {
+                return b || b();
+            }
+            function h(a) {
+                g(a);
+                return a;
+            }
+        }()(42));
+    }
+    expect: {
+        "use strict";
+        console.log(function(a) {
+            return b = a, b || b(), a;
+            var b;
+        }(42));
+    }
+    expect_stdout: "42"
+}


### PR DESCRIPTION
fixes #2657