### PR TITLE
ufuzz: add strings "a", "b", "c" to VALUES

### DIFF
--- a/test/ufuzz.js
+++ b/test/ufuzz.js
@@ -127,6 +127,9 @@ for (var i = 2; i < process.argv.length; ++i) {
 }
 
 var VALUES = [
+    '"a"',
+    '"b"',
+    '"c"',
     '""',
     'true',
     'false',


### PR DESCRIPTION
Address a shortcoming in the fuzzer. This PR can now generate code like this:
```js
var foo = { a: 1, b: 2 }["b"];
```