### PR TITLE
improve SymbolDef info in `--output ast`

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -227,28 +227,15 @@ function run() {
             result.ast.figure_out_scope({});
         }
         print(JSON.stringify(result.ast, function(key, value) {
-            switch (key) {
+            if (value) switch (key) {
               case "thedef":
-                if (typeof value == "object" && typeof value.id == "number") {
-                    return value.id;
-                }
-                return;
+                return symdef(value);
               case "enclosed":
-                return value.map(function(sym){
-                    return sym.id;
-                });
+                return value.length ? value.map(symdef) : undefined;
               case "variables":
               case "functions":
               case "globals":
-                if (value && value.size()) {
-                    var ret = {};
-                    value.each(function(val, key) {
-                        // key/val inverted for readability.
-                        ret[val.id] = key;
-                    });
-                    return ret;
-                }
-                return;
+                return value.size() ? value.map(symdef) : undefined;
             }
             if (skip_key(key)) return;
             if (value instanceof UglifyJS.AST_Token) return;
@@ -401,6 +388,12 @@ function parse_source_map() {
 
 function skip_key(key) {
     return skip_keys.indexOf(key) >= 0;
+}
+
+function symdef(def) {
+    var ret = (1e6 + def.id) + " " + def.name;
+    if (def.mangled_name) ret += " " + def.mangled_name;
+    return ret;
 }
 
 function format_object(obj) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -57,7 +57,7 @@ function SymbolDef(scope, orig, init) {
     this.id = SymbolDef.next_id++;
 };
 
-SymbolDef.next_id = 1e6;
+SymbolDef.next_id = 1;
 
 SymbolDef.prototype = {
     unmangleable: function(options) {


### PR DESCRIPTION
* SymbolDef info (a.k.a. `thedef`) is now represented as a string containing `"ID name [mangled_name]"`. 
* Enhance display of `globals`, `variables`, `functions` and `enclosed`.
* `SymbolDef.next_id` starts at `1` and the `id` is adjusted for `-o ast` display.

```js
$ echo 'function f(x,y){var z=3; console.log(x,y,z);} var x=1; f(x,2);' | bin/uglifyjs -m -o ast
{
  "_class": "AST_Toplevel",
  "globals": [
    "1000007 console"
  ],
  "variables": [
    "1000002 f",
    "1000006 x"
  ],
  "functions": [
    "1000002 f"
  ],
  "enclosed": [
    "1000007 console",
    "1000006 x",
    "1000002 f"
  ],
  "body": [
    {
      "_class": "AST_Defun",
      "name": {
        "_class": "AST_SymbolDefun",
        "name": "f",
        "thedef": "1000002 f"
      },
      "argnames": [
        {
          "_class": "AST_SymbolFunarg",
          "name": "x",
          "thedef": "1000003 x o"
        },
        {
          "_class": "AST_SymbolFunarg",
          "name": "y",
          "thedef": "1000004 y f"
        }
      ],
      "uses_arguments": false,
      "variables": [
        "1000001 arguments",
        "1000003 x o",
        "1000004 y f",
        "1000005 z n"
      ],
      "enclosed": [
        "1000003 x o",
        "1000004 y f",
        "1000005 z n",
        "1000007 console"
      ],
      "body": [
        {
          "_class": "AST_Var",
          "definitions": [
            {
              "_class": "AST_VarDef",
              "name": {
                "_class": "AST_SymbolVar",
                "name": "z",
                "thedef": "1000005 z n"
              },
              "value": {
                "_class": "AST_Number",
                "value": 3
              }
            }
          ]
        },
        {
          "_class": "AST_SimpleStatement",
          "body": {
            "_class": "AST_Call",
            "expression": {
              "_class": "AST_Dot",
              "expression": {
                "_class": "AST_SymbolRef",
                "name": "console",
                "thedef": "1000007 console"
              },
              "property": "log"
            },
            "args": [
              {
                "_class": "AST_SymbolRef",
                "name": "x",
                "thedef": "1000003 x o"
              },
              {
                "_class": "AST_SymbolRef",
                "name": "y",
                "thedef": "1000004 y f"
              },
              {
                "_class": "AST_SymbolRef",
                "name": "z",
                "thedef": "1000005 z n"
              }
            ]
          }
        }
      ]
    },
    {
      "_class": "AST_Var",
      "definitions": [
        {
          "_class": "AST_VarDef",
          "name": {
            "_class": "AST_SymbolVar",
            "name": "x",
            "thedef": "1000006 x"
          },
          "value": {
            "_class": "AST_Number",
            "value": 1
          }
        }
      ]
    },
    {
      "_class": "AST_SimpleStatement",
      "body": {
        "_class": "AST_Call",
        "expression": {
          "_class": "AST_SymbolRef",
          "name": "f",
          "thedef": "1000002 f"
        },
        "args": [
          {
            "_class": "AST_SymbolRef",
            "name": "x",
            "thedef": "1000006 x"
          },
          {
            "_class": "AST_Number",
            "value": 2
          }
        ]
      }
    }
  ]
}
```