### PR TITLE
warn on deprecated features

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -5461,6 +5461,14 @@ merge(Compressor.prototype, {
     });
 
     OPT(AST_Dot, function(self, compressor){
+        if (self.property == "arguments" || self.property == "caller") {
+            compressor.warn("Function.protoype.{prop} not supported [{file}:{line},{col}]", {
+                prop: self.property,
+                file: self.start.file,
+                line: self.start.line,
+                col: self.start.col
+            });
+        }
         var def = self.resolve_defines(compressor);
         if (def) {
             return def.optimize(compressor);

--- a/test/compress/issue-2719.js
+++ b/test/compress/issue-2719.js
@@ -1,0 +1,32 @@
+warn: {
+    options = {
+        evaluate: true,
+        inline: true,
+        passes: 2,
+        properties: true,
+        reduce_funcs: true,
+        reduce_vars: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        function f() {
+            return g();
+        }
+        function g() {
+            return g["call" + "er"].arguments;
+        }
+        // 3
+        console.log(f(1, 2, 3).length);
+    }
+    expect: {
+        // TypeError: Cannot read property 'arguments' of null
+        console.log(function g() {
+            return g.caller.arguments;
+        }().length);
+    }
+    expect_warnings: [
+        "WARN: Function.protoype.caller not supported [test/compress/issue-2719.js:17,19]",
+        "WARN: Function.protoype.arguments not supported [test/compress/issue-2719.js:17,19]",
+    ]
+}


### PR DESCRIPTION
- `function.arguments`
- `function.callers`

fixes #2719