### PR TITLE
fix `unsafe` `evaluate` on type-converting operators

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2375,6 +2375,7 @@ merge(Compressor.prototype, {
             }
             return this;
         });
+        var non_converting_unary = makePredicate("! typeof void");
         def(AST_UnaryPrefix, function(compressor, depth) {
             var e = this.expression;
             // Function would be evaluated to an array and so typeof would
@@ -2386,6 +2387,7 @@ merge(Compressor.prototype, {
                         && e.fixed_value() instanceof AST_Lambda)) {
                 return typeof function(){};
             }
+            if (!non_converting_unary(this.operator)) depth++;
             e = e._eval(compressor, depth);
             if (e === this.expression) return this;
             switch (this.operator) {
@@ -2402,7 +2404,9 @@ merge(Compressor.prototype, {
             }
             return this;
         });
+        var non_converting_binary = makePredicate("&& || === !==");
         def(AST_Binary, function(compressor, depth) {
+            if (!non_converting_binary(this.operator)) depth++;
             var left = this.left._eval(compressor, depth);
             if (left === this.left) return this;
             var right = this.right._eval(compressor, depth);

--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -1429,3 +1429,63 @@ string_case: {
         "199",
     ]
 }
+
+issue_2916_1: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        unsafe: true,
+    }
+    input: {
+        var c = "PASS";
+        (function(a, b) {
+            (function(d) {
+                d[0] = 1;
+            })(b);
+            a == b && (c = "FAIL");
+        })("", []);
+        console.log(c);
+    }
+    expect: {
+        var c = "PASS";
+        (function(a, b) {
+            (function(d) {
+                d[0] = 1;
+            })(b);
+            a == b && (c = "FAIL");
+        })("", []);
+        console.log(c);
+    }
+    expect_stdout: "PASS"
+}
+
+issue_2916_2: {
+    options = {
+        collapse_vars: true,
+        evaluate: true,
+        inline: true,
+        reduce_vars: true,
+        side_effects: true,
+        unsafe: true,
+        unused: true,
+    }
+    input: {
+        var c = "FAIL";
+        (function(b) {
+            (function(d) {
+                d[0] = 1;
+            })(b);
+            +b && (c = "PASS");
+        })([]);
+        console.log(c);
+    }
+    expect: {
+        var c = "FAIL";
+        (function(b) {
+            b[0] = 1;
+            +b && (c = "PASS");
+        })([]);
+        console.log(c);
+    }
+    expect_stdout: "PASS"
+}


### PR DESCRIPTION
fixes #2916