### PR TITLE
enhance `join_vars` & `sequences`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -884,6 +884,7 @@ merge(Compressor.prototype, {
             }
             if (compressor.sequences_limit > 0) {
                 sequencesize(statements, compressor);
+                sequencesize_2(statements, compressor);
             }
             if (compressor.option("join_vars")) {
                 join_consecutive_vars(statements, compressor);
@@ -1537,6 +1538,12 @@ merge(Compressor.prototype, {
             });
         }
 
+        function declarations_only(node) {
+            return all(node.definitions, function(var_def) {
+                return !var_def.value;
+            });
+        }
+
         function sequencesize(statements, compressor) {
             if (statements.length < 2) return;
             var seq = [], n = 0;
@@ -1553,6 +1560,9 @@ merge(Compressor.prototype, {
                     var body = stat.body;
                     if (seq.length > 0) body = body.drop_side_effect_free(compressor);
                     if (body) merge_sequence(seq, body);
+                } else if (stat instanceof AST_Definitions && declarations_only(stat)
+                    || stat instanceof AST_Defun) {
+                    statements[n++] = stat;
                 } else {
                     push_seq();
                     statements[n++] = stat;
@@ -1560,13 +1570,31 @@ merge(Compressor.prototype, {
             }
             push_seq();
             statements.length = n;
-            sequencesize_2(statements, compressor);
-            CHANGED = statements.length != len;
+            if (n != len) CHANGED = true;
+        }
+
+        function to_simple_statement(block, decls) {
+            if (!(block instanceof AST_BlockStatement)) return block;
+            var defs = [];
+            var stat = null;
+            for (var i = 0, len = block.body.length; i < len; i++) {
+                var line = block.body[i];
+                if (line instanceof AST_Definitions && declarations_only(line)) {
+                    defs.push(line);
+                } else if (stat) {
+                    return false;
+                } else {
+                    stat = line;
+                }
+            }
+            [].push.apply(decls, defs);
+            return stat;
         }
 
         function sequencesize_2(statements, compressor) {
             function cons_seq(right) {
                 n--;
+                CHANGED = true;
                 var left = prev.body;
                 return make_sequence(left, [ left, right ]).transform(compressor);
             };
@@ -1588,6 +1616,7 @@ merge(Compressor.prototype, {
                             else {
                                 stat.init = prev.body;
                                 n--;
+                                CHANGED = true;
                             }
                         }
                     }
@@ -1607,6 +1636,22 @@ merge(Compressor.prototype, {
                         stat.expression = cons_seq(stat.expression);
                     }
                 }
+                if (compressor.option("conditionals") && stat instanceof AST_If) {
+                    var decls = [];
+                    var body = to_simple_statement(stat.body, decls);
+                    var alt = to_simple_statement(stat.alternative, decls);
+                    if (body !== false && alt !== false && decls.length > 0) {
+                        decls.push(make_node(AST_If, stat, {
+                            condition: stat.condition,
+                            body: body || make_node(AST_EmptyStatement, stat.body),
+                            alternative: alt
+                        }));
+                        stat = make_node(AST_BlockStatement, stat, {
+                            body: decls
+                        });
+                        CHANGED = true;
+                    }
+                }
                 statements[n++] = stat;
                 prev = stat instanceof AST_SimpleStatement ? stat : null;
             }
@@ -1614,30 +1659,44 @@ merge(Compressor.prototype, {
         }
 
         function join_consecutive_vars(statements, compressor) {
+            var defs;
             for (var i = 0, j = -1, len = statements.length; i < len; i++) {
                 var stat = statements[i];
                 var prev = statements[j];
-                if (stat instanceof AST_Definitions && prev && prev.TYPE == stat.TYPE) {
-                    prev.definitions = prev.definitions.concat(stat.definitions);
-                    CHANGED = true;
-                }
-                else if (stat instanceof AST_For
-                         && prev instanceof AST_Var
-                         && (!stat.init || stat.init.TYPE == prev.TYPE)) {
-                    CHANGED = true;
-                    if (stat.init) {
-                        stat.init.definitions = prev.definitions.concat(stat.init.definitions);
+                if (stat instanceof AST_Definitions) {
+                    if (prev && prev.TYPE == stat.TYPE) {
+                        prev.definitions = prev.definitions.concat(stat.definitions);
+                        CHANGED = true;
+                    } else if (defs && defs.TYPE == stat.TYPE && declarations_only(stat)) {
+                        defs.definitions = defs.definitions.concat(stat.definitions);
+                        CHANGED = true;
                     } else {
-                        stat.init = prev;
+                        statements[++j] = stat;
+                        defs = stat;
                     }
-                    statements[j] = stat;
-                }
-                else {
+                } else if (stat instanceof AST_For) {
+                    if (prev instanceof AST_Var && (!stat.init || stat.init.TYPE == prev.TYPE)) {
+                        if (stat.init) {
+                            stat.init.definitions = prev.definitions.concat(stat.init.definitions);
+                        } else {
+                            stat.init = prev;
+                        }
+                        statements[j] = stat;
+                        CHANGED = true;
+                    } else if (defs && stat.init && defs.TYPE == stat.init.TYPE && declarations_only(stat.init)) {
+                        defs.definitions = defs.definitions.concat(stat.init.definitions);
+                        stat.init = null;
+                        statements[++j] = stat;
+                        CHANGED = true;
+                    } else {
+                        statements[++j] = stat;
+                    }
+                } else {
                     statements[++j] = stat;
                 }
             }
             statements.length = j + 1;
-        };
+        }
     }
 
     function extract_declarations_from_unreachable_code(compressor, stat, target) {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1677,10 +1677,9 @@ merge(Compressor.prototype, {
                 } else if (stat instanceof AST_For) {
                     if (prev instanceof AST_Var && (!stat.init || stat.init.TYPE == prev.TYPE)) {
                         if (stat.init) {
-                            stat.init.definitions = prev.definitions.concat(stat.init.definitions);
-                        } else {
-                            stat.init = prev;
+                            prev.definitions = prev.definitions.concat(stat.init.definitions);
                         }
+                        stat.init = prev;
                         statements[j] = stat;
                         CHANGED = true;
                     } else if (defs && stat.init && defs.TYPE == stat.init.TYPE && declarations_only(stat.init)) {

--- a/test/compress/conditionals.js
+++ b/test/compress/conditionals.js
@@ -1203,3 +1203,24 @@ issue_2560: {
         "2",
     ]
 }
+
+hoist_decl: {
+    options = {
+        conditionals: true,
+        join_vars: true,
+        sequences: true,
+    }
+    input: {
+        if (x()) {
+            var a;
+            y();
+        } else {
+            z();
+            var b;
+        }
+    }
+    expect: {
+        var a, b;
+        x() ? y() : z();
+    }
+}

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -800,12 +800,12 @@ issue_2601_1: {
     expect: {
         var a = "FAIL";
         (function() {
+            var b;
             b = "foo",
             function(b) {
                 b && b();
             }(),
             b && (a = "PASS");
-            var b;
         })(),
         console.log(a);
     }

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -833,3 +833,29 @@ hoist_decl: {
         for (y(); 0;) z();
     }
 }
+
+for_init_var: {
+    options = {
+        join_vars: true,
+        unused: false,
+    }
+    input: {
+        var a = "PASS";
+        (function() {
+            var b = 42;
+            for (var c = 5; c > 0;) c--;
+            a = "FAIL";
+            var a;
+        })();
+        console.log(a);
+    }
+    expect: {
+        var a = "PASS";
+        (function() {
+            for (var b = 42, c = 5, a; c > 0;) c--;
+            a = "FAIL";
+        })();
+        console.log(a);
+    }
+    expect_stdout: "PASS"
+}

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -796,3 +796,40 @@ cascade_assignment_in_return: {
         }
     }
 }
+
+hoist_defun: {
+    options = {
+        join_vars: true,
+        sequences: true,
+    }
+    input: {
+        x();
+        function f() {}
+        y();
+    }
+    expect: {
+        function f() {}
+        x(), y();
+    }
+}
+
+hoist_decl: {
+    options = {
+        join_vars: true,
+        sequences: true,
+    }
+    input: {
+        var a;
+        w();
+        var b = x();
+        y();
+        for (var c; 0;) z();
+        var d;
+    }
+    expect: {
+        var a;
+        w();
+        var b = x(), c, d;
+        for (y(); 0;) z();
+    }
+}


### PR DESCRIPTION
While `hoist_funs` or `hoist_vars` gives worse gzipped results overall, a more localised version around `join_vars` and `sequences` seems to produce good winnings.

`node test/benchmark.js --toplevel -mc unsafe,keep_fargs=0,passes=10000`

<table>
<tr>
<th>master</th>
<th>This PR</th>
</tr>
<tr>
<td>

```
https://code.jquery.com/jquery-3.2.1.js
- parse: 0.218s
- rename: 0.172s
- compress: 2.906s
- scope: 0.047s
- mangle: 0.141s
- properties: 0.000s
- output: 0.125s
- total: 3.609s

Original: 268039 bytes
Uglified: 86013 bytes
GZipped:  29963 bytes
SHA1 sum: 2e4c11417dbad03462abfcabc528f91e13bb14ad

https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.4/angular.js
- parse: 0.515s
- rename: 0.297s
- compress: 6.469s
- scope: 0.094s
- mangle: 0.203s
- properties: 0.000s
- output: 0.156s
- total: 7.734s

Original: 1249863 bytes
Uglified: 173307 bytes
GZipped:  60009 bytes
SHA1 sum: e8057d9310ae0ba4714243f05a02e48c34c5904f

https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.9.0/math.js
- parse: 0.890s
- rename: 0.578s
- compress: 12.766s
- scope: 0.250s
- mangle: 0.328s
- properties: 0.000s
- output: 0.250s
- total: 15.062s

Original: 1590107 bytes
Uglified: 464850 bytes
GZipped:  118699 bytes
SHA1 sum: bf03e8fe6615b7f8d818dfd95e1e18cdb45bfb2c

https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.js
- parse: 0.093s
- rename: 0.047s
- compress: 0.938s
- scope: 0.015s
- mangle: 0.063s
- properties: 0.000s
- output: 0.031s
- total: 1.187s

Original: 69707 bytes
Uglified: 36808 bytes
GZipped:  9571 bytes
SHA1 sum: 952f3a1317e80e73ba91a7ee3f32c3afb0ca143d

https://unpkg.com/react@15.3.2/dist/react.js
- parse: 0.484s
- rename: 0.250s
- compress: 5.375s
- scope: 0.078s
- mangle: 0.219s
- properties: 0.000s
- output: 0.203s
- total: 6.609s

Original: 701412 bytes
Uglified: 204306 bytes
GZipped:  62191 bytes
SHA1 sum: 6385b9b3db33405fc2ec6ef8f2403471c4a77240

http://builds.emberjs.com/tags/v2.11.0/ember.prod.js
- parse: 0.812s
- rename: 0.625s
- compress: 12.360s
- scope: 0.156s
- mangle: 0.312s
- properties: 0.000s
- output: 0.235s
- total: 14.500s

Original: 1852178 bytes
Uglified: 524421 bytes
GZipped:  128526 bytes
SHA1 sum: 685974cb9372e7819330830cfdbd08ce92eda78c

https://cdn.jsdelivr.net/lodash/4.17.4/lodash.js
- parse: 0.250s
- rename: 0.234s
- compress: 5.750s
- scope: 0.031s
- mangle: 0.125s
- properties: 0.000s
- output: 0.094s
- total: 6.484s

Original: 539590 bytes
Uglified: 69640 bytes
GZipped:  24733 bytes
SHA1 sum: 3aa7a4063c7aa3333c202652407bce5a672d8579

https://cdnjs.cloudflare.com/ajax/libs/d3/4.5.0/d3.js
- parse: 0.578s
- rename: 0.375s
- compress: 7.922s
- scope: 0.109s
- mangle: 0.234s
- properties: 0.000s
- output: 0.141s
- total: 9.359s

Original: 451131 bytes
Uglified: 211294 bytes
GZipped:  70804 bytes
SHA1 sum: 398038ada50636cbe8dacefe52fbb8d7694c068a

https://raw.githubusercontent.com/kangax/html-minifier/v3.5.7/dist/htmlminifier.js
- parse: 0.859s
- rename: 0.469s
- compress: 14.969s
- scope: 0.140s
- mangle: 0.344s
- properties: 0.000s
- output: 0.281s
- total: 17.062s

Original: 1063075 bytes
Uglified: 507288 bytes
GZipped:  157786 bytes
SHA1 sum: b121b4b0baafb7d63bbcf88a5a1be06f39f56937
```

</td>
<td>

```
https://code.jquery.com/jquery-3.2.1.js
- parse: 0.218s
- rename: 0.141s
- compress: 2.781s
- scope: 0.031s
- mangle: 0.141s
- properties: 0.000s
- output: 0.109s
- total: 3.421s

Original: 268039 bytes
Uglified: 86006 bytes
GZipped:  29952 bytes
SHA1 sum: 91138ec1e59acc9a957e21c6501eaa874bd30078

https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.4/angular.js
- parse: 0.500s
- rename: 0.296s
- compress: 6.719s
- scope: 0.063s
- mangle: 0.219s
- properties: 0.000s
- output: 0.109s
- total: 7.906s

Original: 1249863 bytes
Uglified: 173241 bytes
GZipped:  59894 bytes
SHA1 sum: 1820da7cac96168889a32666bb2e4c8b876db5f3

https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.9.0/math.js
- parse: 0.859s
- rename: 0.578s
- compress: 12.719s
- scope: 0.156s
- mangle: 0.328s
- properties: 0.000s
- output: 0.360s
- total: 15.000s

Original: 1590107 bytes
Uglified: 464782 bytes
GZipped:  118689 bytes
SHA1 sum: a3edd0e5563457e2daa7f0d1c34f0a344fb47a76

https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.js
- parse: 0.093s
- rename: 0.063s
- compress: 0.922s
- scope: 0.015s
- mangle: 0.063s
- properties: 0.000s
- output: 0.047s
- total: 1.203s

Original: 69707 bytes
Uglified: 36807 bytes
GZipped:  9577 bytes
SHA1 sum: 99f2e943a08a68fd62f4b38d6e7e6f5811f022c6

https://unpkg.com/react@15.3.2/dist/react.js
- parse: 0.437s
- rename: 0.281s
- compress: 5.672s
- scope: 0.063s
- mangle: 0.219s
- properties: 0.000s
- output: 0.125s
- total: 6.797s

Original: 701412 bytes
Uglified: 204183 bytes
GZipped:  62155 bytes
SHA1 sum: ed2de4500fa4fdac254e2796f05f35a1c9717234

http://builds.emberjs.com/tags/v2.11.0/ember.prod.js
- parse: 0.859s
- rename: 0.578s
- compress: 12.672s
- scope: 0.141s
- mangle: 0.312s
- properties: 0.000s
- output: 0.235s
- total: 14.797s

Original: 1852178 bytes
Uglified: 524348 bytes
GZipped:  128470 bytes
SHA1 sum: 30365fb5aba2efa35566ba47803974a19520a37e

https://cdn.jsdelivr.net/lodash/4.17.4/lodash.js
- parse: 0.250s
- rename: 0.203s
- compress: 5.859s
- scope: 0.031s
- mangle: 0.157s
- properties: 0.000s
- output: 0.078s
- total: 6.578s

Original: 539590 bytes
Uglified: 69621 bytes
GZipped:  24756 bytes
SHA1 sum: 72a484071aa5272e24d7fb44f6d0a0fbf3af4c5d

https://cdnjs.cloudflare.com/ajax/libs/d3/4.5.0/d3.js
- parse: 0.562s
- rename: 0.344s
- compress: 8.047s
- scope: 0.094s
- mangle: 0.265s
- properties: 0.000s
- output: 0.141s
- total: 9.453s

Original: 451131 bytes
Uglified: 211251 bytes
GZipped:  70770 bytes
SHA1 sum: 0b9bf3defb67efc196c0289c19edf2fc42372a9b

https://raw.githubusercontent.com/kangax/html-minifier/v3.5.7/dist/htmlminifier.js
- parse: 0.890s
- rename: 0.531s
- compress: 12.610s
- scope: 0.141s
- mangle: 0.359s
- properties: 0.000s
- output: 0.281s
- total: 14.812s

Original: 1063075 bytes
Uglified: 506852 bytes
GZipped:  157599 bytes
SHA1 sum: 5de841c9fe8babd9467319c583246319032e0c47
```

</td>
</tr>
</table>