### PR TITLE
describe a few compiler assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,6 +1103,14 @@ To enable fast minify mode with the API use:
 UglifyJS.minify(code, { compress: false, mangle: true });
 ```
 
+#### Source maps and debugging
+
+Various `compress` transforms that simplify, rearrange, inline and remove code
+are known to have an adverse effect on debugging with source maps. This is
+expected as code is optimized and mappings are often simply not possible as
+some code no longer exists. For highest fidelity in source map debugging
+disable the Uglify `compress` option and just use `mangle`.
+
 ### Compiler assumptions
 
 To allow for better optimizations, the compiler makes various assumptions.
@@ -1117,11 +1125,3 @@ To allow for better optimizations, the compiler makes various assumptions.
 - Object properties can be added, removed and modified (not prevented with
   `Object.defineProperty()`, `Object.defineProperties()`, `Object.freeze()`,
   `Object.preventExtensions()` or `Object.seal()`).
-
-### Source maps and debugging
-
-Various `compress` transforms that simplify, rearrange, inline and remove code
-are known to have an adverse effect on debugging with source maps. This is
-expected as code is optimized and mappings are often simply not possible as
-some code no longer exists. For highest fidelity in source map debugging
-disable the Uglify `compress` option and just use `mangle`.

--- a/README.md
+++ b/README.md
@@ -1115,5 +1115,5 @@ To allow for better optimizations, the compiler makes various assumptions.
 - Getting and setting properties on a plain object does not cause other side effects
   (using `.watch()` or `Proxy`).
 - Object properties are able to be added (not prevented with
-  `Object.defineProperty()`, `Object.defineProperties()`, `Object.freeze()` or
-  `Object.preventExtensions()`).
+  `Object.defineProperty()`, `Object.defineProperties()`, `Object.freeze()`,
+  `Object.preventExtensions()` or `Object.seal()`).

--- a/README.md
+++ b/README.md
@@ -1114,7 +1114,7 @@ To allow for better optimizations, the compiler makes various assumptions.
   `Error.prototype.stack` to be anything in particular.
 - Getting and setting properties on a plain object does not cause other side effects
   (using `.watch()` or `Proxy`).
-- Object properties are able to be added (not prevented with
+- Object properties can be added, removed and modified (not prevented with
   `Object.defineProperty()`, `Object.defineProperties()`, `Object.freeze()`,
   `Object.preventExtensions()` or `Object.seal()`).
 

--- a/README.md
+++ b/README.md
@@ -1117,3 +1117,11 @@ To allow for better optimizations, the compiler makes various assumptions.
 - Object properties are able to be added (not prevented with
   `Object.defineProperty()`, `Object.defineProperties()`, `Object.freeze()`,
   `Object.preventExtensions()` or `Object.seal()`).
+
+### Source maps and debugging
+
+Various `compress` transforms that simplify, rearrange, inline and remove code
+are known to have an adverse effect on debugging with source maps. This is
+expected as code is optimized and mappings are often simply not possible as
+some code no longer exists. For highest fidelity in source map debugging
+disable the Uglify `compress` option and just use `mangle`.

--- a/README.md
+++ b/README.md
@@ -1113,9 +1113,10 @@ disable the Uglify `compress` option and just use `mangle`.
 
 ### Compiler assumptions
 
-To allow for better optimizations, the compiler makes various assumptions.
+To allow for better optimizations, the compiler makes various assumptions:
 
-- `.toString()` and `.valueOf()` have not been overridden, and don't have side effects.
+- `.toString()` and `.valueOf()` don't have side effects, and for built-in
+  objects they have not been overridden.
 - `undefined`, `NaN` and `Infinity` have not been externally redefined.
 - `arguments.callee`, `arguments.caller` and `Function.prototype.caller` are not used.
 - The code doesn't expect the contents of `Function.prototype.toString()` or

--- a/README.md
+++ b/README.md
@@ -1102,3 +1102,18 @@ To enable fast minify mode with the API use:
 ```js
 UglifyJS.minify(code, { compress: false, mangle: true });
 ```
+
+### Compiler assumptions
+
+To allow for better optimizations, the compiler makes various assumptions.
+
+- `.toString()` and `.valueOf()` have not been overridden, and don't have side effects.
+- `undefined`, `NaN` and `Infinity` have not been externally redefined.
+- `arguments.callee`, `arguments.caller` and `Function.prototype.caller` are not used.
+- The code doesn't expect the contents of `Function.prototype.toString()` or
+  `Error.prototype.stack` to be anything in particular.
+- Getting and setting properties on a plain object does not cause other side effects
+  (using `.watch()` or `Proxy`).
+- Object properties are able to be added (not prevented with
+  `Object.defineProperty()`, `Object.defineProperties()`, `Object.freeze()` or
+  `Object.preventExtensions()`).


### PR DESCRIPTION
[My addition rendered](https://github.com/Skalman/UglifyJS2/blob/compiler_assumptions/README.md#compiler-assumptions)

I've created a new README section to describe some of the compiler assumptions. I'd appreciate any suggestions of clarifications.

In particular, I'm unsure about the factual accuracy of the last couple of bullet points:

- Getting and setting properties on a plain object does not cause other side effects (using `.watch()` or `Proxy`).
- Object properties are able to be added (not prevented with `Object.defineProperty()`, `Object.defineProperties()`, `Object.freeze()` or `Object.preventExtensions()`).
