### PR TITLE
[WIP] have test/compress tests also run reminified input if expect_stdout present

### DIFF
--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -208,7 +208,7 @@ function run_compress_tests() {
                     // The test with expect_stdout passed.
                     // Now try to reminify original input with standard options
                     // to see if it matches expect_stdout.
-                    var reminify_input = test.input.print_to_string();
+                    var reminify_input = input_code;
                     var reminify_options = {
                         output: {
                             beautify: true,

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -208,7 +208,8 @@ function run_compress_tests() {
                     // The test with expect_stdout passed.
                     // Now try to reminify original input with standard options
                     // to see if it matches expect_stdout.
-                    var reminified_result = U.minify(test.input.print_to_string(), {
+                    var reminify_input = test.input.print_to_string();
+                    var reminify_options = {
                         output: {
                             beautify: true,
                         },
@@ -222,7 +223,9 @@ function run_compress_tests() {
                             // keep_classnames: options.keep_classnames, // harmony
                             // probably other test affecting options have to be copied
                         },
-                    });
+                    };
+                    var reminify_options_json = JSON.stringify(JSON.parse(JSON.stringify(reminify_options)), null, 2);
+                    var reminified_result = U.minify(reminify_input, reminify_options);
                     if (reminified_result.error) {
                         log("!!! failed input reminify\n---INPUT---\n{input}\n--reminify error---\n{reminify_error}\n\n", {
                             input: input_formatted,
@@ -233,8 +236,9 @@ function run_compress_tests() {
                     } else {
                         stdout = sandbox.run_code(reminified_result.code);
                         if (!sandbox.same_stdout(test.expect_stdout, stdout)) {
-                            log("!!! failed running reminified input\n---INPUT---\n{input}\n---reminified INPUT---\n{output}\n---EXPECTED {expected_type}---\n{expected}\n---ACTUAL {actual_type}---\n{actual}\n\n", {
-                                input: input_formatted,
+                            log("!!! failed running reminified input\n---INPUT---\n{input}\n---options---\n{options}\n---reminified INPUT---\n{output}\n---EXPECTED {expected_type}---\n{expected}\n---ACTUAL {actual_type}---\n{actual}\n\n", {
+                                input: reminify_input,
+                                options: reminify_options_json,
                                 output: reminified_result.code,
                                 expected_type: typeof test.expect_stdout == "string" ? "STDOUT" : "ERROR",
                                 expected: test.expect_stdout,

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -205,6 +205,48 @@ function run_compress_tests() {
                             failed_files[file] = 1;
                         }
                     }
+                    // The test with expect_stdout passed.
+                    // Now try to reminify original input with standard options
+                    // to see if it matches expect_stdout.
+                    var reminified_result = U.minify(test.input.print_to_string(), {
+                        output: {
+                            beautify: true,
+                        },
+                        mangle: false,
+                        compress: {
+                            passes: 9,
+                            toplevel: true,
+                            global_defs: options.global_defs,
+                            keep_fargs: options.keep_fargs,
+                            keep_fnames: options.keep_fnames,
+                            // keep_classnames: options.keep_classnames, // harmony
+                            // probably other test affecting options have to be copied
+                        },
+                    });
+                    if (reminified_result.error) {
+                        log("!!! failed input reminify\n---INPUT---\n{input}\n--reminify error---\n{reminify_error}\n\n", {
+                            input: input_formatted,
+                            reminify_error: reminified_result.error,
+                        });
+                        failures++;
+                        failed_files[file] = 1;
+                    } else {
+                        stdout = sandbox.run_code(reminified_result.code);
+                        if (!sandbox.same_stdout(test.expect_stdout, stdout)) {
+                            log("!!! failed running reminified input\n---INPUT---\n{input}\n---reminified INPUT---\n{output}\n---EXPECTED {expected_type}---\n{expected}\n---ACTUAL {actual_type}---\n{actual}\n\n", {
+                                input: input_formatted,
+                                output: reminified_result.code,
+                                expected_type: typeof test.expect_stdout == "string" ? "STDOUT" : "ERROR",
+                                expected: test.expect_stdout,
+                                actual_type: typeof stdout == "string" ? "STDOUT" : "ERROR",
+                                actual: stdout,
+                            });
+                            failures++;
+                            failed_files[file] = 1;
+                        } else {
+                            //log("*** reminify passed: " + test.name);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This was easier to explain in the form of a running PR rather than an issue...

It's been a longstanding issue that unit tests are only tested using specific `minify` options that can hide latent problems. This is an unfinished proof of concept to catch legitimate uglify errors in tests that happen to have `expect_stdout` defined. The idea is to just reminify the test input with default options with a few exceptions (toplevel, passes, global_defs, etc) and see if its result when run matches the original expected result. 

You'll see many legitimate `test/compress` test failures, and a few false positives.

@alexlamsl Could you incorporate this into the test framework once you've eliminated the false positives? Feel free to close this PR and replace it with one of your own.
  
  