### PR TITLE
Updated "Output options" > "comments" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,8 +848,14 @@ can pass additional arguments that control the code output:
   statement.
 
 - `comments` (default `false`) -- pass `true` or `"all"` to preserve all
-  comments, `"some"` to preserve some comments (i.e. `/@preserve|@license|@cc_on/i`), a regular expression string
-  (e.g. `/^!/`), or a function that returns a *truthy/falsy* value that will be converted to `boolean` (e.g. `(_, comment) => preserveComment(comment.value)` where `preserveComment` is a user-defined function).
+  comments, `"some"` to preserve multi-line comments that contain `@cc_on`,
+  `@license`, or `@preserve` (case-insensitive), a regular expression string
+  (e.g. `/^!/`), or a function which returns `boolean`, e.g.
+  ```js
+  function(node, comment) {
+      return comment.value.indexOf("@type " + node.TYPE) >= 0;
+  }
+  ```
 
 - `indent_level` (default `4`)
 

--- a/README.md
+++ b/README.md
@@ -848,8 +848,8 @@ can pass additional arguments that control the code output:
   statement.
 
 - `comments` (default `false`) -- pass `true` or `"all"` to preserve all
-  comments, `"some"` to preserve some comments, a regular expression string
-  (e.g. `/^!/`) or a function.
+  comments, `"some"` to preserve some comments (i.e. `/@preserve|@license|@cc_on/i`), a regular expression string
+  (e.g. `/^!/`), or a function that returns a *truthy/falsy* value that will be converted to `boolean` (e.g. `(_, comment) => preserveComment(comment.value)` where `preserveComment` is a user-defined function).
 
 - `indent_level` (default `4`)
 


### PR DESCRIPTION
Expanded the current documentation to include:

- What the value of `"some"` means based on `lib/output.js`.
- Information about the `Function` overload parameters and expected output.