### PR TITLE
avoid duplicate property names in object literals under "use strict"

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -893,7 +893,7 @@ merge(Compressor.prototype, {
                 sequencesize_2(statements, compressor);
             }
             if (compressor.option("join_vars")) {
-                join_consecutive_vars(statements, compressor);
+                join_consecutive_vars(statements);
             }
             if (compressor.option("collapse_vars")) {
                 collapse(statements, compressor);
@@ -1746,8 +1746,14 @@ merge(Compressor.prototype, {
                     prop = prop.evaluate(compressor);
                 }
                 if (prop instanceof AST_Node) break;
+                prop = "" + prop;
+                if (compressor.has_directive("use strict")) {
+                    if (!all(def.value.properties, function(node) {
+                        return node.key != prop && node.key.name != prop;
+                    })) break;
+                }
                 def.value.properties.push(make_node(AST_ObjectKeyVal, node, {
-                    key: "" + prop,
+                    key: prop,
                     value: node.right
                 }));
                 exprs.shift();
@@ -1756,7 +1762,7 @@ merge(Compressor.prototype, {
             return trimmed && exprs;
         }
 
-        function join_consecutive_vars(statements, compressor) {
+        function join_consecutive_vars(statements) {
             var defs;
             for (var i = 0, j = -1, len = statements.length; i < len; i++) {
                 var stat = statements[i];

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -1561,3 +1561,30 @@ join_object_assignments_regex: {
     }
     expect_stdout: "1"
 }
+
+issue_2816: {
+    options = {
+        join_vars: true,
+    }
+    input: {
+        "use strict";
+        var o = {
+            a: 1
+        };
+        o.b = 2;
+        o.a = 3;
+        o.c = 4;
+        console.log(o.a, o.b, o.c);
+    }
+    expect: {
+        "use strict";
+        var o = {
+            a: 1,
+            b: 2
+        };
+        o.a = 3;
+        o.c = 4;
+        console.log(o.a, o.b, o.c);
+    }
+    expect_stdout: "3 2 4"
+}


### PR DESCRIPTION
fixes #2816