### PR TITLE
fix extra regex slash when going through mozilla AST I/O

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -180,6 +180,17 @@
                 end    : my_end_token(M)
             };
             if (val === null) return new AST_Null(args);
+            var rx = M.regex;
+            if (rx && rx.pattern) {
+                // RegExpLiteral as per ESTree AST spec
+                args.value = new RegExp(rx.pattern, rx.flags);
+                args.value.raw_source = rx.pattern;
+                return new AST_RegExp(args);
+            } else if (rx) {
+                // support legacy RegExp
+                args.value = M.regex && M.raw ? M.raw : val;
+                return new AST_RegExp(args);
+            }
             switch (typeof val) {
               case "string":
                 args.value = val;
@@ -189,16 +200,6 @@
                 return new AST_Number(args);
               case "boolean":
                 return new (val ? AST_True : AST_False)(args);
-              default:
-                var rx = M.regex;
-                if (rx && rx.pattern) {
-                    // RegExpLiteral as per ESTree AST spec
-                    args.value = new RegExp(rx.pattern, rx.flags).toString();
-                } else {
-                    // support legacy RegExp
-                    args.value = M.regex && M.raw ? M.raw : val;
-                }
-                return new AST_RegExp(args);
             }
         },
         Identifier: function(M) {
@@ -410,14 +411,15 @@
     });
 
     def_to_moz(AST_RegExp, function To_Moz_RegExpLiteral(M) {
-        var value = M.value;
+        var flags = M.value.toString().match(/[gimuy]*$/)[0];
+        var value = "/" + M.value.raw_source + "/" + flags;
         return {
             type: "Literal",
             value: value,
-            raw: value.toString(),
+            raw: value,
             regex: {
-                pattern: value.source,
-                flags: value.toString().match(/[gimuy]*$/)[0]
+                pattern: M.value.raw_source,
+                flags: flags
             }
         };
     });

--- a/test/mocha/spidermonkey.js
+++ b/test/mocha/spidermonkey.js
@@ -23,6 +23,15 @@ describe("spidermonkey export/import sanity test", function() {
         });
     });
 
+    it("should not add unnecessary escape slashes to regexps", function() {
+        var input = "/[\\\\/]/;";
+        var ast = uglify.parse(input).to_mozilla_ast();
+        assert.equal(
+            uglify.AST_Node.from_mozilla_ast(ast).print_to_string(),
+            input
+        );
+    });
+
     it("Should judge between directives and strings correctly on import", function() {
         var tests = [
             {


### PR DESCRIPTION
This relates to #1929, but in the context of mozilla AST input/output.

I found this while adding tests for spidermonkey I/O in the harmony branch, and decided to keep it as a separate commit to apply to master too.

```
fabio@fabio-thinkpad ♥  echo '/[\\/]/' | bin/uglifyjs -o spidermonkey | bin/uglifyjs -p spidermonkey
/[\\\/]/;
fabio@fabio-thinkpad ♥  git cherry-pick 0150e02dc49bed2357de5fff33898e7c0f04e3e8
[...]
fabio@fabio-thinkpad ♥  echo '/[\\/]/' | bin/uglifyjs -o spidermonkey | bin/uglifyjs -p spidermonkey
/[\\/]/;

```