### PR TITLE
add SymbolDef IDs to `--output ast`

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -11,7 +11,7 @@ var path = require("path");
 var program = require("commander");
 var UglifyJS = require("../tools/node");
 
-var skip_keys = [ "cname", "enclosed", "inlined", "parent_scope", "scope", "thedef", "uses_eval", "uses_with" ];
+var skip_keys = [ "cname", "inlined", "parent_scope", "scope", "uses_eval", "uses_with" ];
 var files = {};
 var options = {
     compress: false,
@@ -223,7 +223,33 @@ function run() {
         }
         fatal(ex);
     } else if (program.output == "ast") {
+        if (!options.compress && !options.mangle) {
+            result.ast.figure_out_scope({});
+        }
         print(JSON.stringify(result.ast, function(key, value) {
+            switch (key) {
+              case "thedef":
+                if (typeof value == "object" && typeof value.id == "number") {
+                    return value.id;
+                }
+                return;
+              case "enclosed":
+                return value.map(function(sym){
+                    return sym.id;
+                });
+              case "variables":
+              case "functions":
+              case "globals":
+                if (value && value.size()) {
+                    var ret = {};
+                    value.each(function(val, key) {
+                        // key/val inverted for readability.
+                        ret[val.id] = key;
+                    });
+                    return ret;
+                }
+                return;
+            }
             if (skip_key(key)) return;
             if (value instanceof UglifyJS.AST_Token) return;
             if (value instanceof UglifyJS.Dictionary) return;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -57,7 +57,7 @@ function SymbolDef(scope, orig, init) {
     this.id = SymbolDef.next_id++;
 };
 
-SymbolDef.next_id = 1;
+SymbolDef.next_id = 1e6;
 
 SymbolDef.prototype = {
     unmangleable: function(options) {


### PR DESCRIPTION
```js
$ echo 'function f(x,y){var z=3; console.log(x,y,z);} var x=1; f(x,2);' | bin/uglifyjs -o ast
{
  "_class": "AST_Toplevel",
  "globals": {
    "1000006": "console"
  },
  "variables": {
    "1000001": "f",
    "1000005": "x"
  },
  "functions": {
    "1000001": "f"
  },
  "enclosed": [
    1000006,
    1000005,
    1000001
  ],
  "body": [
    {
      "_class": "AST_Defun",
      "name": {
        "_class": "AST_SymbolDefun",
        "name": "f",
        "thedef": 1000001
      },
      "argnames": [
        {
          "_class": "AST_SymbolFunarg",
          "name": "x",
          "thedef": 1000002
        },
        {
          "_class": "AST_SymbolFunarg",
          "name": "y",
          "thedef": 1000003
        }
      ],
      "uses_arguments": false,
      "variables": {
        "1000000": "arguments",
        "1000002": "x",
        "1000003": "y",
        "1000004": "z"
      },
      "enclosed": [
        1000002,
        1000003,
        1000004,
        1000006
      ],
      "body": [
        {
          "_class": "AST_Var",
          "definitions": [
            {
              "_class": "AST_VarDef",
              "name": {
                "_class": "AST_SymbolVar",
                "name": "z",
                "thedef": 1000004
              },
              "value": {
                "_class": "AST_Number",
                "value": 3
              }
            }
          ]
        },
        {
          "_class": "AST_SimpleStatement",
          "body": {
            "_class": "AST_Call",
            "expression": {
              "_class": "AST_Dot",
              "expression": {
                "_class": "AST_SymbolRef",
                "name": "console",
                "thedef": 1000006
              },
              "property": "log"
            },
            "args": [
              {
                "_class": "AST_SymbolRef",
                "name": "x",
                "thedef": 1000002
              },
              {
                "_class": "AST_SymbolRef",
                "name": "y",
                "thedef": 1000003
              },
              {
                "_class": "AST_SymbolRef",
                "name": "z",
                "thedef": 1000004
              }
            ]
          }
        }
      ]
    },
    {
      "_class": "AST_Var",
      "definitions": [
        {
          "_class": "AST_VarDef",
          "name": {
            "_class": "AST_SymbolVar",
            "name": "x",
            "thedef": 1000005
          },
          "value": {
            "_class": "AST_Number",
            "value": 1
          }
        }
      ]
    },
    {
      "_class": "AST_SimpleStatement",
      "body": {
        "_class": "AST_Call",
        "expression": {
          "_class": "AST_SymbolRef",
          "name": "f",
          "thedef": 1000001
        },
        "args": [
          {
            "_class": "AST_SymbolRef",
            "name": "x",
            "thedef": 1000005
          },
          {
            "_class": "AST_Number",
            "value": 2
          }
        ]
      }
    }
  ]
}
```
`uglifyjs --self -o ast` also looks interesting.