### PR TITLE
improve `mocha` tests

### DIFF
--- a/test/mocha.js
+++ b/test/mocha.js
@@ -1,29 +1,24 @@
-var Mocha = require('mocha'),
-    fs = require('fs'),
-    path = require('path');
+var fs = require("fs");
+var Mocha = require("mocha");
+var path = require("path");
 
-// Instantiate a Mocha instance.
-var mocha = new Mocha({});
+// Instantiate a Mocha instance
+var mocha = new Mocha({
+    timeout: 5000
+});
+var testDir = __dirname + "/mocha/";
 
-var testDir = __dirname + '/mocha/';
-
-// Add each .js file to the mocha instance
-fs.readdirSync(testDir).filter(function(file){
-    // Only keep the .js files
-    return file.substr(-3) === '.js';
-
-}).forEach(function(file){
-    mocha.addFile(
-        path.join(testDir, file)
-    );
+// Add each .js file to the Mocha instance
+fs.readdirSync(testDir).filter(function(file) {
+    return /\.js$/.test(file);
+}).forEach(function(file) {
+    mocha.addFile(path.join(testDir, file));
 });
 
 module.exports = function() {
     mocha.run(function(failures) {
-        if (failures !== 0) {
-            process.on('exit', function () {
-                process.exit(failures);
-            });
-        }
+        if (failures) process.on("exit", function() {
+            process.exit(failures);
+        });
     });
 };


### PR DESCRIPTION
- workaround sporadic delays from Travis CI

```
1) bin/uglifyjs with input file globs bin/uglifyjs with multiple input file globs.:
Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```