### PR TITLE
remove blanket safeguard from `source-map`

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -217,23 +217,12 @@ function OutputStream(options) {
 
     var flush_mappings = mappings ? function() {
         mappings.forEach(function(mapping) {
-            try {
-                options.source_map.add(
-                    mapping.token.file,
-                    mapping.line, mapping.col,
-                    mapping.token.line, mapping.token.col,
-                    !mapping.name && mapping.token.type == "name" ? mapping.token.value : mapping.name
-                );
-            } catch(ex) {
-                AST_Node.warn("Couldn't figure out mapping for {file}:{line},{col} → {cline},{ccol} [{name}]", {
-                    file: mapping.token.file,
-                    line: mapping.token.line,
-                    col: mapping.token.col,
-                    cline: mapping.line,
-                    ccol: mapping.col,
-                    name: mapping.name || ""
-                })
-            }
+            options.source_map.add(
+                mapping.token.file,
+                mapping.line, mapping.col,
+                mapping.token.line, mapping.token.col,
+                !mapping.name && mapping.token.type == "name" ? mapping.token.value : mapping.name
+            );
         });
         mappings = [];
     } : noop;


### PR DESCRIPTION
Things has stabilised since 80a18fe2fa60d8a689516b921a386839d30b6abe, so it makes sense to remove the unconditional masking for ease of debugging.