### PR TITLE
faster output of comments

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -451,6 +451,11 @@ function OutputStream(options) {
         return OUTPUT;
     };
 
+    function has_nlb() {
+        var index = OUTPUT.lastIndexOf("\n");
+        return /^ *$/.test(OUTPUT.slice(index + 1));
+    }
+
     function prepend_comments(node) {
         var self = this;
         var start = node.start;
@@ -499,7 +504,7 @@ function OutputStream(options) {
 
         comments = comments.filter(comment_filter, node);
         if (comments.length == 0) return;
-        var last_nlb = /(^|\n) *$/.test(OUTPUT);
+        var last_nlb = has_nlb();
         comments.forEach(function(c, i) {
             if (!last_nlb) {
                 if (c.nlb) {
@@ -546,7 +551,7 @@ function OutputStream(options) {
                 print("\n");
                 indent();
                 need_newline_indented = false;
-            } else if (c.nlb && (i > 0 || !/(^|\n) *$/.test(OUTPUT))) {
+            } else if (c.nlb && (i > 0 || !has_nlb())) {
                 print("\n");
                 indent();
             } else if (i > 0 || !tail) {


### PR DESCRIPTION
#### Before
```
$ nvs use node
PATH = node/9.3.0/x64

$ uglifyjs ember.prod.js --comments all --timings | node
- parse: 0.421s
- rename: 0.000s
- compress: 0.000s
- scope: 0.000s
- mangle: 0.000s
- properties: 0.000s
- output: 3.256s
- total: 3.677s

$ nvs use chakracore
PATH -= chakracore/8.6.0/x64

$ uglifyjs ember.prod.js --comments all --timings | node
- parse: 0.621s
- rename: 0.000s
- compress: 0.000s
- scope: 0.000s
- mangle: 0.000s
- properties: 0.000s
- output: 22.834s
- total: 23.455s
```

#### After
```
$ nvs use node
PATH = node/9.3.0/x64

$ uglifyjs ember.prod.js --comments all --timings | node
- parse: 0.421s
- rename: 0.000s
- compress: 0.000s
- scope: 0.000s
- mangle: 0.000s
- properties: 0.000s
- output: 1.907s
- total: 2.328s

$ nvs use chakracore
PATH -= chakracore/8.6.0/x64

$ uglifyjs ember.prod.js --comments all --timings | node
- parse: 0.628s
- rename: 0.000s
- compress: 0.000s
- scope: 0.000s
- mangle: 0.000s
- properties: 0.000s
- output: 1.557s
- total: 2.185s
```