### PR TITLE
binary number support

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -59,6 +59,7 @@ var OPERATOR_CHARS = makePredicate(characters("+-*&%=<>!?|~^"));
 
 var RE_HEX_NUMBER = /^0x[0-9a-f]+$/i;
 var RE_OCT_NUMBER = /^0[0-7]+$/;
+var RE_BIN_NUMBER = /^0b[01]+$/i;
 
 var OPERATORS = makePredicate([
     "in",
@@ -193,6 +194,8 @@ function parse_js_number(num) {
         return parseInt(num.substr(2), 16);
     } else if (RE_OCT_NUMBER.test(num)) {
         return parseInt(num.substr(1), 8);
+    } else if (RE_BIN_NUMBER.test(num)) {
+        return parseInt(num.substr(2), 2);
     } else {
         var val = parseFloat(num);
         if (val == num) return val;


### PR DESCRIPTION
UglifyJS works fine with hexadecimal number and octal numeral, but throws a exception when met binary number, supporting binary number would be a good addition.