### PR TITLE
Fixes performance issue in has_parens()

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -298,6 +298,7 @@ function OutputStream(options) {
                         might_need_semicolon = true;
                     }
                 }
+                LAST_OUTPUT_FRAGMENT = "";
 
                 if (!options.beautify)
                     might_need_space = false;
@@ -309,6 +310,7 @@ function OutputStream(options) {
             while (current_line < target_line) {
                 ensure_line_len();
                 OUTPUT += "\n";
+                LAST_OUTPUT_FRAGMENT = "";
                 current_pos++;
                 current_line++;
                 current_col = 0;
@@ -323,6 +325,7 @@ function OutputStream(options) {
                 || ((ch == "+" || ch == "-") && ch == last))
             {
                 OUTPUT += " ";
+                LAST_OUTPUT_FRAGMENT = "";
                 current_col++;
                 current_pos++;
             }

--- a/lib/output.js
+++ b/lib/output.js
@@ -109,6 +109,7 @@ function OutputStream(options) {
     var current_line = 1;
     var current_pos = 0;
     var OUTPUT = "";
+    var LAST_OUTPUT_FRAGMENT = "";
 
     var to_utf8 = options.ascii_only ? function(str, identifier) {
         return str.replace(/[\u0000-\u001f\u007f-\uffff]/g, function(ch) {
@@ -233,7 +234,7 @@ function OutputStream(options) {
         if (current_col > options.max_line_len) {
             if (might_add_newline) {
                 var left = OUTPUT.slice(0, might_add_newline);
-                var right = OUTPUT.slice(might_add_newline);
+                var right = LAST_OUTPUT_FRAGMENT = OUTPUT.slice(might_add_newline);
                 if (mappings) {
                     var delta = right.length - current_col;
                     mappings.forEach(function(mapping) {
@@ -339,7 +340,7 @@ function OutputStream(options) {
             if (!might_add_newline) do_add_mapping();
         }
 
-        OUTPUT += str;
+        OUTPUT += LAST_OUTPUT_FRAGMENT = str;
         current_pos += str.length;
         var a = str.split(/\r?\n/), n = a.length - 1;
         current_line += n;
@@ -375,7 +376,7 @@ function OutputStream(options) {
     var newline = options.beautify ? function() {
         if (newline_insert < 0) return print("\n");
         if (OUTPUT[newline_insert] != "\n") {
-            OUTPUT = OUTPUT.slice(0, newline_insert) + "\n" + OUTPUT.slice(newline_insert);
+            OUTPUT = OUTPUT.slice(0, newline_insert) + "\n" + (LAST_OUTPUT_FRAGMENT = OUTPUT.slice(newline_insert));
             current_pos++;
             current_line++;
         }
@@ -576,7 +577,7 @@ function OutputStream(options) {
         indentation     : function() { return indentation },
         current_width   : function() { return current_col - indentation },
         should_break    : function() { return options.width && this.current_width() >= options.width },
-        has_parens      : function() { return OUTPUT[OUTPUT.length - 1] == "(" },
+        has_parens      : function() { return LAST_OUTPUT_FRAGMENT[LAST_OUTPUT_FRAGMENT.length - 1] == "(" },
         newline         : newline,
         print           : print,
         space           : space,


### PR DESCRIPTION
Fixes performance issue in function has_parens() with large files.

Instead of checking the whole OUTPUT-string in has_parens(), we now keep a LAST_OUTPUT_FRAGMENT-string that "caches" the last addition to OUTPUT that could contain a "(" in the last position.