### PR TITLE
make sure let and const aren't put out of blocks

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3127,7 +3127,9 @@ merge(Compressor.prototype, {
         tighten_body(self.body, compressor);
         switch (self.body.length) {
           case 1:
-            if (!compressor.has_directive("use strict") && compressor.parent() instanceof AST_If && can_be_extracted_from_if_block(self.body[0])
+            if (!compressor.has_directive("use strict")
+                && compressor.parent() instanceof AST_If
+                && can_be_extracted_from_if_block(self.body[0])
                 || can_be_evicted_from_block(self.body[0])) {
                 return self.body[0];
             }

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3118,7 +3118,8 @@ merge(Compressor.prototype, {
     function can_be_extracted_from_if_block(node) {
         return !(
             node instanceof AST_Const ||
-            node instanceof AST_Let
+            node instanceof AST_Let ||
+            node instanceof AST_Class
         );
     }
 

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3115,11 +3115,18 @@ merge(Compressor.prototype, {
         return self;
     });
 
+    function can_be_extracted_from_if_block(node) {
+        return !(
+            node instanceof AST_Const ||
+            node instanceof AST_Let
+        );
+    }
+
     OPT(AST_BlockStatement, function(self, compressor){
         tighten_body(self.body, compressor);
         switch (self.body.length) {
           case 1:
-            if (!compressor.has_directive("use strict") && compressor.parent() instanceof AST_If
+            if (!compressor.has_directive("use strict") && compressor.parent() instanceof AST_If && can_be_extracted_from_if_block(self.body[0])
                 || can_be_evicted_from_block(self.body[0])) {
                 return self.body[0];
             }

--- a/test/compress/blocks.js
+++ b/test/compress/blocks.js
@@ -187,3 +187,30 @@ issue_1672_if_strict: {
     expect_stdout: true
     node_version: ">=6"
 }
+
+issue_2946_else_const: {
+    input: {
+        if (1) {
+            const x = 6;
+        } else {
+            const y = 12;
+        }
+        if (2) {
+            let z = 24;
+        } else {
+            let w = 48;
+        }
+    }
+    expect: {
+        if (1) {
+            const x = 6;
+        } else {
+            const y = 12;
+        }
+        if (2) {
+            let z = 24;
+        } else {
+            let w = 48;
+        }
+    }
+}

--- a/test/compress/blocks.js
+++ b/test/compress/blocks.js
@@ -200,6 +200,11 @@ issue_2946_else_const: {
         } else {
             let w = 48;
         }
+        if (3) {
+            class X {}
+        } else {
+            class Y {}
+        }
     }
     expect: {
         if (1) {
@@ -211,6 +216,11 @@ issue_2946_else_const: {
             let z = 24;
         } else {
             let w = 48;
+        }
+        if (3) {
+            class X {}
+        } else {
+            class Y {}
         }
     }
 }


### PR DESCRIPTION
This closes #2946. When not in strict mode, let and const declarations can't have their surrounding blocks removed.