### PR TITLE
[ES6] add parenthesis around sequence in `yield`

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -772,6 +772,7 @@ function OutputStream(options) {
             || p instanceof AST_DefaultAssign                 // x => (x = (0, function(){}))
             || p instanceof AST_Expansion                     // [...(a, b)]
             || p instanceof AST_ForOf && this === p.object    // for (e of (foo, bar)) {}
+            || p instanceof AST_Yield                         // yield (foo, bar)
         ;
     });
 

--- a/test/compress/yield.js
+++ b/test/compress/yield.js
@@ -211,3 +211,43 @@ issue_2689: {
     }
     expect_exact: "function*y(){return new(yield x())}"
 }
+
+issue_2832: {
+    beautify = {
+        beautify: true,
+    }
+    input: {
+        function* gen(i) {
+            const result = yield (x = i, -x);
+            var x;
+            console.log(x);
+            console.log(result);
+            yield 2;
+        }
+        var x = gen(1);
+        console.log(x.next("first").value);
+        console.log(x.next("second").value);
+    }
+    expect_exact: [
+        "function* gen(i) {",
+        "    const result = yield (x = i, -x);",
+        "    var x;",
+        "    console.log(x);",
+        "    console.log(result);",
+        "    yield 2;",
+        "}",
+        "",
+        "var x = gen(1);",
+        "",
+        'console.log(x.next("first").value);',
+        "",
+        'console.log(x.next("second").value);',
+    ]
+    expect_stdout: [
+        "-1",
+        "1",
+        "second",
+        "2",
+    ]
+    node_version: ">=4"
+}


### PR DESCRIPTION
fixes #2832