### PR TITLE
improve usability of `includeSources`

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -182,6 +182,8 @@ function minify(files, options) {
                     } else for (var name in files) if (HOP(files, name)) {
                         options.output.source_map.get().setSourceContent(name, files[name]);
                     }
+                } else {
+                    options.output.source_map.get()._sourcesContents = null;
                 }
             }
             delete options.output.ast;

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -121,7 +121,8 @@ describe("bin/uglifyjs", function () {
         var command = [
             uglifyjscmd,
             "--source-map", "content=" + mapFile,
-            "--source-map", "url=inline"
+            "--source-map", "includeSources=true",
+            "--source-map", "url=inline",
         ].join(" ");
 
         var child = exec(command, function(err, stdout) {
@@ -216,7 +217,14 @@ describe("bin/uglifyjs", function () {
         });
     });
     it("Should process inline source map", function(done) {
-        var command = uglifyjscmd + " test/input/issue-520/input.js -mc toplevel --source-map content=inline,url=inline";
+        var command = [
+            uglifyjscmd,
+            "test/input/issue-520/input.js",
+            "-mc", "toplevel",
+            "--source-map", "content=inline",
+            "--source-map", "includeSources=true",
+            "--source-map", "url=inline",
+        ].join(" ");
 
         exec(command, function (err, stdout) {
             if (err) throw err;

--- a/test/mocha/input-sourcemaps.js
+++ b/test/mocha/input-sourcemaps.js
@@ -1,66 +1,68 @@
-var Uglify = require('../../');
 var assert = require("assert");
+var Uglify = require("../../");
 var SourceMapConsumer = require("source-map").SourceMapConsumer;
 
+function getMap() {
+    return {
+        "version": 3,
+        "sources": ["index.js"],
+        "names": [],
+        "mappings": ";;AAAA,IAAI,MAAM,SAAN,GAAM;AAAA,SAAK,SAAS,CAAd;AAAA,CAAV;AACA,QAAQ,GAAR,CAAY,IAAI,KAAJ,CAAZ",
+        "file": "bundle.js",
+        "sourcesContent": ["let foo = x => \"foo \" + x;\nconsole.log(foo(\"bar\"));"]
+    };
+}
+
+function prepareMap(sourceMap) {
+    var code = [
+        '"use strict";',
+        "",
+        "var foo = function foo(x) {",
+        '  return "foo " + x;',
+        "};",
+        'console.log(foo("bar"));',
+        "",
+        "//# sourceMappingURL=bundle.js.map",
+    ].join("\n");
+    var result = Uglify.minify(code, {
+        sourceMap: {
+            content: sourceMap,
+            includeSources: true,
+        }
+    });
+    if (result.error) throw result.error;
+    return new SourceMapConsumer(result.map);
+}
+
 describe("input sourcemaps", function() {
-    var transpilemap, map;
-
-    function getMap() {
-      return {
-          "version": 3,
-          "sources": ["index.js"],
-          "names": [],
-          "mappings": ";;AAAA,IAAI,MAAM,SAAN,GAAM;AAAA,SAAK,SAAS,CAAd;AAAA,CAAV;AACA,QAAQ,GAAR,CAAY,IAAI,KAAJ,CAAZ",
-          "file": "bundle.js",
-          "sourcesContent": ["let foo = x => \"foo \" + x;\nconsole.log(foo(\"bar\"));"]
-      };
-    }
-
-    function prepareMap(sourceMap) {
-        var transpiled = '"use strict";\n\n' +
-            'var foo = function foo(x) {\n  return "foo " + x;\n};\n' +
-            'console.log(foo("bar"));\n\n' +
-            '//# sourceMappingURL=bundle.js.map';
-
-        transpilemap = sourceMap || getMap();
-
-        var result = Uglify.minify(transpiled, {
-            sourceMap: {
-                content: transpilemap
-            }
-        });
-
-        map = new SourceMapConsumer(result.map);
-    }
-
-    beforeEach(function () {
-      prepareMap();
-    });
-
     it("Should copy over original sourcesContent", function() {
-        assert.equal(map.sourceContentFor("index.js"), transpilemap.sourcesContent[0]);
+        var orig = getMap();
+        var map = prepareMap(orig);
+        assert.equal(map.sourceContentFor("index.js"), orig.sourcesContent[0]);
     });
 
-    it("Should copy sourcesContent if sources are relative", function () {
+    it("Should copy sourcesContent if sources are relative", function() {
         var relativeMap = getMap();
         relativeMap.sources = ['./index.js'];
-
-        prepareMap(relativeMap);
+        var map = prepareMap(relativeMap);
         assert.notEqual(map.sourcesContent, null);
         assert.equal(map.sourcesContent.length, 1);
-        assert.equal(map.sourceContentFor("index.js"), transpilemap.sourcesContent[0]);
+        assert.equal(map.sourceContentFor("index.js"), relativeMap.sourcesContent[0]);
     });
 
-    it("Final sourcemap should not have invalid mappings from inputSourceMap (issue #882)", function() {
+    it("Should not have invalid mappings from inputSourceMap (issue #882)", function() {
+        var map = prepareMap(getMap());
         // The original source has only 2 lines, check that mappings don't have more lines
-
         var msg = "Mapping should not have higher line number than the original file had";
         map.eachMapping(function(mapping) {
-            assert.ok(mapping.originalLine <= 2, msg)
+            assert.ok(mapping.originalLine <= 2, msg);
         });
-
-        map.allGeneratedPositionsFor({source: "index.js", line: 1, column: 1}).forEach(function(pos) {
+        map.allGeneratedPositionsFor({
+            source: "index.js",
+            line: 1,
+            column: 1
+        }).forEach(function(pos) {
             assert.ok(pos.line <= 2, msg);
-        })
+        });
     });
 });

--- a/test/mocha/sourcemaps.js
+++ b/test/mocha/sourcemaps.js
@@ -70,6 +70,7 @@ describe("sourcemaps", function() {
                 compress: { toplevel: true },
                 sourceMap: {
                     content: "inline",
+                    includeSources: true,
                     url: "inline"
                 }
             }).code + "\n";
@@ -108,6 +109,29 @@ describe("sourcemaps", function() {
             var err = result.error;
             assert.ok(err instanceof Error);
             assert.strictEqual(err.stack.split(/\n/)[0], "Error: inline source map only works with singular input");
+        });
+        it("Should drop source contents for includeSources=false", function() {
+            var result = Uglify.minify(read("./test/input/issue-520/input.js"), {
+                compress: false,
+                mangle: false,
+                sourceMap: {
+                    content: "inline",
+                    includeSources: true,
+                },
+            });
+            if (result.error) throw result.error;
+            var map = JSON.parse(result.map);
+            assert.strictEqual(map.sourcesContent.length, 1);
+            result = Uglify.minify(result.code, {
+                compress: false,
+                mangle: false,
+                sourceMap: {
+                    content: result.map,
+                },
+            });
+            if (result.error) throw result.error;
+            map = JSON.parse(result.map);
+            assert.ok(!("sourcesContent" in map));
         });
     });
 


### PR DESCRIPTION
Exclude source contents from input source map if `includeSources=false`