### PR TITLE
fix AST corruption due to `collapse_vars` & `inline`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -4379,6 +4379,7 @@ merge(Compressor.prototype, {
                 && !self.pure
                 && !fn.contains_this()
                 && can_inject_symbols()) {
+                fn._squeezed = true;
                 return make_sequence(self, flatten_fn()).optimize(compressor);
             }
             if (compressor.option("side_effects") && all(fn.body, is_empty)) {

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -1989,3 +1989,33 @@ issue_2783: {
     }
     expect_stdout: "PASS"
 }
+
+issue_2898: {
+    options = {
+        collapse_vars: true,
+        inline: true,
+        reduce_vars: true,
+        sequences: true,
+        unused: true,
+    }
+    input: {
+        var c = 0;
+        (function() {
+            while (f());
+            function f() {
+                var b = (c = 1 + c, void (c = 1 + c));
+                b && b[0];
+            }
+        })();
+        console.log(c);
+    }
+    expect: {
+        var c = 0;
+        (function() {
+            while (b = void 0, void ((b = void (c = 1 + (c = 1 + c))) && b[0]));
+            var b;
+        })(),
+        console.log(c);
+    }
+    expect_stdout: "2"
+}


### PR DESCRIPTION
fixes #2898