### PR TITLE
Fix mangle collision with cache reuse across runs

### DIFF
--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -114,7 +114,8 @@ function mangle_properties(ast, options) {
     if (cache == null) {
         cache = {
             cname: -1,
-            props: new Dictionary()
+            props: new Dictionary(),
+            props_inv: new Dictionary()
         };
     }
 
@@ -214,10 +215,11 @@ function mangle_properties(ast, options) {
             if (!mangled) {
                 do {
                     mangled = base54(++cache.cname);
-                } while (!can_mangle(mangled));
+                } while (!can_mangle(mangled) || cache.props_inv.get(mangled));
             }
 
             cache.props.set(name, mangled);
+            cache.props_inv.set(mangled, name);
         }
         return mangled;
     }


### PR DESCRIPTION
When mangling multiple files in separate runs of uglify using a shared cache file, it is possible for mangled names to collide and map multiple properties to the same mangled property. Although the mangled name is based on `cache.cname` which is always increasing and different per property, `base54` seems to be non-deterministic between separate runs of uglify. My best guess is that `base54.sort()` operates on frequencies that aren't preserved in the cache but does adjust the alphabet used in the encoder.

This pull request introduces a very simple fix which checks that the mangled version of the property definitely has never been used be maintaining an inverted dictionary of `cache.props`.

This is rather difficult to provide a test case for as it is only likely to happen with many thousands of properties being mangled which we've only noticed on our large internal code base. We've seen this issue using the Webpack UglifyJs plugin running version 2.8, but from what I can tell, this seems to still be an issue in v3.x.



