### PR TITLE
fix: invalid filenames in `sources` of source maps

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -111,6 +111,7 @@ function minify(files, options) {
                 content: null,
                 filename: null,
                 includeSources: false,
+                json: true,
                 root: null,
                 url: null,
             }, true);
@@ -207,7 +208,13 @@ function minify(files, options) {
             toplevel.print(stream);
             result.code = stream.get();
             if (options.sourceMap) {
-                result.map = options.output.source_map.toString();
+                result.map = options.output.source_map.get().toJSON();
+                if (Array.isArray(files)) {
+                    result.map.sources = [null];
+                }
+                if (options.sourceMap.json !== false) {
+                    result.map = JSON.stringify(result.map);
+                }
                 if (options.sourceMap.url == "inline") {
                     result.code += "\n//# sourceMappingURL=data:application/json;charset=utf-8;base64," + to_base64(result.map);
                 } else if (options.sourceMap.url) {


### PR DESCRIPTION
When the parsed files have no associated filenames (eg: when a string or array of strings is passed to the `minify` function), the `sources` array of the generated sourcemap must only contain null values.

Currently, it contains the stringified indexes of the array. For example, passing a string to `minify` results in a `sources` array of `["0"]`. **This breaks the sourcemap.**

This PR fixes this issue. 😄

It also adds the `sourceMap.json` option. When explicitly set to `false`, the sourcemap is *not* stringified.