### PR TITLE
fix read_source_map bug

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -1,14 +1,14 @@
 "use strict";
 
 var to_ascii = typeof atob == "undefined" ? function(b64) {
-    return new Buffer(b64, "base64").toString();
+    return ( Buffer.from ? Buffer.from(b64, "base64") : new Buffer(b64, "base64") ).toString();
 } : atob;
 var to_base64 = typeof btoa == "undefined" ? function(str) {
-    return new Buffer(str).toString("base64");
+    return ( Buffer.from ? Buffer.from(str) : new Buffer(str) ).toString("base64");
 } : btoa;
 
 function read_source_map(name, code) {
-    var match = /\n\/\/# sourceMappingURL=data:application\/json(;.*?)?;base64,(.*)/.exec(code);
+    var match = /(?:^|[^.])\/\/# sourceMappingURL=data:application\/json(;.*?)?;base64,(.*)\s*$/.exec(code);
     if (!match) {
         AST_Node.warn("inline source map not found: " + name);
         return null;


### PR DESCRIPTION
1. `new Buffer` can cause a global `DeprecationWarning` in `Node.js` nowadays. Fix it as `Buffer.from ? Buffer.from : new Buffer`.
2. **(A)** The previous regExp may match a map-like string or otherthings before the real inline map, which must in the end of the file. **(B)** And, the eol in javascript is not only `\n`, but also `\r` `\u2028` `\u2029`.