### PR TITLE
skip only `var`s in `if_return`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1523,7 +1523,7 @@ merge(Compressor.prototype, {
             function next_index(i) {
                 for (var j = i + 1, len = statements.length; j < len; j++) {
                     var stat = statements[j];
-                    if (!(stat instanceof AST_Definitions && declarations_only(stat))) {
+                    if (!(stat instanceof AST_Var && declarations_only(stat))) {
                         break;
                     }
                 }
@@ -1533,7 +1533,7 @@ merge(Compressor.prototype, {
             function prev_index(i) {
                 for (var j = i; --j >= 0;) {
                     var stat = statements[j];
-                    if (!(stat instanceof AST_Definitions && declarations_only(stat))) {
+                    if (!(stat instanceof AST_Var && declarations_only(stat))) {
                         break;
                     }
                 }


### PR DESCRIPTION
fixes #2747

Doesn't change any behaviour on `master`, but this would minimise diff between the branches.
  