### PR TITLE
avoid `evaluate` of compound assignment after `dead_code` transform

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -5357,6 +5357,7 @@ merge(Compressor.prototype, {
                     if (in_try(level, parent instanceof AST_Throw)) break;
                     if (is_reachable(def.scope, [ def ])) break;
                     if (self.operator == "=") return self.right;
+                    def.fixed = false;
                     return make_node(AST_Binary, self, {
                         operator: self.operator.slice(0, -1),
                         left: self.left,

--- a/test/compress/dead-code.js
+++ b/test/compress/dead-code.js
@@ -879,3 +879,41 @@ unsafe_builtin: {
         z;
     }
 }
+
+issue_2860_1: {
+    options = {
+        dead_code: true,
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        console.log(function(a) {
+            return a ^= 1;
+        }());
+    }
+    expect: {
+        console.log(function(a) {
+            return 1 ^ a;
+        }());
+    }
+    expect_stdout: "1"
+}
+
+issue_2860_2: {
+    options = {
+        dead_code: true,
+        evaluate: true,
+        inline: true,
+        passes: 2,
+        reduce_vars: true,
+    }
+    input: {
+        console.log(function(a) {
+            return a ^= 1;
+        }());
+    }
+    expect: {
+        console.log(1);
+    }
+    expect_stdout: "1"
+}

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -5467,3 +5467,43 @@ chained_assignments: {
     }
     expect_stdout: "5eadbeef"
 }
+
+issue_2860_1: {
+    options = {
+        dead_code: true,
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        console.log(function(a) {
+            return a ^= 1;
+            a ^= 2;
+        }());
+    }
+    expect: {
+        console.log(function(a) {
+            return 1 ^ a;
+        }());
+    }
+    expect_stdout: "1"
+}
+
+issue_2860_2: {
+    options = {
+        dead_code: true,
+        evaluate: true,
+        inline: true,
+        passes: 2,
+        reduce_vars: true,
+    }
+    input: {
+        console.log(function(a) {
+            return a ^= 1;
+            a ^= 2;
+        }());
+    }
+    expect: {
+        console.log(1);
+    }
+    expect_stdout: "1"
+}


### PR DESCRIPTION
fixes #2860