### PR TITLE
make tests compatible with Node.js 12

### DIFF
--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -1245,12 +1245,12 @@ self_comparison_1: {
     }
     input: {
         var o = { n: NaN };
-        console.log(o.n == o.n, o.n === o.n, o.n != o.n, o.n !== o.n, typeof o.n);
+        console.log(typeof o.n, o.n == o.n, o.n === o.n, o.n != o.n, o.n !== o.n);
     }
     expect: {
-        console.log(false, false, true, true, "number");
+        console.log("number", false, false, true, true);
     }
-    expect_stdout: "false false true true 'number'"
+    expect_stdout: "number false false true true"
 }
 
 self_comparison_2: {
@@ -1265,12 +1265,12 @@ self_comparison_2: {
     }
     input: {
         var o = { n: NaN };
-        console.log(o.n == o.n, o.n === o.n, o.n != o.n, o.n !== o.n, typeof o.n);
+        console.log(typeof o.n, o.n == o.n, o.n === o.n, o.n != o.n, o.n !== o.n);
     }
     expect: {
-        console.log(false, false, true, true, "number");
+        console.log("number", false, false, true, true);
     }
-    expect_stdout: "false false true true 'number'"
+    expect_stdout: "number false false true true"
 }
 
 issue_2535_1: {

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -2740,18 +2740,18 @@ issue_1814_2: {
         !function() {
             var b = a + 1;
             !function(a) {
-                console.log(a++, b);
+                console.log(b, a++);
             }(0);
         }();
     }
     expect: {
         !function() {
             !function(a) {
-                console.log(a++, "321");
+                console.log("321", a++);
             }(0);
         }();
     }
-    expect_stdout: "0 '321'"
+    expect_stdout: "321 0"
 }
 
 try_abort: {


### PR DESCRIPTION
In Node.js 12, the formatting of console arguments will change slightly. Previously, a string other than the first argument was formatted using single quotes if the first argument was non-string. Now, quotes are never added regardless of position of a string argument.

To make test compatible in all Node.js versions, I work around by ensuring the first argument to console.log is a string which prevents the quotes from being added on older versions of Node.js.

Ref: https://github.com/nodejs/node/pull/23162