### PR TITLE
fix `read_source_map` inline bug

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -8,7 +8,7 @@ var to_base64 = typeof btoa == "undefined" ? function(str) {
 } : btoa;
 
 function read_source_map(name, code) {
-    var match = /\n\/\/# sourceMappingURL=data:application\/json(;.*?)?;base64,(.*)/.exec(code);
+    var match = /(?:^|[^.])\/\/# sourceMappingURL=data:application\/json(;[\w=-]*)?;base64,([+/0-9A-Za-z]*=*)\s*$/.exec(code);
     if (!match) {
         AST_Node.warn("inline source map not found: " + name);
         return null;

--- a/test/input/issue-520/input.js
+++ b/test/input/issue-520/input.js
@@ -1,3 +1,4 @@
 var Foo = function Foo(){console.log(1+2);}; new Foo();
 
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,I/am/not/a/sourceMappingURL/but/a/comment
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjpudWxsLCJzb3VyY2VzIjpbInN0ZGluIl0sInNvdXJjZXNDb250ZW50IjpbImNsYXNzIEZvbyB7IGNvbnN0cnVjdG9yKCl7Y29uc29sZS5sb2coMSsyKTt9IH0gbmV3IEZvbygpO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLElBQU0sR0FBRyxHQUFDLEFBQUUsWUFBVyxFQUFFLENBQUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFBLEFBQUUsQ0FBQyxJQUFJLEdBQUcsRUFBRSxDQUFDOyJ9


### PR DESCRIPTION
1.  The previous regExp may match a map-like string or otherthings before the real inline map, which must in the end of the file. And,
2. The eol in javascript is not only `\n`, but also `\r` `\u2028` `\u2029`, and even no eol before (start of the file).