### PR TITLE
fix accounting after conversion to assignment

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3038,9 +3038,11 @@ merge(Compressor.prototype, {
                                 if (var_defs.length > 1 && (!def.value || sym.orig.indexOf(def.name) > sym.eliminated)) {
                                     compressor.warn("Dropping duplicated definition of variable {name} [{file}:{line},{col}]", template(def.name));
                                     if (def.value) {
+                                        var ref = make_node(AST_SymbolRef, def.name, def.name);
+                                        sym.references.push(ref);
                                         var assign = make_node(AST_Assign, def, {
                                             operator: "=",
-                                            left: make_node(AST_SymbolRef, def.name, def.name),
+                                            left: ref,
                                             right: def.value
                                         });
                                         if (fixed_ids[sym.id] === def) {

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -1692,3 +1692,30 @@ issue_2768: {
     }
     expect_stdout: "PASS undefined"
 }
+
+issue_2846: {
+    options = {
+        collapse_vars: true,
+        reduce_vars: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        function f(a, b) {
+            var a = 0;
+            b && b(a);
+            return a++;
+        }
+        var c = f();
+        console.log(c);
+    }
+    expect: {
+        var c = function(a, b) {
+            a = 0;
+            b && b(a);
+            return a++;
+        }();
+        console.log(c);
+    }
+    expect_stdout: "0"
+}


### PR DESCRIPTION
Missing reference to `AST_SymbolRef` created by `unused` causes `collapse_vars` to misbehave.

fixes #2846