### PR TITLE
handle `break` & `continue` in `collapse_vars`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -968,6 +968,7 @@ merge(Compressor.prototype, {
                     || node instanceof AST_Call && lhs instanceof AST_PropAccess && lhs.equivalent_to(node.expression)
                     || node instanceof AST_Debugger
                     || node instanceof AST_IterationStatement && !(node instanceof AST_For)
+                    || node instanceof AST_LoopControl
                     || node instanceof AST_Try
                     || node instanceof AST_With
                     || parent instanceof AST_For && node !== parent.init

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -4383,3 +4383,53 @@ cond_branch_switch: {
     }
     expect_stdout: "1"
 }
+
+issue_2873_1: {
+    options = {
+        collapse_vars: true,
+    }
+    input: {
+        var b = 1, c = 0;
+        do {
+            c++;
+            if (!--b) break;
+            c = 1 + c;
+        } while (0);
+        console.log(b, c);
+    }
+    expect: {
+        var b = 1, c = 0;
+        do {
+            c++;
+            if (!--b) break;
+            c = 1 + c;
+        } while (0);
+        console.log(b, c);
+    }
+    expect_stdout: "0 1"
+}
+
+issue_2873_2: {
+    options = {
+        collapse_vars: true,
+    }
+    input: {
+        var b = 1, c = 0;
+        do {
+            c++;
+            if (!--b) continue;
+            c = 1 + c;
+        } while (0);
+        console.log(b, c);
+    }
+    expect: {
+        var b = 1, c = 0;
+        do {
+            c++;
+            if (!--b) continue;
+            c = 1 + c;
+        } while (0);
+        console.log(b, c);
+    }
+    expect_stdout: "0 1"
+}


### PR DESCRIPTION
fixes #2873