### PR TITLE
Fix deprecated Buffer constructor usage and add safeguards

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -1,10 +1,24 @@
 "use strict";
 
 var to_ascii = typeof atob == "undefined" ? function(b64) {
-    return new Buffer(b64, "base64").toString();
+    if (Buffer.from && Buffer.from !== Uint8Array.from) {
+      // Node >= 4.5.0
+      return Buffer.from(b64, "base64").toString();
+    } else {
+      // Node < 4.5.0, old API, manual safeguards
+      if (typeof b64 !== "string") throw new Errror("\"b64\" must be a string");
+      return new Buffer(b64, "base64").toString();
+    }
 } : atob;
 var to_base64 = typeof btoa == "undefined" ? function(str) {
-    return new Buffer(str).toString("base64");
+    if (Buffer.from && Buffer.from !== Uint8Array.from) {
+      // Node >= 4.5.0
+      return Buffer.from(str, "ascii").toString("base64");
+    } else {
+      // Node < 4.5.0, old API, manual safeguards
+      if (typeof str !== "string") throw new Errror("\"str\" must be a string");
+      return new Buffer(str).toString("base64");
+    }
 } : btoa;
 
 function read_source_map(code) {


### PR DESCRIPTION
This avoids using deprecated Buffer constructor API on newer Node.js versions.

To achieve that, Buffer.from presence is checked, with validating that it's not the same method as Uint8Array.from.

Also, additional checks were added for older Node.js versions to ensure that a number is never accidentally passed to the Buffer constructor. Throwing is in line with browser atob/btoa behavior, and in line with what Buffer.from does on numbers in newer Node.js versions.

No actual security issues present in that code, the safeguard has been added preemptively to avoid accidential calls to atob/btoa(number) in the future.

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor