### PR TITLE
enable reminify on harmony branch to avoid regressions

### DIFF
--- a/test/compress/blocks.js
+++ b/test/compress/blocks.js
@@ -75,6 +75,7 @@ issue_1664: {
     }
     expect_stdout: "1"
     node_version: ">=6"
+    reminify: false // FIXME - block scoped function
 }
 
 issue_1672_for: {

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -60,6 +60,7 @@ dead_code_2_should_warn: {
     }
     expect_stdout: true
     node_version: ">=6"
+    reminify: false // FIXME - block scoped function
 }
 
 dead_code_2_should_warn_strict: {
@@ -100,6 +101,7 @@ dead_code_2_should_warn_strict: {
     }
     expect_stdout: true
     node_version: ">=4"
+    reminify: false // FIXME - block scoped function
 }
 
 dead_code_constant_boolean_should_warn_more: {
@@ -135,6 +137,7 @@ dead_code_constant_boolean_should_warn_more: {
     }
     expect_stdout: true
     node_version: ">=6"
+    reminify: false // FIXME - block scoped function
 }
 
 dead_code_constant_boolean_should_warn_more_strict: {
@@ -171,6 +174,7 @@ dead_code_constant_boolean_should_warn_more_strict: {
     }
     expect_stdout: true
     node_version: ">=4"
+    reminify: false // FIXME - block scoped function
 }
 
 dead_code_block_decls_die: {

--- a/test/compress/issue-1466.js
+++ b/test/compress/issue-1466.js
@@ -79,6 +79,7 @@ same_variable_in_multiple_forOf: {
         }
     }
     expect_stdout: true
+    reminify: false // FIXME - regression https://github.com/mishoo/UglifyJS2/issues/2835
 }
 
 same_variable_in_multiple_forIn: {
@@ -120,6 +121,7 @@ same_variable_in_multiple_forIn: {
         }
     }
     expect_stdout: true
+    reminify: false // FIXME - regression https://github.com/mishoo/UglifyJS2/issues/2835
 }
 
 different_variable_in_multiple_for_loop: {


### PR DESCRIPTION
* can skip known test failures with `reminify: false`