### PR TITLE
general improvements around `AST_ForIn`

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -267,11 +267,10 @@ var AST_For = DEFNODE("For", "init condition step", {
     }
 }, AST_IterationStatement);
 
-var AST_ForIn = DEFNODE("ForIn", "init name object", {
+var AST_ForIn = DEFNODE("ForIn", "init object", {
     $documentation: "A `for ... in` statement",
     $propdoc: {
         init: "[AST_Node] the `for/in` initialization code",
-        name: "[AST_SymbolRef?] the loop variable, only if `init` is AST_Var",
         object: "[AST_Node] the object that we're looping through"
     },
     _walk: function(visitor) {

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -847,9 +847,8 @@ merge(Compressor.prototype, {
     };
 
     function loop_body(x) {
-        if (x instanceof AST_Switch) return x;
-        if (x instanceof AST_For || x instanceof AST_ForIn || x instanceof AST_DWLoop) {
-            return (x.body instanceof AST_BlockStatement ? x.body : x);
+        if (x instanceof AST_IterationStatement) {
+            return x.body instanceof AST_BlockStatement ? x.body : x;
         }
         return x;
     };
@@ -1190,6 +1189,11 @@ merge(Compressor.prototype, {
                     if (expr.init) extract_candidates(expr.init);
                     if (expr.condition) extract_candidates(expr.condition);
                     if (expr.step) extract_candidates(expr.step);
+                    if (!(expr.body instanceof AST_Block)) {
+                        extract_candidates(expr.body);
+                    }
+                } else if (expr instanceof AST_ForIn) {
+                    extract_candidates(expr.object);
                     if (!(expr.body instanceof AST_Block)) {
                         extract_candidates(expr.body);
                     }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1054,12 +1054,10 @@ function parse($TEXT, options) {
     };
 
     function for_in(init) {
-        var lhs = init instanceof AST_Var ? init.definitions[0].name : null;
         var obj = expression(true);
         expect(")");
         return new AST_ForIn({
             init   : init,
-            name   : lhs,
             object : obj,
             body   : in_loop(statement)
         });

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -4062,3 +4062,30 @@ cascade_statement: {
         }
     }
 }
+
+cascade_forin: {
+    options = {
+        collapse_vars: true,
+    }
+    input: {
+        var a;
+        function f(b) {
+            return [ b, b, b ];
+        }
+        for (var c in a = console, f(a))
+            console.log(c);
+    }
+    expect: {
+        var a;
+        function f(b) {
+            return [ b, b, b ];
+        }
+        for (var c in f(a = console))
+            console.log(c);
+    }
+    expect_stdout: [
+        "0",
+        "1",
+        "2",
+    ]
+}


### PR DESCRIPTION
- compress using `collapse_vars`
- remove unused `name`
- simplify `loop_body`

The existence of `AST_ForIn.name` goes back [millennia](https://github.com/mishoo/UglifyJS2/commit/861e26a66639ca61eab2af53de45760370c4d534).