### PR TITLE
Typo in minify.js when producing Source Maps

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -189,7 +189,7 @@ function minify(files, options) {
                 options.output.source_map = SourceMap({
                     file: options.sourceMap.filename,
                     orig: source_maps,
-                    root: options.sourceMap.root
+                    sourceRoot: options.sourceMap.root
                 });
                 if (options.sourceMap.includeSources) {
                     if (files instanceof AST_Toplevel) {


### PR DESCRIPTION
After looking through the SourceMap wrapper code, I believe `root` should be `sourceRoot` when passing to the `SourceMap`. This was causing issues for me with certain files resolving correctly when passing in the `root` option (was basically being ignored).