### PR TITLE
increase mocha `--reduce-test` timeout

### DIFF
--- a/test/mocha/reduce.js
+++ b/test/mocha/reduce.js
@@ -9,7 +9,7 @@ function read(path) {
 
 describe("test/reduce.js", function() {
     it("Should reduce test case", function() {
-        this.timeout(30000);
+        this.timeout(60000);
         var result = reduce_test(read("test/input/reduce/input.js"), {
             compress: {
                 unsafe_math: true,


### PR DESCRIPTION
GitHub Actions timed out with Node.js 0.12 on Linux (31.2s > 30s) just now &minus; doubling the value should be sufficient.