### PR TITLE
[ES6] fix `arguments` in arrow functions

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -383,6 +383,11 @@ AST_Lambda.DEFMETHOD("init_scope_vars", function(){
     }));
 });
 
+AST_Arrow.DEFMETHOD("init_scope_vars", function(){
+    AST_Scope.prototype.init_scope_vars.apply(this, arguments);
+    this.uses_arguments = false;
+});
+
 AST_Symbol.DEFMETHOD("mark_enclosed", function(options) {
     var def = this.definition();
     var s = this.scope;

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -1439,3 +1439,34 @@ issue_2794_6: {
     ]
     node_version: ">=6"
 }
+
+inline_arrow_using_arguments: {
+    options = {
+        evaluate: true,
+        inline: 1,
+        reduce_funcs: true,
+        reduce_vars: true,
+        sequences: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        (function(){
+            ((x) => {
+                console.log.apply(console, arguments),
+                console.log(x);
+            })(4);
+        })(3, 2, 1);
+    }
+    expect: {
+        (function(){
+            console.log.apply(console, arguments),
+            console.log(4);
+        })(3, 2, 1);
+    }
+    expect_stdout: [
+        "3 2 1",
+        "4",
+    ]
+    node_version: ">=6"
+}


### PR DESCRIPTION
Arrow functions do not have an implicit `arguments` variable.