### PR TITLE
fix AST corruption during `inline` of simple `return`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -4576,7 +4576,12 @@ merge(Compressor.prototype, {
         if (compressor.option("inline") && stat instanceof AST_Return) {
             var value = stat.value;
             if (!value || value.is_constant_expression()) {
-                var args = self.args.concat(value || make_node(AST_Undefined, self));
+                if (value) {
+                    value = value.clone(true);
+                } else {
+                    value = make_node(AST_Undefined, self);
+                }
+                var args = self.args.concat(value);
                 return make_sequence(self, args).optimize(compressor);
             }
         }

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -2237,3 +2237,33 @@ issue_3018: {
     }
     expect_stdout: "PASS"
 }
+
+issue_3054: {
+    options = {
+        booleans: true,
+        collapse_vars: true,
+        inline: 1,
+        reduce_vars: true,
+        toplevel: true,
+    }
+    input: {
+        "use strict";
+        function f() {
+            return { a: true };
+        }
+        console.log(function(b) {
+            b = false;
+            return f();
+        }().a, f.call().a);
+    }
+    expect: {
+        "use strict";
+        function f() {
+            return { a: !0 };
+        }
+        console.log(function(b) {
+            return { a: !(b = !1) };
+        }().a, f.call().a);
+    }
+    expect_stdout: "true true"
+}


### PR DESCRIPTION
fixes #3054