### PR TITLE
improve `process.exit()` workaround

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -3,11 +3,7 @@
 
 "use strict";
 
-// workaround for tty output truncation upon process.exit()
-[process.stdout, process.stderr].forEach(function(stream){
-    if (stream._handle && stream._handle.setBlocking)
-        stream._handle.setBlocking(true);
-});
+require("../tools/exit");
 
 var fs = require("fs");
 var info = require("../package.json");

--- a/test/jetstream.js
+++ b/test/jetstream.js
@@ -5,11 +5,7 @@
 
 var site = "http://browserbench.org/JetStream";
 if (typeof phantom == "undefined") {
-    // workaround for tty output truncation upon process.exit()
-    [process.stdout, process.stderr].forEach(function(stream){
-        if (stream._handle && stream._handle.setBlocking)
-            stream._handle.setBlocking(true);
-    });
+    require("../tools/exit");
     var args = process.argv.slice(2);
     var debug = args.indexOf("--debug");
     if (debug >= 0) {

--- a/test/ufuzz.js
+++ b/test/ufuzz.js
@@ -6,11 +6,7 @@
 // bin/uglifyjs s.js -c && bin/uglifyjs s.js -c passes=3 && bin/uglifyjs s.js -c passes=3 -m
 // cat s.js | node && node s.js && bin/uglifyjs s.js -c | node && bin/uglifyjs s.js -c passes=3 | node && bin/uglifyjs s.js -c passes=3 -m | node
 
-// workaround for tty output truncation upon process.exit()
-[process.stdout, process.stderr].forEach(function(stream){
-    if (stream._handle && stream._handle.setBlocking)
-        stream._handle.setBlocking(true);
-});
+require("../tools/exit");
 
 var UglifyJS = require("..");
 var randomBytes = require("crypto").randomBytes;

--- a/tools/exit.js
+++ b/tools/exit.js
@@ -1,0 +1,15 @@
+// workaround for tty output truncation upon process.exit()
+var exit = process.exit;
+process.exit = function() {
+    var args = [].slice.call(arguments);
+    process.once("uncaughtException", function() {
+        (function callback() {
+            if (process.stdout.bufferSize || process.stderr.bufferSize) {
+                setImmediate(callback);
+            } else {
+                exit.apply(process, args);
+            }
+        })();
+    });
+    throw exit;
+};


### PR DESCRIPTION
- use public API
- fix issue with Node.js 0.10 on WIndows

Related:
https://github.com/mishoo/UglifyJS2/pull/1061
https://github.com/mochajs/mocha/issues/333#issuecomment-7437412