### PR TITLE
Fix test expectation

### DIFF
--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -1124,14 +1124,14 @@ issue_2207_1: {
         console.log(Math.max(3, 6, 2, 7, 3, 4));
         console.log(Math.cos(1.2345));
         console.log(Math.cos(1.2345) - Math.sin(4.321));
-        console.log(Math.pow(Math.PI, Math.E - Math.LN10));
+        console.log(Math.pow(Math.PI, Math.E - Math.LN10).toFixed(15));
     }
     expect: {
         console.log("A");
         console.log(7);
         console.log(Math.cos(1.2345));
         console.log(1.2543732512566947);
-        console.log(1.6093984514472044);
+        console.log("1.609398451447204");
     }
     expect_stdout: true
 }


### PR DESCRIPTION
The test expects a specific precision value that is not met on all
V8 versions anymore due to a recent consolidation of different
algorithms across the V8 code base.

This makes sure the preceision is tested against one digit less to
keep the test working on all V8 versions.

Refs: https://chromium.googlesource.com/v8/v8/+/98453126c109016c9d32c6ebd89dd83f69dd8efb
Refs: https://github.com/nodejs/node/issues/25060#issuecomment-477953457