### PR TITLE
workaround `pure_getters=true` when dropping unused assignments

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3028,9 +3028,11 @@ merge(Compressor.prototype, {
             } else if (node instanceof AST_Unary && node.write_only) {
                 sym = node.expression;
             }
-            while (sym instanceof AST_PropAccess && !sym.expression.may_throw_on_access(compressor)) {
-                if (sym instanceof AST_Sub) props.unshift(sym.property);
-                sym = sym.expression;
+            if (/strict/.test(compressor.option("pure_getters"))) {
+                while (sym instanceof AST_PropAccess && !sym.expression.may_throw_on_access(compressor)) {
+                    if (sym instanceof AST_Sub) props.unshift(sym.property);
+                    sym = sym.expression;
+                }
             }
             return sym;
         };

--- a/test/compress/pure_getters.js
+++ b/test/compress/pure_getters.js
@@ -721,3 +721,30 @@ issue_2838: {
     }
     expect_stdout: "PASS"
 }
+
+issue_2938: {
+    options = {
+        pure_getters: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        var Parser = function Parser() {};
+        var p = Parser.prototype;
+        p.initialContext = function initialContext() {
+            console.log("PASS");
+        };
+        p.braceIsBlock = function() {};
+        (new Parser).initialContext();
+    }
+    expect: {
+        var Parser = function() {};
+        var p = Parser.prototype;
+        p.initialContext = function() {
+            console.log("PASS");
+        };
+        p.braceIsBlock = function() {};
+        (new Parser).initialContext();
+    }
+    expect_stdout: "PASS"
+}

--- a/test/compress/pure_getters.js
+++ b/test/compress/pure_getters.js
@@ -722,7 +722,31 @@ issue_2838: {
     expect_stdout: "PASS"
 }
 
-issue_2938: {
+issue_2938_1: {
+    options = {
+        pure_getters: true,
+        unused: true,
+    }
+    input: {
+        function f(a) {
+            a.b = "PASS";
+        }
+        var o = {};
+        f(o);
+        console.log(o.b);
+    }
+    expect: {
+        function f(a) {
+            a.b = "PASS";
+        }
+        var o = {};
+        f(o);
+        console.log(o.b);
+    }
+    expect_stdout: "PASS"
+}
+
+issue_2938_2: {
     options = {
         pure_getters: true,
         toplevel: true,

--- a/test/mocha/release.js
+++ b/test/mocha/release.js
@@ -38,7 +38,7 @@ describe("test/jetstream.js", function() {
     this.timeout(20 * 60 * 1000);
     [
         "-mc",
-        "-mc keep_fargs=false,passes=3,unsafe,unsafe_comps,unsafe_math,unsafe_proto",
+        "-mc keep_fargs=false,passes=3,pure_getters,unsafe,unsafe_comps,unsafe_math,unsafe_proto",
     ].forEach(function(options) {
         it("Should pass with options " + options, function(done) {
             var args = options.split(/ /);


### PR DESCRIPTION
fixes #2938

/cc @kzc