### PR TITLE
fix #2994 by fixing block aborts() definition

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3074,8 +3074,12 @@ merge(Compressor.prototype, {
         def(AST_Statement, return_null);
         def(AST_Jump, return_this);
         function block_aborts(){
-            var n = this.body.length;
-            return n > 0 && aborts(this.body[n - 1]);
+            for (var i = 0; i < this.body.length; i++) {
+                if (aborts(this.body[i])) {
+                    return this.body[i];
+                }
+            }
+            return null;
         };
         def(AST_Import, function(){ return null; });
         def(AST_BlockStatement, block_aborts);

--- a/test/compress/conditionals.js
+++ b/test/compress/conditionals.js
@@ -1204,6 +1204,45 @@ issue_2560: {
     ]
 }
 
+issue_2994: {
+    options = {
+        conditionals: true,
+        if_return: true
+    }
+    input: {
+        function f() {
+            if (condition1) {
+                if (condition2) {
+                    return aValue;
+                } else {
+                    const variable1 = 'something';
+                    if (condition3) {
+                        const variable2 = 'else';
+                        return anotherValue;
+                    } else {
+                        return undefined;
+                    }
+                }
+            }
+        }
+    }
+    expect: {
+        function f() {
+            if (condition1) {
+                if (condition2) return aValue;
+                {
+                    const variable1 = 'something';
+                    if (condition3) {
+                        const variable2 = 'else';
+                        return anotherValue;
+                    }
+                    return;
+                }
+            }
+        }
+    }
+}
+
 hoist_decl: {
     options = {
         conditionals: true,

--- a/test/compress/conditionals.js
+++ b/test/compress/conditionals.js
@@ -1210,7 +1210,7 @@ issue_2994: {
         if_return: true
     }
     input: {
-        function f() {
+        function f(condition1, condition2, condition3) {
             if (condition1) {
                 if (condition2) {
                     return aValue;
@@ -1225,22 +1225,40 @@ issue_2994: {
                 }
             }
         }
+        let aValue = 2, anotherValue = 3;
+        for (let i = 0; i < 8; ++i) {
+            console.log(f(i & 4, i & 2, i & 1));
+        }
     }
     expect: {
-        function f() {
+        function f(condition1, condition2, condition3) {
             if (condition1) {
                 if (condition2) return aValue;
                 {
-                    const variable1 = 'something';
+                    const variable1 = "something";
                     if (condition3) {
-                        const variable2 = 'else';
+                        const variable2 = "else";
                         return anotherValue;
                     }
                     return;
                 }
             }
         }
+        let aValue = 2, anotherValue = 3;
+        for (let i = 0; i < 8; ++i)
+            console.log(f(4 & i, 2 & i, 1 & i));
     }
+    expect_stdout: [
+        "undefined",
+        "undefined",
+        "undefined",
+        "undefined",
+        "undefined",
+        "3",
+        "2",
+        "2",
+    ]
+    node_version: ">=6"
 }
 
 hoist_decl: {

--- a/test/compress/issue-1034.js
+++ b/test/compress/issue-1034.js
@@ -69,15 +69,15 @@ non_hoisted_function_after_return_2a: {
         "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:48,16]",
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:51,16]",
         "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:51,16]",
-        "WARN: Dropping unused variable a [test/compress/issue-1034.js:48,20]",
-        "WARN: Dropping unused function nope [test/compress/issue-1034.js:55,21]",
-        "WARN: pass 0: last_count: Infinity, count: 37",
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:53,12]",
         "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:53,12]",
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:56,12]",
+        "WARN: Dropping unused variable a [test/compress/issue-1034.js:48,20]",
         "WARN: Dropping unused variable b [test/compress/issue-1034.js:51,20]",
         "WARN: Dropping unused variable c [test/compress/issue-1034.js:53,16]",
-        "WARN: pass 1: last_count: 37, count: 18",
+        "WARN: Dropping unused function nope [test/compress/issue-1034.js:55,21]",
+        "WARN: pass 0: last_count: Infinity, count: 23",
+        "WARN: pass 1: last_count: 23, count: 18",
     ]
 }
 
@@ -200,15 +200,15 @@ non_hoisted_function_after_return_2a_strict: {
         "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:175,16]",
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:178,16]",
         "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:178,16]",
-        "WARN: Dropping unused variable a [test/compress/issue-1034.js:175,20]",
-        "WARN: Dropping unused function nope [test/compress/issue-1034.js:182,21]",
-        "WARN: pass 0: last_count: Infinity, count: 48",
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:180,12]",
         "WARN: Declarations in unreachable code! [test/compress/issue-1034.js:180,12]",
         "WARN: Dropping unreachable code [test/compress/issue-1034.js:183,12]",
+        "WARN: Dropping unused variable a [test/compress/issue-1034.js:175,20]",
         "WARN: Dropping unused variable b [test/compress/issue-1034.js:178,20]",
         "WARN: Dropping unused variable c [test/compress/issue-1034.js:180,16]",
-        "WARN: pass 1: last_count: 48, count: 29",
+        "WARN: Dropping unused function nope [test/compress/issue-1034.js:182,21]",
+        "WARN: pass 0: last_count: Infinity, count: 34",
+        "WARN: pass 1: last_count: 34, count: 29",
     ]
 }
 

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -175,8 +175,8 @@ function run_compress_tests() {
                 if (expected_warnings != actual_warnings) {
                     log("!!! failed\n---INPUT---\n{input}\n---EXPECTED WARNINGS---\n{expected_warnings}\n---ACTUAL WARNINGS---\n{actual_warnings}\n\n", {
                         input: input_formatted,
-                        expected_warnings: expected_warnings,
-                        actual_warnings: actual_warnings,
+                        expected_warnings: JSON.parse(expected_warnings).join('\n'),
+                        actual_warnings: JSON.parse(actual_warnings).join('\n'),
                     });
                     return false;
                 }


### PR DESCRIPTION
Before, a block would only abort in its last statement. This ensures that block.aborts() returns properly even if it's not the last statement that's aborting.

fixes #2994