### PR TITLE
relax `collapse_vars` on `AST_Exit`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1044,7 +1044,6 @@ merge(Compressor.prototype, {
                 // but are otherwise not safe to scan into or beyond them.
                 var sym;
                 if (node instanceof AST_Call
-                    || node instanceof AST_Exit
                     || node instanceof AST_PropAccess
                         && (side_effects || node.expression.may_throw_on_access(compressor))
                     || node instanceof AST_SymbolRef

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -4107,3 +4107,58 @@ unsafe_builtin: {
     }
     expect_stdout: "1 4"
 }
+
+return_1: {
+    options = {
+        collapse_vars: true,
+        unused: true,
+    }
+    input: {
+        var log = console.log;
+        function f(b, c) {
+            var a = c;
+            if (b) return b;
+            log(a);
+        }
+        f(false, 1);
+        f(true, 2);
+    }
+    expect: {
+        var log = console.log;
+        function f(b, c) {
+            if (b) return b;
+            log(c);
+        }
+        f(false, 1);
+        f(true, 2);
+    }
+    expect_stdout: "1"
+}
+
+return_2: {
+    options = {
+        collapse_vars: true,
+        unused: true,
+    }
+    input: {
+        var log = console.log;
+        function f(b, c) {
+            var a = b <<= c;
+            if (b) return b;
+            log(a);
+        }
+        f(false, 1);
+        f(true, 2);
+    }
+    expect: {
+        var log = console.log;
+        function f(b, c) {
+            var a = b <<= c;
+            if (b) return b;
+            log(a);
+        }
+        f(false, 1);
+        f(true, 2);
+    }
+    expect_stdout: "0"
+}

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -4143,6 +4143,34 @@ return_2: {
     input: {
         var log = console.log;
         function f(b, c) {
+            var a = c();
+            if (b) return b;
+            log(a);
+        }
+        f(false, function() { return 1 });
+        f(true, function() { return 2 });
+    }
+    expect: {
+        var log = console.log;
+        function f(b, c) {
+            var a = c();
+            if (b) return b;
+            log(a);
+        }
+        f(false, function() { return 1 });
+        f(true, function() { return 2 });
+    }
+    expect_stdout: "1"
+}
+
+return_3: {
+    options = {
+        collapse_vars: true,
+        unused: true,
+    }
+    input: {
+        var log = console.log;
+        function f(b, c) {
             var a = b <<= c;
             if (b) return b;
             log(a);


### PR DESCRIPTION
First introduced in #1862 to stop assignments to migrate beyond `return` or `throw`. Since then `collapse_vars` has been improved to handle various side-effect-related corner cases.