### PR TITLE
Doc: "keep_infinity" is redundant on modern Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
   `Function.prototype.name`. See also: the `keep_fnames` [mangle option](#mangle).
 
 - `keep_infinity` (default: `false`) -- Pass `true` to prevent `Infinity` from
-  being compressed into `1/0`, which may cause performance issues on Chrome.
+  being compressed into `1/0`, which may cause performance issues on old versions of Chrome.
 
 - `loops` (default: `true`) -- optimizations for `do`, `while` and `for` loops
   when we can statically determine the condition.


### PR DESCRIPTION
Clarify that "keep_infinity" compress option is only useful for older versions of Chrome.

The initial performance assessment that concluded `Infinity` was faster than `1/0` was based on Chrome 57.
https://github.com/mishoo/UglifyJS2/pull/1723#issuecomment-290122814

Chrome 63 suffers no such degradation.
https://jsperf.com/infinity-vs-1-0-v2-0