### PR TITLE
stop replacement of symbols in an AST_Expansion

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1047,6 +1047,9 @@ merge(Compressor.prototype, {
                     || node instanceof AST_Call && lhs instanceof AST_PropAccess && lhs.equivalent_to(node.expression)
                     || node instanceof AST_Debugger
                     || node instanceof AST_Destructuring
+                    || node instanceof AST_Expansion
+                       && node.expression instanceof AST_Symbol
+                       && node.expression.definition().references.length > 1
                     || node instanceof AST_IterationStatement && !(node instanceof AST_For)
                     || node instanceof AST_LoopControl
                     || node instanceof AST_Try

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -1601,3 +1601,28 @@ issue_2874_3: {
     ]
     node_version: ">=6"
 }
+
+issue_3028: {
+    options = {
+        collapse_vars: true,
+        evaluate: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        function a(array) {
+            var shifted = array.splice(0, 2);
+            return [ ...array, ...shifted ];
+        }
+        console.log(a([ 1, 2, 3 ]).join(" "));
+    }
+    expect: {
+        function a(array) {
+            var shifted = array.splice(0, 2);
+            return [ ...array, ...shifted ];
+        }
+        console.log(a([ 1, 2, 3 ]).join(" "));
+    }
+    expect_stdout: "3 1 2"
+    node_version: ">=6"
+}


### PR DESCRIPTION
This aims to fix #3028. 