### PR TITLE
refine precision limits on `unsafe_math`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -2953,7 +2953,8 @@ merge(Compressor.prototype, {
                 && typeof result == "number"
                 && (this.operator == "+" || this.operator == "-")) {
                 var digits = Math.max(0, decimals(left), decimals(right));
-                if (digits < 21) return +result.toFixed(digits);
+                // 53-bit significand => 15.95 decimal places
+                if (digits < 16) return +result.toFixed(digits);
             }
             return result;
 

--- a/test/compress/numbers.js
+++ b/test/compress/numbers.js
@@ -917,3 +917,17 @@ issue_3547_4: {
         "number 0",
     ]
 }
+
+unsafe_math_rounding: {
+    options = {
+        evaluate: true,
+        unsafe_math: true,
+    }
+    input: {
+        console.log(4 / -3 + 1 === 1 / -3);
+    }
+    expect: {
+        console.log(false);
+    }
+    expect_stdout: "false"
+}


### PR DESCRIPTION
https://github.com/mishoo/UglifyJS2/pull/3587#issuecomment-554645525

@kzc the original rationale for picking `20` as the limits instead is due to this:
![toFixed](https://user-images.githubusercontent.com/1898413/68996028-8b819800-08cf-11ea-8dfa-61977bd7e17c.png)

Obviously your suggestion makes better sense 😉

(TIL https://en.wikipedia.org/wiki/Significand#Use_of_%22mantissa%22)