### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "LICENSE"
   ],
   "dependencies": {
-    "commander": "~2.13.0",
+    "commander": "~2.14.1",
     "source-map": "~0.6.1"
   },
   "devDependencies": {
-    "acorn": "~5.3.0",
+    "acorn": "~5.4.1",
     "mocha": "~3.5.1",
-    "semver": "~5.4.1"
+    "semver": "~5.5.0"
   },
   "scripts": {
     "test": "node test/run-tests.js"


### PR DESCRIPTION
- `acorn@5.4.1`
- `commander@2.14.1`
- `semver@5.5.0`

P.S. `source-map@0.7.0` only supports Node.js 8+, which means we'll be stuck with 0.6 forever.

P.P.S. #2716 is taking a real toll on `node@0.12` - running `npm test` on other versions take less than a minute, while 0.12 requires >5 min