### PR TITLE
[ES6] add `block_scope` to `--output ast`

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -269,11 +269,9 @@ function run() {
                     _class: "AST_" + value.TYPE
                 };
                 if (value.block_scope) {
-                    result.block_scope = {
-                        variables: value.block_scope.variables,
-                        functions: value.block_scope.functions,
-                        enclosed: value.block_scope.enclosed,
-                    };
+                    result.variables = value.block_scope.variables;
+                    result.functions = value.block_scope.functions;
+                    result.enclosed = value.block_scope.enclosed;
                 }
                 value.CTOR.PROPS.forEach(function(prop) {
                     result[prop] = value[prop];

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -268,6 +268,13 @@ function run() {
                 var result = {
                     _class: "AST_" + value.TYPE
                 };
+                if (value.block_scope) {
+                    result.block_scope = {
+                        variables: value.block_scope.variables,
+                        functions: value.block_scope.functions,
+                        enclosed: value.block_scope.enclosed,
+                    };
+                }
                 value.CTOR.PROPS.forEach(function(prop) {
                     result[prop] = value[prop];
                 });


### PR DESCRIPTION
from: https://github.com/mishoo/UglifyJS2/issues/2762#issuecomment-357459603

I suppose it can be applied before #2778 is merged to harmony, it just won't look as good. 