### PR TITLE
Preserve whether an object property is quoted in mozilla-ast.js

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -137,7 +137,12 @@
                 end        : my_end_token(M),
                 properties : M.properties.map(function(prop) {
                     prop.type = "Property";
-                    return from_moz(prop)
+                    var ret = from_moz(prop);
+                    if (prop.key.type === "Literal" &&
+                        (prop.key.raw[0] === '"' || prop.key.raw[0] === "'")) {
+                        ret.quote = true;
+                    }
+                    return ret;
                 })
             });
         },


### PR DESCRIPTION
With this change, parsing
```
var x = {
  raw: 3,
  "quoted": 5
};
```
in say acorn, then running `from_mozilla_ast`, then printing it, will emit the same output as the input, that is, the quoted property remains quoted.