### PR TITLE
reduce hoisting declarations

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -325,9 +325,14 @@ merge(Compressor.prototype, {
             def.single_use = undefined;
         }
 
-        function reset_variables(compressor, node) {
+        function reset_variables(tw, compressor, node) {
             node.variables.each(function(def) {
                 reset_def(compressor, def);
+                if (def.fixed === undefined && def.orig[0].TYPE == "SymbolVar") {
+                    def.fixed = null;
+                    def.safe_ids = tw.safe_ids;
+                    mark(tw, def, true);
+                }
             });
         }
 
@@ -356,6 +361,11 @@ merge(Compressor.prototype, {
         }
 
         function safe_to_assign(tw, def, value) {
+            if (def.fixed === null && def.safe_ids) {
+                def.safe_ids[def.id] = false;
+                delete def.safe_ids;
+                return true;
+            }
             if (!HOP(tw.safe_ids, def.id)) return false;
             if (!safe_to_read(tw, def)) return false;
             if (def.fixed === false) return false;
@@ -462,10 +472,7 @@ merge(Compressor.prototype, {
             var node = this;
             if (node.operator != "=" || !(node.left instanceof AST_SymbolRef)) return;
             var d = node.left.definition();
-            if (safe_to_assign(tw, d, node.right)
-                || d.fixed === undefined && all(d.orig, function(sym) {
-                    return sym instanceof AST_SymbolVar;
-                })) {
+            if (safe_to_assign(tw, d, node.right)) {
                 d.references.push(node.left);
                 d.fixed = function() {
                     return node.right;
@@ -495,7 +502,6 @@ merge(Compressor.prototype, {
             return true;
         });
         def(AST_Defun, function(tw, descend, compressor) {
-            reset_variables(compressor, this);
             this.inlined = false;
             var d = this.name.definition();
             if (compressor.exposed(d) || safe_to_read(tw, d)) {
@@ -508,6 +514,7 @@ merge(Compressor.prototype, {
             }
             var save_ids = tw.safe_ids;
             tw.safe_ids = Object.create(null);
+            reset_variables(tw, compressor, this);
             descend();
             tw.safe_ids = save_ids;
             return true;
@@ -555,9 +562,9 @@ merge(Compressor.prototype, {
         });
         def(AST_Function, function(tw, descend, compressor) {
             var node = this;
-            reset_variables(compressor, node);
             node.inlined = false;
             push(tw);
+            reset_variables(tw, compressor, node);
             var iife;
             if (!node.name
                 && (iife = tw.parent()) instanceof AST_Call
@@ -644,7 +651,7 @@ merge(Compressor.prototype, {
             this.globals.each(function(def) {
                 reset_def(compressor, def);
             });
-            reset_variables(compressor, this);
+            reset_variables(tw, compressor, this);
         });
         def(AST_Try, function(tw) {
             push(tw);
@@ -669,8 +676,6 @@ merge(Compressor.prototype, {
                     tw.loop_ids[d.id] = tw.in_loop;
                     mark(tw, d, false);
                     descend();
-                } else {
-                    d.fixed = null;
                 }
                 mark(tw, d, true);
                 return true;
@@ -4008,8 +4013,8 @@ merge(Compressor.prototype, {
                 var name = fn.argnames[i];
                 var value = self.args[i];
                 if (name.__unused) {
-                    if (value || expressions.length) {
-                        expressions.unshift(value || make_node(AST_Undefined, self));
+                    if (value) {
+                        expressions.unshift(value);
                     }
                 } else {
                     var def = name.definition();
@@ -4024,10 +4029,10 @@ merge(Compressor.prototype, {
                     }));
                     var sym = make_node(AST_SymbolRef, name, name);
                     def.references.push(sym);
-                    expressions.unshift(make_node(AST_Assign, self, {
+                    if (value) expressions.unshift(make_node(AST_Assign, self, {
                         operator: "=",
                         left: sym,
-                        right: value || make_node(AST_Undefined, self)
+                        right: value
                     }));
                 }
             }

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -2312,8 +2312,7 @@ delay_def: {
     }
     expect: {
         function f() {
-            return a;
-            var a;
+            return;
         }
         function g() {
             return a;
@@ -2322,6 +2321,28 @@ delay_def: {
         console.log(f(), g());
     }
     expect_stdout: true
+}
+
+delay_def_lhs: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        console.log(function() {
+            long_name++;
+            return long_name;
+            var long_name;
+        }());
+    }
+    expect: {
+        console.log(function() {
+            long_name++;
+            return long_name;
+            var long_name;
+        }());
+    }
+    expect_stdout: "NaN"
 }
 
 booleans: {
@@ -4951,4 +4972,30 @@ issue_2598: {
         console.log(g(false) === g(null));
     }
     expect_stdout: "true"
+}
+
+var_if: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        function f() {
+            if (x()) {
+                var a;
+                if (!g) a = true;
+                if (a) g();
+            }
+        }
+    }
+    expect: {
+        function f() {
+            if (x()) {
+                var a;
+                if (!g) a = true;
+                if (a) g();
+            }
+        }
+    }
 }


### PR DESCRIPTION
paving the way for `inline` to omit all those `a = void 0, ...; var a;`